### PR TITLE
Implement extra TypedArray constructors, and conversion from iterators for collections

### DIFF
--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -5,10 +5,7 @@ pub type ByteArray = TypedArray<u8>;
 
 godot_test!(
     test_byte_array_access {
-        let mut arr = ByteArray::new();
-        for i in 0..8 {
-            arr.push(i);
-        }
+        let arr = (0..8).collect::<ByteArray>();
 
         let original_read = {
             let read = arr.read();
@@ -26,8 +23,15 @@ godot_test!(
             }
         }
 
+        cow_arr.append_slice(&[0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(16, cow_arr.len());
+
         for i in 0..8 {
             assert_eq!(i * 2, cow_arr.get(i as i32));
+        }
+
+        for i in 8..16 {
+            assert_eq!(i - 8, cow_arr.get(i as i32));
         }
 
         // the write shouldn't have affected the original array
@@ -37,11 +41,7 @@ godot_test!(
 
 godot_test!(
     test_byte_array_debug {
-        let mut arr = ByteArray::new();
-        for i in 0..8 {
-            arr.push(i);
-        }
-
+        let arr = (0..8).collect::<ByteArray>();
         assert_eq!(format!("{:?}", arr), "[0, 1, 2, 3, 4, 5, 6, 7]");
     }
 );

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -6,10 +6,11 @@ pub type ColorArray = TypedArray<Color>;
 
 godot_test!(
     test_color_array_access {
-        let mut arr = ColorArray::new();
-        arr.push_ref(&Color::rgb(1.0, 0.0, 0.0));
-        arr.push_ref(&Color::rgb(0.0, 1.0, 0.0));
-        arr.push_ref(&Color::rgb(0.0, 0.0, 1.0));
+        let arr = ColorArray::from_vec(vec![
+            Color::rgb(1.0, 0.0, 0.0),
+            Color::rgb(0.0, 1.0, 0.0),
+            Color::rgb(0.0, 0.0, 1.0),
+        ]);
 
         let original_read = {
             let read = arr.read();
@@ -46,10 +47,11 @@ godot_test!(
 
 godot_test!(
     test_color_array_debug {
-        let mut arr = ColorArray::new();
-        arr.push_ref(&Color::rgb(1.0, 0.0, 0.0));
-        arr.push_ref(&Color::rgb(0.0, 1.0, 0.0));
-        arr.push_ref(&Color::rgb(0.0, 0.0, 1.0));
+        let arr = ColorArray::from_vec(vec![
+            Color::rgb(1.0, 0.0, 0.0),
+            Color::rgb(0.0, 1.0, 0.0),
+            Color::rgb(0.0, 0.0, 1.0),
+        ]);
 
         assert_eq!(format!("{:?}", arr), "[Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 }, Color { r: 0.0, g: 1.0, b: 0.0, a: 1.0 }, Color { r: 0.0, g: 0.0, b: 1.0, a: 1.0 }]");
     }

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -1,7 +1,11 @@
+use std::iter::{Extend, FromIterator};
+
 use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
 
+use crate::ToVariant;
+use crate::ToVariantEq;
 use crate::Variant;
 use crate::VariantArray;
 use std::fmt;
@@ -124,6 +128,46 @@ impl_basic_traits!(
 impl fmt::Debug for Dictionary {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.to_json().to_string().fmt(f)
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for Dictionary
+where
+    K: ToVariantEq,
+    V: ToVariant,
+{
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut dic = Dictionary::new();
+        dic.extend(iter);
+        dic
+    }
+}
+
+impl FromIterator<(Variant, Variant)> for Dictionary {
+    fn from_iter<I: IntoIterator<Item = (Variant, Variant)>>(iter: I) -> Self {
+        let mut dic = Dictionary::new();
+        dic.extend(iter);
+        dic
+    }
+}
+
+impl<K, V> Extend<(K, V)> for Dictionary
+where
+    K: ToVariantEq,
+    V: ToVariant,
+{
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        for (key, value) in iter {
+            self.set(&key.to_variant(), &value.to_variant());
+        }
+    }
+}
+
+impl Extend<(Variant, Variant)> for Dictionary {
+    fn extend<I: IntoIterator<Item = (Variant, Variant)>>(&mut self, iter: I) {
+        for (key, value) in iter {
+            self.set(&key.to_variant(), &value.to_variant());
+        }
     }
 }
 

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -5,10 +5,7 @@ pub type Float32Array = TypedArray<f32>;
 
 godot_test!(
     test_float32_array_access {
-        let mut arr = Float32Array::new();
-        for i in 0..8 {
-            arr.push(i as f32);
-        }
+        let arr = (0..8).map(|i| i as f32).collect::<Float32Array>();
 
         let original_read = {
             let read = arr.read();
@@ -41,11 +38,7 @@ godot_test!(
 
 godot_test!(
     test_float32_array_debug {
-        let mut arr = Float32Array::new();
-        for i in 0..8 {
-            arr.push(i as f32);
-        }
-
+        let arr = (0..8).map(|i| i as f32).collect::<Float32Array>();
         assert_eq!(format!("{:?}", arr), "[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]");
     }
 );

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -5,10 +5,7 @@ pub type Int32Array = TypedArray<i32>;
 
 godot_test!(
     test_int32_array_access {
-        let mut arr = Int32Array::new();
-        for i in 0..8 {
-            arr.push(i);
-        }
+        let arr = (0..8).collect::<Int32Array>();
 
         let original_read = {
             let read = arr.read();
@@ -37,10 +34,7 @@ godot_test!(
 
 godot_test!(
     test_int32_array_debug {
-        let mut arr = Int32Array::new();
-        for i in 0..8 {
-            arr.push(i);
-        }
+        let arr = (0..8).collect::<Int32Array>();
         assert_eq!(format!("{:?}", arr), "[0, 1, 2, 3, 4, 5, 6, 7]");
     }
 );

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -6,10 +6,11 @@ pub type StringArray = TypedArray<GodotString>;
 
 godot_test!(
     test_string_array_access {
-        let mut arr = StringArray::new();
-        arr.push_ref(&GodotString::from("foo"));
-        arr.push_ref(&GodotString::from("bar"));
-        arr.push_ref(&GodotString::from("baz"));
+        let arr = StringArray::from_vec(vec![
+            GodotString::from("foo"),
+            GodotString::from("bar"),
+            GodotString::from("baz"),
+        ]);
 
         let original_read = {
             let read = arr.read();
@@ -46,10 +47,11 @@ godot_test!(
 
 godot_test!(
     test_string_array_debug {
-        let mut arr = StringArray::new();
-        arr.push_ref(&GodotString::from("foo"));
-        arr.push_ref(&GodotString::from("bar"));
-        arr.push_ref(&GodotString::from("baz"));
+        let arr = StringArray::from_vec(vec![
+            GodotString::from("foo"),
+            GodotString::from("bar"),
+            GodotString::from("baz"),
+        ]);
 
         assert_eq!(format!("{:?}", arr), "[\"foo\", \"bar\", \"baz\"]");
     }

--- a/gdnative-core/src/typed_array.rs
+++ b/gdnative-core/src/typed_array.rs
@@ -298,6 +298,20 @@ impl<T: Element> Extend<T> for TypedArray<T> {
     }
 }
 
+impl<T: Element + PartialEq> PartialEq for TypedArray<T> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        let left = self.read();
+        let right = other.read();
+
+        left.as_slice() == right.as_slice()
+    }
+}
+impl<T: Element + Eq> Eq for TypedArray<T> {}
+
 /// RAII read guard.
 pub struct ReadGuard<'a, T: Element> {
     access: *mut T::SysReadAccess,

--- a/gdnative-core/src/typed_array.rs
+++ b/gdnative-core/src/typed_array.rs
@@ -1,4 +1,6 @@
+use std::convert::TryFrom;
 use std::fmt;
+use std::iter::{Extend, FromIterator};
 
 use gdnative_impl_proc_macros as macros;
 
@@ -6,8 +8,15 @@ use crate::access::{Aligned, MaybeUnaligned};
 use crate::private::get_api;
 use crate::{Color, GodotString, VariantArray, Vector2, Vector2Godot, Vector3, Vector3Godot};
 
-/// A reference-counted typed vector using Godot's pool allocator, generic over possible
+/// A reference-counted CoW typed vector using Godot's pool allocator, generic over possible
 /// element types.
+///
+/// This type is CoW. The `Clone` implementation of this type creates a new reference without
+/// copying the contents.
+///
+/// When using this type, it's generally better to perform mutations in batch using `write`,
+/// or the `append` methods, as opposed to `push` or `set`, because the latter ones trigger
+/// CoW behavior each time they are called.
 pub struct TypedArray<T: Element> {
     inner: T::SysArray,
 }
@@ -20,6 +29,7 @@ pub type Read<'a, T> = Aligned<ReadGuard<'a, T>>;
 pub type Write<'a, T> = Aligned<WriteGuard<'a, T>>;
 
 impl<T: Element> Drop for TypedArray<T> {
+    #[inline]
     fn drop(&mut self) {
         unsafe {
             (T::destroy_fn(get_api()))(self.sys_mut());
@@ -28,6 +38,7 @@ impl<T: Element> Drop for TypedArray<T> {
 }
 
 impl<T: Element> Default for TypedArray<T> {
+    #[inline]
     fn default() -> Self {
         TypedArray::new()
     }
@@ -39,8 +50,16 @@ impl<T: Element + fmt::Debug> fmt::Debug for TypedArray<T> {
     }
 }
 
+impl<T: Element> Clone for TypedArray<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.new_ref()
+    }
+}
+
 impl<T: Element> TypedArray<T> {
     /// Creates an empty array.
+    #[inline]
     pub fn new() -> Self {
         unsafe {
             let mut inner = T::SysArray::default();
@@ -50,6 +69,7 @@ impl<T: Element> TypedArray<T> {
     }
 
     /// Creates from a `VariantArray` by making a best effort to convert each variant.
+    #[inline]
     pub fn from_variant_array(array: &VariantArray) -> Self {
         unsafe {
             let mut inner = T::SysArray::default();
@@ -58,7 +78,16 @@ impl<T: Element> TypedArray<T> {
         }
     }
 
+    /// Creates a `TypedArray` moving elements from `src`.
+    #[inline]
+    pub fn from_vec(mut src: Vec<T>) -> Self {
+        let mut arr = Self::new();
+        arr.append_vec(&mut src);
+        arr
+    }
+
     /// Creates a new reference to this reference-counted instance.
+    #[inline]
     pub fn new_ref(&self) -> Self {
         unsafe {
             let mut inner = T::SysArray::default();
@@ -93,6 +122,25 @@ impl<T: Element> TypedArray<T> {
         unsafe {
             (T::append_array_fn(get_api()))(self.sys_mut(), src.sys());
         }
+    }
+
+    /// Moves all the elements from `src` into `self`, leaving `src` empty.
+    ///
+    /// # Panics
+    ///
+    /// If the resulting length would not fit in `i32`.
+    pub fn append_vec(&mut self, src: &mut Vec<T>) {
+        let start = self.len() as usize;
+        let new_len = start + src.len();
+        self.resize(i32::try_from(new_len).expect("new length should fit in i32"));
+
+        let mut write = self.write();
+        let mut drain = src.drain(..);
+        for dst in &mut write[start..] {
+            *dst = drain.next().unwrap();
+        }
+
+        assert!(drain.next().is_none());
     }
 
     /// Inserts an element at the given offset and returns `true` if successful.
@@ -154,15 +202,18 @@ impl<T: Element> TypedArray<T> {
     }
 
     /// Returns the number of elements in the array.
+    #[inline]
     pub fn len(&self) -> i32 {
         unsafe { (T::size_fn(get_api()))(self.sys()) }
     }
 
     /// Returns `true` if the container is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Returns a RAII read access into this array.
     pub fn read(&self) -> Read<'_, T> {
         unsafe {
             MaybeUnaligned::new(ReadGuard::new(self.sys()))
@@ -171,6 +222,8 @@ impl<T: Element> TypedArray<T> {
         }
     }
 
+    /// Returns a RAII write access into this array. This triggers CoW once per lock, instead
+    /// of once each mutation.
     pub fn write(&mut self) -> Write<'_, T> {
         unsafe {
             MaybeUnaligned::new(WriteGuard::new(self.sys() as *mut _))
@@ -180,18 +233,68 @@ impl<T: Element> TypedArray<T> {
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn sys(&self) -> *const T::SysArray {
         &self.inner
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn sys_mut(&mut self) -> *mut T::SysArray {
         &mut self.inner
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn from_sys(sys: T::SysArray) -> Self {
         TypedArray { inner: sys }
+    }
+}
+
+impl<T: Element + Copy> TypedArray<T> {
+    /// Creates a new `TypedArray` by copying from `src`.
+    ///
+    /// # Panics
+    ///
+    /// If the length of `src` does not fit in `i32`.
+    #[inline]
+    pub fn from_slice(src: &[T]) -> Self {
+        let mut arr = Self::new();
+        arr.append_slice(src);
+        arr
+    }
+
+    /// Copies and appends all values in `src` to the end of the array.
+    ///
+    /// # Panics
+    ///
+    /// If the resulting length would not fit in `i32`.
+    pub fn append_slice(&mut self, src: &[T]) {
+        let start = self.len() as usize;
+        let new_len = start + src.len();
+        self.resize(i32::try_from(new_len).expect("new length should fit in i32"));
+
+        let mut write = self.write();
+        write[start..].copy_from_slice(src)
+    }
+}
+
+// `FromIterator` and `Extend` implementations collect into `Vec` first, because Rust `Vec`s
+// are better at handling unknown lengths than the Godot arrays (`push` CoWs every time!)
+
+impl<T: Element> FromIterator<T> for TypedArray<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let vec = iter.into_iter().collect::<Vec<_>>();
+        Self::from_vec(vec)
+    }
+}
+
+impl<T: Element> Extend<T> for TypedArray<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let mut vec = iter.into_iter().collect::<Vec<_>>();
+        self.append_vec(&mut vec);
     }
 }
 

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,6 +1,9 @@
+use std::iter::{Extend, FromIterator};
+
 use crate::private::get_api;
 use crate::sys;
 
+use crate::ToVariant;
 use crate::Variant;
 
 use std::fmt;
@@ -226,6 +229,22 @@ impl<'a> Iterator for IterMut<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
+    }
+}
+
+impl<T: ToVariant> FromIterator<T> for VariantArray {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut arr = Self::new();
+        arr.extend(iter);
+        arr
+    }
+}
+
+impl<T: ToVariant> Extend<T> for VariantArray {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for elem in iter {
+            self.push(&elem.to_variant());
+        }
     }
 }
 

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -6,10 +6,11 @@ pub type Vector2Array = TypedArray<Vector2>;
 
 godot_test!(
     test_vector2_array_access {
-        let mut arr = Vector2Array::new();
-        arr.push_ref(&Vector2::new(1.0, 2.0));
-        arr.push_ref(&Vector2::new(3.0, 4.0));
-        arr.push_ref(&Vector2::new(5.0, 6.0));
+        let arr = Vector2Array::from_vec(vec![
+            Vector2::new(1.0, 2.0),
+            Vector2::new(3.0, 4.0),
+            Vector2::new(5.0, 6.0),
+        ]);
 
         let original_read = {
             let read = arr.read();
@@ -46,10 +47,11 @@ godot_test!(
 
 godot_test!(
     test_vector2_array_debug {
-        let mut arr = Vector2Array::new();
-        arr.push_ref(&Vector2::new(1.0, 2.0));
-        arr.push_ref(&Vector2::new(3.0, 4.0));
-        arr.push_ref(&Vector2::new(5.0, 6.0));
+        let arr = Vector2Array::from_vec(vec![
+            Vector2::new(1.0, 2.0),
+            Vector2::new(3.0, 4.0),
+            Vector2::new(5.0, 6.0),
+        ]);
 
         assert_eq!(format!("{:?}", arr), format!("{:?}", &[Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0), Vector2::new(5.0, 6.0)]));
     }

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -6,10 +6,11 @@ pub type Vector3Array = TypedArray<Vector3>;
 
 godot_test!(
     test_vector3_array_access {
-        let mut arr = Vector3Array::new();
-        arr.push_ref(&Vector3::new(1.0, 2.0, 3.0));
-        arr.push_ref(&Vector3::new(3.0, 4.0, 5.0));
-        arr.push_ref(&Vector3::new(5.0, 6.0, 7.0));
+        let arr = Vector3Array::from_vec(vec![
+            Vector3::new(1.0, 2.0, 3.0),
+            Vector3::new(3.0, 4.0, 5.0),
+            Vector3::new(5.0, 6.0, 7.0),
+        ]);
 
         let original_read = {
             let read = arr.read();
@@ -47,10 +48,11 @@ godot_test!(
 
 godot_test!(
     test_vector3_array_debug {
-        let mut arr = Vector3Array::new();
-        arr.push_ref(&Vector3::new(1.0, 2.0, 3.0));
-        arr.push_ref(&Vector3::new(3.0, 4.0, 5.0));
-        arr.push_ref(&Vector3::new(5.0, 6.0, 7.0));
+        let arr = Vector3Array::from_vec(vec![
+            Vector3::new(1.0, 2.0, 3.0),
+            Vector3::new(3.0, 4.0, 5.0),
+            Vector3::new(5.0, 6.0, 7.0),
+        ]);
 
         assert_eq!(format!("{:?}", arr), format!("{:?}", &[Vector3::new(1.0, 2.0, 3.0), Vector3::new(3.0, 4.0, 5.0), Vector3::new(5.0, 6.0, 7.0)]));
     }


### PR DESCRIPTION
Added `from_vec`, `append_vec`, `from_slice` and `append_slice` to `TypedArray`. Implemented `FromIterator` and `Extend` for `TypedArray` and `VariantArray`.

Implemented `FromIterator` and `Extend` for `Dictionary`. Both traits can take `Variant`s or `ToVariant` types. Added a new `ToVariantEq` trait as a bound for `Dictionary` keys, as a measure to prevent surprising behavior with user-defined `ToVariant` types.

The second commit also implemented `PartialEq` and `Eq` for `TypedArray`.

Close #378. Close #379.