### PR TITLE
Adding BufWriter to gdnative-bindings/build.rs

### DIFF
--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -2,13 +2,17 @@ use gdnative_bindings_generator::*;
 
 use std::env;
 use std::fs::File;
+use std::io::BufWriter;
 use std::path::PathBuf;
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let mut types_output = File::create(out_path.join("bindings_types.rs")).unwrap();
-    let mut traits_output = File::create(out_path.join("bindings_traits.rs")).unwrap();
-    let mut methods_output = File::create(out_path.join("bindings_methods.rs")).unwrap();
+    let mut types_output =
+        BufWriter::new(File::create(out_path.join("bindings_types.rs")).unwrap());
+    let mut traits_output =
+        BufWriter::new(File::create(out_path.join("bindings_traits.rs")).unwrap());
+    let mut methods_output =
+        BufWriter::new(File::create(out_path.join("bindings_methods.rs")).unwrap());
 
     // gdnative-core already implements all dependencies of Object
     let to_ignore = { strongly_connected_components(&Api::new(), "Object", None) };


### PR DESCRIPTION
This reduces the build time on my box by close to a second. 
Figure it’d be even better on boxes that may have worse iops.