### PR TITLE
Fix and silence a few clippy lints

### DIFF
--- a/gdnative-core/src/access.rs
+++ b/gdnative-core/src/access.rs
@@ -48,8 +48,11 @@ impl<G: Guard> MaybeUnaligned<G> {
         MaybeUnaligned { guard }
     }
 
-    /// Assumes that an access is aligned. It is undefined behavior to Deref the resulting
-    /// access if the underlying pointer is not aligned to `G::Target`.
+    /// Assumes that an access is aligned.
+    ///
+    /// # Safety
+    /// It is undefined behavior to Deref the resulting access if the underlying pointer is not
+    /// aligned to `G::Target`.
     #[inline]
     pub unsafe fn assume_aligned(self) -> Aligned<G> {
         Aligned { guard: self.guard }

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -74,7 +74,6 @@ pub trait NativeClassMethods: NativeClass {
 }
 
 /// A reference to a GodotObject with a rust NativeClass attached.
-#[allow(clippy::new_without_default)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Instance<T: NativeClass> {
     owner: T::Base,
@@ -87,6 +86,7 @@ impl<T: NativeClass> Instance<T> {
     ///
     /// Must be called after the library is initialized.
     #[inline]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self
     where
         T::Base: Instanciable,

--- a/gdnative-core/src/geom/basis.rs
+++ b/gdnative-core/src/geom/basis.rs
@@ -581,6 +581,7 @@ impl core::ops::Mul<Basis> for Basis {
 }
 
 #[cfg(test)]
+#[allow(clippy::unreadable_literal)]
 mod tests {
     use super::*;
 
@@ -681,7 +682,7 @@ mod tests {
     fn rotated() {
         let (b, _bn) = test_inputs();
 
-        let r = Vector3::new(-50.167156, 60.677813, -70.043058).normalize();
+        let r = Vector3::new(-50.167156, 60.67781, -70.04305).normalize();
         let expected = Basis::from_elements([
             Vector3::new(-0.676245, 0.113805, 0.727833),
             Vector3::new(-0.467094, 0.697765, -0.54309),

--- a/gdnative-core/src/user_data.rs
+++ b/gdnative-core/src/user_data.rs
@@ -87,7 +87,7 @@ pub unsafe trait UserData: Sized + Clone {
     /// This gives "ownership" to the engine.
     ///
     /// This operation must never fail.
-    unsafe fn into_user_data(self) -> *const libc::c_void;
+    fn into_user_data(self) -> *const libc::c_void;
 
     /// Takes an opaque pointer produced by `into_user_data` and "consumes" it to produce the
     /// original instance, keeping the reference count.
@@ -98,6 +98,10 @@ pub unsafe trait UserData: Sized + Clone {
     /// `ptr` is guaranteed to be non-null.
     ///
     /// This operation must never fail.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be pointing to valid data of the correct type.
     unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self;
 
     /// Takes an opaque pointer produced by `into_user_data` and "clones" it to produce the
@@ -108,6 +112,10 @@ pub unsafe trait UserData: Sized + Clone {
     /// `ptr` is guaranteed to be non-null.
     ///
     /// This operation must never fail.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be pointing to valid data of the correct type.
     unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self;
 }
 
@@ -222,7 +230,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_user_data(self) -> *const libc::c_void {
+    fn into_user_data(self) -> *const libc::c_void {
         Arc::into_raw(self.lock) as *const libc::c_void
     }
 
@@ -320,7 +328,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_user_data(self) -> *const libc::c_void {
+    fn into_user_data(self) -> *const libc::c_void {
         Arc::into_raw(self.lock) as *const libc::c_void
     }
 
@@ -414,7 +422,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_user_data(self) -> *const libc::c_void {
+    fn into_user_data(self) -> *const libc::c_void {
         Arc::into_raw(self.0) as *const libc::c_void
     }
 
@@ -544,7 +552,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_user_data(self) -> *const libc::c_void {
+    fn into_user_data(self) -> *const libc::c_void {
         Arc::into_raw(self.inner) as *const libc::c_void
     }
 
@@ -645,7 +653,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_user_data(self) -> *const libc::c_void {
+    fn into_user_data(self) -> *const libc::c_void {
         1 as *const libc::c_void
     }
 


### PR DESCRIPTION
- Added safety section to `Access` and `UserData` doc-comments
- Moved `#[allow(clippy::new_without_default)]` to the correct position
- Allowed `unreadable_literal` in test.
