### PR TITLE
Fix variant collections with interior mutability

### DIFF
--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -38,6 +38,7 @@ use std::ptr;
 
 use crate::private::get_api;
 use crate::NativeClass;
+use crate::RefCounted;
 
 use crate::Variant;
 

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -243,86 +243,6 @@ macro_rules! godot_error {
     })
 }
 
-macro_rules! impl_basic_trait {
-    (
-        Drop for $Type:ident as $GdType:ident : $gd_method:ident
-    ) => {
-        impl Drop for $Type {
-            #[inline]
-            fn drop(&mut self) {
-                unsafe { (get_api().$gd_method)(&mut self.0) }
-            }
-        }
-    };
-
-    (
-        Clone for $Type:ident as $GdType:ident : $gd_method:ident
-    ) => {
-        impl Clone for $Type {
-            #[inline]
-            fn clone(&self) -> Self {
-                unsafe {
-                    let mut result = sys::$GdType::default();
-                    (get_api().$gd_method)(&mut result, &self.0);
-                    $Type(result)
-                }
-            }
-        }
-    };
-
-    (
-        Default for $Type:ident as $GdType:ident : $gd_method:ident
-    ) => {
-        impl Default for $Type {
-            #[inline]
-            fn default() -> Self {
-                unsafe {
-                    let mut gd_val = sys::$GdType::default();
-                    (get_api().$gd_method)(&mut gd_val);
-                    $Type(gd_val)
-                }
-            }
-        }
-    };
-
-    (
-        PartialEq for $Type:ident as $GdType:ident : $gd_method:ident
-    ) => {
-        impl PartialEq for $Type {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                unsafe { (get_api().$gd_method)(&self.0, &other.0) }
-            }
-        }
-    };
-
-    (
-        Eq for $Type:ident as $GdType:ident : $gd_method:ident
-    ) => {
-        impl PartialEq for $Type {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                unsafe { (get_api().$gd_method)(&self.0, &other.0) }
-            }
-        }
-        impl Eq for $Type {}
-    };
-}
-
-macro_rules! impl_basic_traits {
-    (
-        for $Type:ident as $GdType:ident {
-            $( $Trait:ident => $gd_method:ident; )*
-        }
-    ) => (
-        $(
-            impl_basic_trait!(
-                $Trait for $Type as $GdType : $gd_method
-            );
-        )*
-    )
-}
-
 macro_rules! impl_basic_trait_as_sys {
     (
         Drop for $Type:ident as $GdType:ident : $gd_method:ident
@@ -416,39 +336,6 @@ macro_rules! impl_basic_traits_as_sys {
             );
         )*
     )
