### PR TITLE
Fix VariantOperator typos and discriminant values

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -182,6 +182,7 @@ pub enum Ty {
     Float32Array,
     Result,
     VariantType,
+    VariantOperator,
     Enum(String),
     Object(String),
 }
@@ -218,6 +219,7 @@ impl Ty {
             "PoolRealArray" => Ty::Float32Array,
             "enum.Error" => Ty::Result,
             "enum.Variant::Type" => Ty::VariantType,
+            "enum.Variant::Operator" => Ty::VariantOperator,
             ty if ty.starts_with("enum.") => {
                 let mut split = ty[5..].split("::");
                 let mut class = split.next().unwrap();
@@ -262,6 +264,7 @@ impl Ty {
             &Ty::Float32Array => Some(String::from("Float32Array")),
             &Ty::Result => Some(String::from("GodotResult")),
             &Ty::VariantType => Some(String::from("VariantType")),
+            &Ty::VariantOperator => Some(String::from("VariantOperator")),
             &Ty::Enum(ref name) => Some(String::from(name.clone())),
             &Ty::Object(ref name) => Some(format!("Option<{}>", name)),
         }
@@ -298,6 +301,7 @@ impl Ty {
             &Ty::Float32Array => Some(String::from("sys::godot_pool_real_array")),
             &Ty::Result => Some(String::from("sys::godot_error")),
             &Ty::VariantType => Some(String::from("sys::variant_type")),
+            &Ty::VariantOperator => Some(String::from("sys::godot_variant_operator")),
             &Ty::Enum(_) => None, // TODO
             &Ty::Object(_) => Some(String::from("sys::godot_object")),
         }

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -524,6 +524,14 @@ fn generate_return_pre(w: &mut impl Write, ty: &Ty) -> GeneratorResult {
     let ret_ptr = (&mut ret) as *mut _;"#
             )?;
         }
+        &Ty::VariantOperator => {
+            // An invalid value is used here, so that `try_from_sys` can detect the error in case
+            // the pointer is not written to.
+            writeln!(w, r#"
+    let mut ret: sys::godot_variant_operator = sys::godot_variant_operator_GODOT_VARIANT_OP_MAX;
+    let ret_ptr = (&mut ret) as *mut _;"#
+            )?;
+        }
         &Ty::Enum(ref name) => {
             writeln!(w, r#"
     let mut ret: {} = mem::transmute(0);
@@ -611,6 +619,13 @@ fn generate_return_post(w: &mut impl Write, ty: &Ty) -> GeneratorResult {
                 w,
                 r#"
     VariantType::from_sys(ret)"#
+            )?;
+        }
+        &Ty::VariantOperator => {
+            writeln!(
+                w,
+                r#"
+    VariantOperator::try_from_sys(ret).expect("enum variant should be valid")"#
             )?;
         }
     }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -9,6 +9,7 @@ mod test_free_ub;
 mod test_register;
 mod test_return_leak;
 mod test_variant_call_args;
+mod test_variant_ops;
 
 #[no_mangle]
 pub extern "C" fn run_tests(
@@ -62,6 +63,7 @@ pub extern "C" fn run_tests(
     status &= test_register::run_tests();
     status &= test_return_leak::run_tests();
     status &= test_variant_call_args::run_tests();
+    status &= test_variant_ops::run_tests();
 
     gdnative::Variant::from_bool(status).forget()
 }
@@ -225,6 +227,7 @@ fn init(handle: init::InitHandle) {
     test_register::register(&handle);
     test_return_leak::register(&handle);
     test_variant_call_args::register(&handle);
+    test_variant_ops::register(&handle);
 }
 
 godot_gdnative_init!();

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -1,0 +1,47 @@
+use gdnative::*;
+
+pub(crate) fn run_tests() -> bool {
+    let mut status = true;
+
+    status &= test_variant_ops();
+
+    status
+}
+
+pub(crate) fn register(_handle: &init::InitHandle) {}
+
+fn test_variant_ops() -> bool {
+    println!(" -- test_variant_ops");
+
+    let ok = std::panic::catch_unwind(|| {
+        let mut arr = VariantArray::new();
+        arr.push(&"bar".to_variant());
+        arr.push(&"baz".to_variant());
+        let arr = arr.to_variant();
+
+        assert_eq!(
+            Ok(42.to_variant()),
+            6.to_variant()
+                .evaluate(VariantOperator::Multiply, &7.to_variant()),
+        );
+
+        assert_eq!(
+            Ok(false.to_variant()),
+            "foo".to_variant().evaluate(VariantOperator::In, &arr),
+        );
+
+        assert_eq!(
+            Err(InvalidOp),
+            "foo"
+                .to_variant()
+                .evaluate(VariantOperator::Multiply, &"bar".to_variant()),
+        );
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_variant_ops failed");
+    }
+
+    ok
+}


### PR DESCRIPTION
This also adds `Variant::evaluate` for `godot_variant_evaluate`.

Close #365