-}
-
-macro_rules! impl_common_method {
-    (
-        $(#[$attr:meta])*
-        $visibility:vis fn new_ref(&self) -> $Type:ident : $gd_method:ident
-    ) => {
-        $(#[$attr])*
-        /// Creates a new reference to this reference-counted instance.
-        $visibility fn new_ref(&self) -> $Type {
-            unsafe {
-                let mut result = Default::default();
-                (get_api().$gd_method)(&mut result, &self.0);
-                $Type(result)
-            }
-        }
-    };
-}
-
-macro_rules! impl_common_methods {
-    (
-        $(
-            $(#[$attr:meta])*
-            $visibility:vis fn $name:ident(&self $(,$pname:ident : $pty:ty)*) -> $Ty:ident : $gd_method:ident;
-        )*
-    ) => (
-        $(
-            impl_common_method!(
-                $(#[$attr])*
-                $visibility fn $name(&self $(,$pname : $pty)*) -> $Ty : $gd_method
-            );
-        )*
-    );
 }
 
 macro_rules! godot_test {

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -111,15 +111,14 @@ impl NodePath {
 
     #[doc(hidden)]
     #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_node_path {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
     pub fn from_sys(sys: sys::godot_node_path) -> Self {
         NodePath(sys)
-    }
-}
-
-impl RefCounted for NodePath {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> NodePath : godot_node_path_new_copy;
     }
 }
 
@@ -154,10 +153,11 @@ impl Into<GodotString> for NodePath {
     }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for NodePath as godot_node_path {
         Drop => godot_node_path_destroy;
         Eq => godot_node_path_operator_equal;
+        RefCounted => godot_node_path_new_copy;
     }
 );
 

--- a/gdnative-core/src/rid.rs
+++ b/gdnative-core/src/rid.rs
@@ -49,7 +49,7 @@ impl Rid {
 
     #[doc(hidden)]
     #[inline]
-    pub fn mut_sys(&mut self) -> *mut sys::godot_rid {
+    pub fn sys_mut(&mut self) -> *mut sys::godot_rid {
         &mut self.0
     }
 
@@ -60,7 +60,7 @@ impl Rid {
     }
 }
 
-impl_basic_traits! {
+impl_basic_traits_as_sys! {
     for Rid as godot_rid {
         Eq => godot_rid_operator_equal;
         Default => godot_rid_new;

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -194,6 +194,12 @@ impl GodotString {
 
     #[doc(hidden)]
     #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_string {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
     pub fn from_sys(sys: sys::godot_string) -> Self {
         GodotString(sys)
     }
@@ -207,18 +213,12 @@ impl Clone for GodotString {
     }
 }
 
-impl RefCounted for GodotString {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> GodotString : godot_string_new_copy;
-    }
-}
-
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for GodotString as godot_string {
         Drop => godot_string_destroy;
         Eq => godot_string_operator_equal;
         Default => godot_string_new;
+        RefCounted => godot_string_new_copy;
     }
 );
 
@@ -278,9 +278,27 @@ impl Utf8String {
     pub fn to_string(&self) -> String {
         String::from(self.as_str())
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys(&self) -> *const sys::godot_char_string {
+        &self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_char_string {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_sys(sys: sys::godot_char_string) -> Self {
+        Self(sys)
+    }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for Utf8String as godot_char_string {
         Drop => godot_char_string_destroy;
     }
@@ -337,9 +355,27 @@ impl StringName {
     pub fn operator_less(&self, s: &StringName) -> bool {
         unsafe { (get_api().godot_string_name_operator_less)(&self.0, &s.0) }
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys(&self) -> *const sys::godot_string_name {
+        &self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_string_name {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_sys(sys: sys::godot_string_name) -> Self {
+        Self(sys)
+    }
 }
 
-impl_basic_traits! {
+impl_basic_traits_as_sys! {
     for StringName as godot_string_name {
         Drop => godot_string_name_destroy;
         Eq => godot_string_name_operator_equal;

--- a/gdnative-core/src/typed_array.rs
+++ b/gdnative-core/src/typed_array.rs
@@ -87,7 +87,7 @@ impl<T: Element> TypedArray<T> {
     pub fn from_variant_array(array: &VariantArray) -> Self {
         unsafe {
             let mut inner = T::SysArray::default();
-            (T::new_with_array_fn(get_api()))(&mut inner, &array.0);
+            (T::new_with_array_fn(get_api()))(&mut inner, array.sys());
             TypedArray { inner }
         }
     }

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -751,7 +751,7 @@ impl Variant {
     }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for Variant as godot_variant {
         Drop => godot_variant_destroy;
         Clone => godot_variant_new_copy;

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,4 +1,5 @@
 use std::iter::{Extend, FromIterator};
+use std::marker::PhantomData;
 
 use crate::private::get_api;
 use crate::sys;
@@ -11,7 +12,21 @@ use std::fmt;
 
 /// A reference-counted `Variant` vector. Godot's generic array data type.
 /// Negative indices can be used to count from the right.
-pub struct VariantArray(pub(crate) sys::godot_array);
+///
+/// # Safety
+///
+/// This is a reference-counted collection with "interior mutability" in Rust parlance. Its use
+/// must follow the official [thread-safety guidelines][thread-safety]. Specifically, it is
+/// undefined behavior to pass an instance to Rust code without locking a mutex if there are
+/// references to it on other threads.
+///
+/// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
+pub struct VariantArray {
+    sys: sys::godot_array,
+
+    /// Marker preventing the compiler from incorrectly deriving `Send` and `Sync`.
+    _marker: PhantomData<*const ()>,
+}
 
 impl VariantArray {
     /// Creates an empty `VariantArray`.
@@ -22,95 +37,114 @@ impl VariantArray {
 
     /// Sets the value of the element at the given offset.
     #[inline]
-    pub fn set(&mut self, idx: i32, val: &Variant) {
-        unsafe { (get_api().godot_array_set)(&mut self.0, idx, &val.0) }
+    pub fn set(&self, idx: i32, val: &Variant) {
+        unsafe { (get_api().godot_array_set)(self.sys_mut(), idx, val.sys()) }
     }
 
     /// Returns a copy of the element at the given offset.
     #[inline]
-    pub fn get_val(&mut self, idx: i32) -> Variant {
-        unsafe { Variant((get_api().godot_array_get)(&self.0, idx)) }
+    pub fn get(&self, idx: i32) -> Variant {
+        unsafe { Variant((get_api().godot_array_get)(self.sys(), idx)) }
     }
 
     /// Returns a reference to the element at the given offset.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference.
+    ///
+    /// `Variant` is reference-counted and thus cheaply cloned. Consider using `get` instead.
     #[inline]
-    pub fn get_ref(&self, idx: i32) -> &Variant {
-        unsafe { Variant::cast_ref((get_api().godot_array_operator_index_const)(&self.0, idx)) }
+    pub unsafe fn get_ref(&self, idx: i32) -> &Variant {
+        Variant::cast_ref((get_api().godot_array_operator_index_const)(
+            self.sys(),
+            idx,
+        ))
     }
 
     /// Returns a mutable reference to the element at the given offset.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference. It is possible to create two mutable references to the same memory location
+    /// if the same `idx` is provided, causing undefined behavior.
     #[inline]
-    pub fn get_mut_ref(&mut self, idx: i32) -> &mut Variant {
-        unsafe { Variant::cast_mut_ref((get_api().godot_array_operator_index)(&mut self.0, idx)) }
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn get_mut_ref(&self, idx: i32) -> &mut Variant {
+        Variant::cast_mut_ref((get_api().godot_array_operator_index)(self.sys_mut(), idx))
     }
 
     #[inline]
-    pub fn count(&mut self, val: &Variant) -> i32 {
-        unsafe { (get_api().godot_array_count)(&mut self.0, &val.0) }
+    pub fn count(&self, val: &Variant) -> i32 {
+        unsafe { (get_api().godot_array_count)(self.sys(), val.sys()) }
     }
 
     /// Clears the array, resizing to 0.
     #[inline]
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         unsafe {
-            (get_api().godot_array_clear)(&mut self.0);
+            (get_api().godot_array_clear)(self.sys_mut());
         }
     }
 
+    /// Removes the element at `idx`.
     #[inline]
-    pub fn remove(&mut self, idx: i32) {
-        unsafe { (get_api().godot_array_remove)(&mut self.0, idx) }
+    pub fn remove(&self, idx: i32) {
+        unsafe { (get_api().godot_array_remove)(self.sys_mut(), idx) }
     }
 
+    /// Removed the first occurrence of `val`.
     #[inline]
-    pub fn erase(&mut self, val: &Variant) {
-        unsafe { (get_api().godot_array_erase)(&mut self.0, &val.0) }
+    pub fn erase(&self, val: &Variant) {
+        unsafe { (get_api().godot_array_erase)(self.sys_mut(), val.sys()) }
     }
 
     /// Returns `true` if the `VariantArray` contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        unsafe { (get_api().godot_array_empty)(&self.0) }
+        unsafe { (get_api().godot_array_empty)(self.sys()) }
     }
 
     /// Returns the number of elements in the array.
     #[inline]
     pub fn len(&self) -> i32 {
-        unsafe { (get_api().godot_array_size)(&self.0) }
+        unsafe { (get_api().godot_array_size)(self.sys()) }
     }
 
     /// Appends an element at the end of the array.
     #[inline]
-    pub fn push(&mut self, val: &Variant) {
+    pub fn push(&self, val: &Variant) {
         unsafe {
-            (get_api().godot_array_push_back)(&mut self.0, &val.0);
+            (get_api().godot_array_push_back)(self.sys_mut(), val.sys());
         }
     }
 
     /// Removes an element at the end of the array.
     #[inline]
-    pub fn pop(&mut self) -> Variant {
-        unsafe { Variant((get_api().godot_array_pop_back)(&mut self.0)) }
+    pub fn pop(&self) -> Variant {
+        unsafe { Variant((get_api().godot_array_pop_back)(self.sys_mut())) }
     }
 
     /// Appends an element to the front of the array.
     #[inline]
-    pub fn push_front(&mut self, val: &Variant) {
+    pub fn push_front(&self, val: &Variant) {
         unsafe {
-            (get_api().godot_array_push_front)(&mut self.0, &val.0);
+            (get_api().godot_array_push_front)(self.sys_mut(), val.sys());
         }
     }
 
     /// Removes an element at the front of the array.
     #[inline]
-    pub fn pop_front(&mut self) -> Variant {
-        unsafe { Variant((get_api().godot_array_pop_front)(&mut self.0)) }
+    pub fn pop_front(&self) -> Variant {
+        unsafe { Variant((get_api().godot_array_pop_front)(self.sys_mut())) }
     }
 
     /// Insert a new int at a given position in the array.
     #[inline]
-    pub fn insert(&mut self, at: i32, val: &Variant) {
-        unsafe { (get_api().godot_array_insert)(&mut self.0, at, &val.0) }
+    pub fn insert(&self, at: i32, val: &Variant) {
+        unsafe { (get_api().godot_array_insert)(self.sys_mut(), at, val.sys()) }
     }
 
     /// Searches the array for a value and returns its index.
@@ -118,18 +152,18 @@ impl VariantArray {
     /// Returns `-1` if value is not found.
     #[inline]
     pub fn find(&self, what: &Variant, from: i32) -> i32 {
-        unsafe { (get_api().godot_array_find)(&self.0, &what.0, from) }
+        unsafe { (get_api().godot_array_find)(self.sys(), what.sys(), from) }
     }
 
     /// Returns true if the `VariantArray` contains the specified value.
     #[inline]
     pub fn contains(&self, what: &Variant) -> bool {
-        unsafe { (get_api().godot_array_has)(&self.0, &what.0) }
+        unsafe { (get_api().godot_array_has)(self.sys(), what.sys()) }
     }
 
     #[inline]
-    pub fn resize(&mut self, size: i32) {
-        unsafe { (get_api().godot_array_resize)(&mut self.0, size) }
+    pub fn resize(&self, size: i32) {
+        unsafe { (get_api().godot_array_resize)(self.sys_mut(), size) }
     }
 
     /// Searches the array in reverse order.
@@ -137,31 +171,31 @@ impl VariantArray {
     /// If negative, the start index is considered relative to the end of the array.
     #[inline]
     pub fn rfind(&self, what: &Variant, from: i32) -> i32 {
-        unsafe { (get_api().godot_array_rfind)(&self.0, &what.0, from) }
+        unsafe { (get_api().godot_array_rfind)(self.sys(), what.sys(), from) }
     }
 
     /// Searches the array in reverse order for a value.
     /// Returns its index or `-1` if not found.
     #[inline]
     pub fn find_last(&self, what: &Variant) -> i32 {
-        unsafe { (get_api().godot_array_find_last)(&self.0, &what.0) }
+        unsafe { (get_api().godot_array_find_last)(self.sys(), what.sys()) }
     }
 
     /// Inverts the order of the elements in the array.
     #[inline]
-    pub fn invert(&mut self) {
-        unsafe { (get_api().godot_array_invert)(&mut self.0) }
+    pub fn invert(&self) {
+        unsafe { (get_api().godot_array_invert)(self.sys_mut()) }
     }
 
     /// Return a hashed i32 value representing the array contents.
     #[inline]
     pub fn hash(&self) -> i32 {
-        unsafe { (get_api().godot_array_hash)(&self.0) }
+        unsafe { (get_api().godot_array_hash)(self.sys()) }
     }
 
     #[inline]
-    pub fn sort(&mut self) {
-        unsafe { (get_api().godot_array_sort)(&mut self.0) }
+    pub fn sort(&self) {
+        unsafe { (get_api().godot_array_sort)(self.sys_mut()) }
     }
 
     // TODO
@@ -171,7 +205,7 @@ impl VariantArray {
 
     // pub fn bsearch(&mut self, val: (), before: bool) -> i32 {
     //     unsafe {
-    //         (get_api().godot_array_bsearch)(&mut self.0, val, before)
+    //         (get_api().godot_array_bsearch)(self.sys_mut(), val, before)
     //     }
     // }
 
@@ -179,47 +213,46 @@ impl VariantArray {
     //     unimplemented!();
     // }
 
+    /// Returns an iterator through all values in the `VariantArray`.
+    ///
+    /// `VariantArray` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
     #[inline]
     pub fn iter(&self) -> Iter {
         Iter {
-            arr: self,
+            arr: self.new_ref(),
             range: 0..self.len(),
-        }
-    }
-
-    #[inline]
-    pub fn iter_mut(&mut self) -> IterMut {
-        let len = self.len();
-        IterMut {
-            arr: self,
-            range: 0..len,
         }
     }
 
     #[doc(hidden)]
     #[inline]
     pub fn sys(&self) -> *const sys::godot_array {
-        &self.0
+        &self.sys
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&self) -> *mut sys::godot_array {
+        &self.sys as *const _ as *mut _
     }
 
     #[doc(hidden)]
     #[inline]
     pub fn from_sys(sys: sys::godot_array) -> Self {
-        VariantArray(sys)
+        VariantArray {
+            sys,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl RefCounted for VariantArray {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> VariantArray : godot_array_new_copy;
-    }
-}
-
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for VariantArray as godot_array {
         Drop => godot_array_destroy;
         Default => godot_array_new;
+        RefCounted => godot_array_new_copy;
     }
 );
 
@@ -230,39 +263,18 @@ impl fmt::Debug for VariantArray {
     }
 }
 
-pub struct Iter<'a> {
-    arr: &'a VariantArray,
+#[derive(Debug)]
+pub struct Iter {
+    arr: VariantArray,
     range: std::ops::Range<i32>,
 }
 
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Variant;
+impl Iterator for Iter {
+    type Item = Variant;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(|idx| self.arr.get_ref(idx))
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
-    }
-}
-
-pub struct IterMut<'a> {
-    arr: &'a mut VariantArray,
-    range: std::ops::Range<i32>,
-}
-
-impl<'a> Iterator for IterMut<'a> {
-    type Item = &'a mut Variant;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(|idx| {
-            let short_ref: &'_ mut Variant = self.arr.get_mut_ref(idx);
-            unsafe { std::mem::transmute::<_, &'a mut Variant>(short_ref) }
-        })
+        self.range.next().map(|idx| self.arr.get(idx))
     }
 
     #[inline]
@@ -294,7 +306,7 @@ godot_test!(test_array {
     let bar = Variant::from_str("bar");
     let nope = Variant::from_str("nope");
 
-    let mut array = VariantArray::new(); // []
+    let array = VariantArray::new(); // []
 
     assert!(array.is_empty());
     assert_eq!(array.len(), 0);
@@ -311,8 +323,8 @@ godot_test!(test_array {
     array.set(0, &bar); // [&bar, &bar]
     array.set(1, &foo); // [&bar, &foo]
 
-    assert_eq!(array.get_ref(0), &bar);
-    assert_eq!(array.get_ref(1), &foo);
+    assert_eq!(&array.get(0), &bar);
+    assert_eq!(&array.get(1), &foo);
 
     array.pop(); // [&bar]
     array.pop(); // []
@@ -332,12 +344,12 @@ godot_test!(test_array {
 
     array.invert(); // [&x, &y, &z, &z]
 
-    assert_eq!(array.get_ref(0), &x);
+    assert_eq!(&array.get(0), &x);
 
     array.pop_front(); // [&y, &z, &z]
     array.pop_front(); // [&z, &z]
 
-    assert_eq!(array.get_ref(0), &z);
+    assert_eq!(&array.get(0), &z);
 
     array.resize(0); // []
     assert!(array.is_empty());
@@ -350,7 +362,7 @@ godot_test!(test_array {
     assert!(array2.contains(&bar));
     assert!(!array2.contains(&nope));
 
-    let mut array3 = VariantArray::new(); // []
+    let array3 = VariantArray::new(); // []
 
     array3.push(&Variant::from_i64(42));
     array3.push(&Variant::from_i64(1337));
@@ -360,20 +372,11 @@ godot_test!(test_array {
         &[42, 1337, 512],
         array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
     );
-
-    for v in array3.iter_mut() {
-        *v = Variant::from_i64(54);
-    }
-
-    assert_eq!(
-        &[54, 54, 54],
-        array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
-    );
 });
 
 godot_test!(
     test_array_debug {
-        let mut arr = VariantArray::new(); // []
+        let arr = VariantArray::new(); // []
         arr.push(&Variant::from_str("hello world"));
         arr.push(&Variant::from_bool(true));
         arr.push(&Variant::from_i64(42));

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -72,7 +72,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
                         })
                     }
                     else {
-                        let __key = String::from_variant(__keys.get_ref(0))
+                        let __key = String::from_variant(&__keys.get(0))
                             .map_err(|__err| FVE::InvalidEnumRepr {
                                 expected: VariantEnumRepr::ExternallyTagged,
                                 error: Box::new(__err),
@@ -80,7 +80,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
                         match __key.as_str() {
                             #(
                                 #ref_var_ident_string_literals => {
-                                    let #var_input_ident_iter = __dict.get_ref(__keys.get_ref(0));
+                                    let #var_input_ident_iter = &__dict.get(&__keys.get(0));
                                     (#var_from_variants).map_err(|err| FVE::InvalidEnumVariant {
                                         variant: "Ok",
                                         error: Box::new(err),

--- a/gdnative-derive/src/variant/repr.rs
+++ b/gdnative-derive/src/variant/repr.rs
@@ -112,7 +112,7 @@ impl VariantRepr {
 
                     quote! {
                         {
-                            let mut __array = ::gdnative::VariantArray::new();
+                            let __array = ::gdnative::VariantArray::new();
                             #(
                                 __array.push(&#exprs);
                             )*
@@ -135,7 +135,7 @@ impl VariantRepr {
 
                 quote! {
                     {
-                        let mut __dict = ::gdnative::Dictionary::new();
+                        let __dict = ::gdnative::Dictionary::new();
                         #(
                             {
                                 let __key = ::gdnative::GodotString::from(#name_string_literals).to_variant();
@@ -191,10 +191,9 @@ impl VariantRepr {
                     let ctor_idents = fields.iter().map(|f| &f.ident);
 
                     let expected_len = Literal::usize_suffixed(non_skipped_fields.len());
-                    let indices =
-                        (0..non_skipped_fields.len() as i32).map(|n| Literal::i32_suffixed(n));
+                    let indices = (0..non_skipped_fields.len() as i32).map(Literal::i32_suffixed);
 
-                    let expr_variant = &quote!(__array.get_ref(__index));
+                    let expr_variant = &quote!(&__array.get(__index));
                     let non_skipped_exprs = non_skipped_fields
                         .iter()
                         .map(|f| f.from_variant(expr_variant));
@@ -253,7 +252,7 @@ impl VariantRepr {
                 let name_string_literals =
                     name_strings.iter().map(|string| Literal::string(&string));
 
-                let expr_variant = &quote!(__dict.get_ref(&__key));
+                let expr_variant = &quote!(&__dict.get(&__key));
                 let exprs = non_skipped_fields
                     .iter()
                     .map(|f| f.from_variant(expr_variant));

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -41,7 +41,7 @@ pub(crate) fn expand_to_variant(derive_data: DeriveData) -> TokenStream {
                         let var_ident_string_literal = Literal::string(&var_ident_string);
                         quote! {
                             #ident::#var_ident #destructure_pattern => {
-                                let mut __dict = ::gdnative::Dictionary::new();
+                                let __dict = ::gdnative::Dictionary::new();
                                 let __key = ::gdnative::GodotString::from(#var_ident_string_literal).to_variant();
                                 let __value = #to_variant;
                                 __dict.set(&__key, &__value);

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -104,8 +104,8 @@ fn test_derive_to_variant() -> bool {
         let tuple_array = variant.try_to_array().expect("should be array");
 
         assert_eq!(2, tuple_array.len());
-        assert_eq!(Some(1), tuple_array.get_ref(0).try_to_i64());
-        assert_eq!(Some(false), tuple_array.get_ref(1).try_to_bool());
+        assert_eq!(Some(1), tuple_array.get(0).try_to_i64());
+        assert_eq!(Some(false), tuple_array.get(1).try_to_bool());
         assert_eq!(
             Ok(ToVarTuple::<f64, i128>(1, 0, false)),
             ToVarTuple::from_variant(&variant)

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -14,7 +14,7 @@ fn test_variant_ops() -> bool {
     println!(" -- test_variant_ops");
 
     let ok = std::panic::catch_unwind(|| {
-        let mut arr = VariantArray::new();
+        let arr = VariantArray::new();
         arr.push(&"bar".to_variant());
         arr.push(&"baz".to_variant());
         let arr = arr.to_variant();


### PR DESCRIPTION
- All methods of `Dictionary` and `VariantArray` now take `&self`.
- Added documentation on safety of these collections.
- Removed `VariantArray::iter_mut` because it's too easy to use in an unsound way and has no clear use cases.
- `Dictionary` and `VariantArray` are now correctly `!Send` and `!Sync`.

This also replaces the older `impl_basic_trait` macro with the more versatile `impl_basic_trait_as_sys`.

Close #395