### PR TITLE
Make all binding methods take shared references

### DIFF
--- a/bindings_generator/src/documentation.rs
+++ b/bindings_generator/src/documentation.rs
@@ -114,6 +114,20 @@ pub fn generate_class_documentation(
         )?;
     }
 
+    writeln!(
+        output,
+        r#"///
+///
+/// ## Safety
+///
+/// All types in the Godot API have "interior mutability" in Rust parlance. Their use
+/// must follow the official [thread-safety guidelines][thread-safety]. Specifically, it is
+/// undefined behavior to pass an instance to Rust code without locking a mutex if there are
+/// references to it on other threads.
+///
+/// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html"#,
+    )?;
+
     Ok(())
 }
 

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -354,12 +354,6 @@ pub fn generate_methods(
                 rust_ret_type = "Variant".to_string();
             }
 
-            let self_param = if method.is_const {
-                "&self"
-            } else {
-                "&mut self"
-            };
-
             if !is_leaf {
                 writeln!(output, "    /// Inherited from {}.", class_doc_link(class))?;
             }
@@ -375,7 +369,7 @@ pub fn generate_methods(
                 writeln!(
                     output,
                     r#"    #[inline]
-    pub fn {rusty_name}({self_param}{params_decl}) -> {rust_ret_type} {{
+    pub fn {rusty_name}(&self{params_decl}) -> {rust_ret_type} {{
         unsafe {{ {namespace}{cname}_{name}(self.this{params_use}) }}
     }}
 "#,
@@ -386,13 +380,12 @@ pub fn generate_methods(
                     rust_ret_type = rust_ret_type,
                     params_decl = params_decl,
                     params_use = params_use,
-                    self_param = self_param,
                 )?;
             } else {
                 writeln!(
                     output,
                     r#"    #[inline]
-    pub unsafe fn {rusty_name}({self_param}{params_decl}) -> {rust_ret_type} {{
+    pub unsafe fn {rusty_name}(&self{params_decl}) -> {rust_ret_type} {{
         {namespace}{cname}_{name}(self.this{params_use})
     }}
 "#,
@@ -403,7 +396,6 @@ pub fn generate_methods(
                     rust_ret_type = rust_ret_type,
                     params_decl = params_decl,
                     params_use = params_use,
-                    self_param = self_param,
                 )?;
             }
         }

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -23,7 +23,7 @@ impl HUD {
 
     #[export]
     pub unsafe fn show_message(&self, owner: CanvasLayer, text: String) {
-        let mut message_label: Label = owner
+        let message_label: Label = owner
             .get_typed_node("message_label")
             .expect("Cannot cast to Label");
 
@@ -39,7 +39,7 @@ impl HUD {
     pub unsafe fn show_game_over(&self, owner: CanvasLayer) {
         self.show_message(owner, "Game Over".into());
 
-        let mut message_label: Label = owner
+        let message_label: Label = owner
             .get_typed_node("message_label")
             .expect("Cannot cast to Label");
 
@@ -61,7 +61,7 @@ impl HUD {
     }
 
     #[export]
-    unsafe fn on_start_button_pressed(&self, mut owner: CanvasLayer) {
+    unsafe fn on_start_button_pressed(&self, owner: CanvasLayer) {
         owner
             .get_typed_node::<Button, _>("start_button")
             .expect("Cannot cast to Button")

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -36,11 +36,11 @@ impl Main {
 
     #[export]
     unsafe fn game_over(&self, owner: Node) {
-        let mut score_timer: Timer = owner
+        let score_timer: Timer = owner
             .get_typed_node("score_timer")
             .expect("Unable to cast to Timer");
 
-        let mut mob_timer: Timer = owner
+        let mob_timer: Timer = owner
             .get_typed_node("mob_timer")
             .expect("Unable to cast to Timer");
 
@@ -52,7 +52,7 @@ impl Main {
             .expect("Unable to cast to CanvasLayer");
 
         Instance::<hud::HUD>::try_from_unsafe_base(hud_node)
-            .and_then(|hud| hud.map_aliased(|x, o| x.show_game_over(o)).ok())
+            .and_then(|hud| hud.map(|x, o| x.show_game_over(o)).ok())
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
@@ -64,7 +64,7 @@ impl Main {
         let player: Area2D = owner
             .get_typed_node("player")
             .expect("Unable to cast to Area2D");
-        let mut start_timer: Timer = owner
+        let start_timer: Timer = owner
             .get_typed_node("start_timer")
             .expect("Unable to cast to Timer");
 
@@ -73,7 +73,7 @@ impl Main {
         Instance::<player::Player>::try_from_unsafe_base(player)
             .and_then(|player| {
                 player
-                    .map_aliased(|x, o| x.start(o, start_position.position()))
+                    .map(|x, o| x.start(o, start_position.position()))
                     .ok()
             })
             .unwrap_or_else(|| godot_print!("Unable to get player"));
@@ -86,7 +86,7 @@ impl Main {
 
         Instance::<hud::HUD>::try_from_unsafe_base(hud_node)
             .and_then(|hud| {
-                hud.map_aliased(|x, o| {
+                hud.map(|x, o| {
                     x.update_score(o, self.score);
                     x.show_message(o, "Get Ready".into());
                 })
@@ -116,17 +116,17 @@ impl Main {
             .expect("Unable to cast to CanvasLayer");
 
         Instance::<hud::HUD>::try_from_unsafe_base(hud_node)
-            .and_then(|hud| hud.map_aliased(|x, o| x.update_score(o, self.score)).ok())
+            .and_then(|hud| hud.map(|x, o| x.update_score(o, self.score)).ok())
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
     #[export]
-    unsafe fn on_mob_timer_timeout(&self, mut owner: Node) {
-        let mut mob_spawn_location: PathFollow2D = owner
+    unsafe fn on_mob_timer_timeout(&self, owner: Node) {
+        let mob_spawn_location: PathFollow2D = owner
             .get_typed_node("mob_path/mob_spawn_locations")
             .expect("Unable to cast to PathFollow2D");
 
-        let mut mob_scene: RigidBody2D = instance_scene(&self.mob).unwrap();
+        let mob_scene: RigidBody2D = instance_scene(&self.mob).unwrap();
 
         let mut rng = rand::thread_rng();
         let offset = rng.gen_range(std::u32::MIN, std::u32::MAX);
@@ -144,7 +144,7 @@ impl Main {
 
         let mob = Instance::<mob::Mob>::try_from_unsafe_base(mob_scene).unwrap();
 
-        mob.map_aliased(|x, mob_owner| {
+        mob.map(|x, mob_owner| {
             mob_scene
                 .set_linear_velocity(Vector2::new(rng.gen_range(x.min_speed, x.max_speed), 0.0));
 
@@ -157,7 +157,7 @@ impl Main {
 
             let hud = Instance::<hud::HUD>::try_from_unsafe_base(hud_node).unwrap();
 
-            hud.map_aliased(|_, mut o| {
+            hud.map(|_, o| {
                 o.connect(
                     "start_game".into(),
                     Some(mob_owner.to_object()),

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -44,7 +44,7 @@ impl Mob {
     #[export]
     unsafe fn _ready(&mut self, owner: RigidBody2D) {
         let mut rng = rand::thread_rng();
-        let mut animated_sprite: AnimatedSprite = owner
+        let animated_sprite: AnimatedSprite = owner
             .get_typed_node("animated_sprite")
             .expect("Unable to cast to AnimatedSprite");
 
@@ -52,12 +52,12 @@ impl Mob {
     }
 
     #[export]
-    unsafe fn on_visibility_screen_exited(&self, mut owner: RigidBody2D) {
+    unsafe fn on_visibility_screen_exited(&self, owner: RigidBody2D) {
         owner.queue_free()
     }
 
     #[export]
-    unsafe fn on_start_game(&self, mut owner: RigidBody2D) {
+    unsafe fn on_start_game(&self, owner: RigidBody2D) {
         owner.queue_free();
     }
 }

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -31,14 +31,14 @@ impl Player {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, mut owner: Area2D) {
+    unsafe fn _ready(&mut self, owner: Area2D) {
         self.screen_size = owner.get_viewport().unwrap().size();
         owner.hide();
     }
 
     #[export]
-    unsafe fn _process(&mut self, mut owner: Area2D, delta: f32) {
-        let mut animated_sprite: AnimatedSprite = owner
+    unsafe fn _process(&mut self, owner: Area2D, delta: f32) {
+        let animated_sprite: AnimatedSprite = owner
             .get_typed_node("animated_sprite")
             .expect("Unable to cast to AnimatedSprite");
 
@@ -86,11 +86,11 @@ impl Player {
     }
 
     #[export]
-    unsafe fn on_player_body_entered(&self, mut owner: Area2D, _body: PhysicsBody2D) {
+    unsafe fn on_player_body_entered(&self, owner: Area2D, _body: PhysicsBody2D) {
         owner.hide();
         owner.emit_signal("hit".into(), &[]);
 
-        let mut collision_shape: CollisionShape2D = owner
+        let collision_shape: CollisionShape2D = owner
             .get_typed_node("collision_shape_2d")
             .expect("Unable to cast to CollisionShape2D");
 
@@ -98,11 +98,11 @@ impl Player {
     }
 
     #[export]
-    pub unsafe fn start(&self, mut owner: Area2D, pos: Vector2) {
+    pub unsafe fn start(&self, owner: Area2D, pos: Vector2) {
         owner.set_global_position(pos);
         owner.show();
 
-        let mut collision_shape: CollisionShape2D = owner
+        let collision_shape: CollisionShape2D = owner
             .get_typed_node("collision_shape_2d")
             .expect("Unable to cast to CollisionShape2D");
 

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -52,7 +52,7 @@ impl SceneCreate {
     }
 
     #[export]
-    unsafe fn spawn_one(&mut self, mut owner: Spatial, message: GodotString) {
+    unsafe fn spawn_one(&mut self, owner: Spatial, message: GodotString) {
         godot_print!("Called spawn_one({})", message.to_string());
 
         let template = if let Some(template) = &self.template {
@@ -65,7 +65,7 @@ impl SceneCreate {
         // Create the scene here. Note that we are hardcoding that the parent must at least be a
         //   child of Spatial in the template argument here...
         match instance_scene::<Spatial>(template) {
-            Ok(mut spatial) => {
+            Ok(spatial) => {
                 // Here is how you rename the child...
                 let key_str = format!("child_{}", self.children_spawned);
                 spatial.set_name(GodotString::from_str(&key_str));
@@ -83,11 +83,11 @@ impl SceneCreate {
         }
 
         let num_children = owner.get_child_count();
-        update_panel(&mut owner, num_children);
+        update_panel(owner, num_children);
     }
 
     #[export]
-    unsafe fn remove_one(&mut self, mut owner: Spatial, str: GodotString) {
+    unsafe fn remove_one(&mut self, owner: Spatial, str: GodotString) {
         godot_print!("Called remove_one({})", str.to_string());
         let num_children = owner.get_child_count();
         if num_children <= 0 {
@@ -98,12 +98,12 @@ impl SceneCreate {
         assert_eq!(self.children_spawned as i64, num_children);
 
         let last_child = owner.get_child(num_children - 1);
-        if let Some(mut node) = last_child {
+        if let Some(node) = last_child {
             node.queue_free();
             self.children_spawned -= 1;
         }
 
-        update_panel(&mut owner, num_children - 1);
+        update_panel(owner, num_children - 1);
     }
 }
 
@@ -140,7 +140,7 @@ where
     }
 }
 
-unsafe fn update_panel(owner: &mut Spatial, num_children: i64) {
+unsafe fn update_panel(owner: Spatial, num_children: i64) {
     // Here is how we call into the panel. First we get its node (we might have saved it
     //   from earlier)
     let panel_node_opt = owner

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -38,7 +38,7 @@ impl SignalEmitter {
     }
 
     #[export]
-    fn _process(&mut self, mut owner: Node, delta: f64) {
+    fn _process(&mut self, owner: Node, delta: f64) {
         if self.timer < 1.0 {
             self.timer += delta;
             return;
@@ -97,7 +97,7 @@ impl SignalSubscriber {
     }
 
     #[export]
-    fn notify(&mut self, mut owner: Label) {
+    fn notify(&mut self, owner: Label) {
         self.times_received += 1;
         let msg = format!("Received signal \"tick\" {} times", self.times_received);
 
@@ -107,7 +107,7 @@ impl SignalSubscriber {
     }
 
     #[export]
-    fn notify_with_data(&mut self, mut owner: Label, data: Variant) {
+    fn notify_with_data(&mut self, owner: Label, data: Variant) {
         let msg = format!(
             "Received signal \"tick_with_data\" with data {}",
             data.try_to_u64().unwrap()

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -48,7 +48,7 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, mut owner: MeshInstance) {
+    unsafe fn _ready(&mut self, owner: MeshInstance) {
         owner.set_physics_process(true);
         self.start = owner.translation();
         godot_warn!("Start: {:?}", self.start);
@@ -59,7 +59,7 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _physics_process(&mut self, mut owner: MeshInstance, delta: f64) {
+    unsafe fn _physics_process(&mut self, owner: MeshInstance, delta: f64) {
         use gdnative::{api::SpatialMaterial, Color, Vector3};
 
         self.time += delta as f32;
@@ -69,7 +69,7 @@ impl RustTest {
         owner.set_translation(self.start + offset);
 
         if let Some(mat) = owner.get_surface_material(0) {
-            let mut mat = mat.cast::<SpatialMaterial>().expect("Incorrect material");
+            let mat = mat.cast::<SpatialMaterial>().expect("Incorrect material");
             mat.set_albedo(Color::rgba(self.time.cos().abs(), 0.0, 0.0, 1.0));
         }
     }

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -221,42 +221,6 @@ impl<T: NativeClass> Instance<T> {
     #[inline]
     pub fn map<F, U>(&self, op: F) -> Result<U, <T::UserData as Map>::Err>
     where
-        T::Base: RefCounted,
-        T::UserData: Map,
-        F: FnOnce(&T, T::Base) -> U,
-    {
-        self.script.map(|script| op(script, self.owner.new_ref()))
-    }
-
-    /// Calls a function with a NativeClass instance and its owner, and returns its return
-    /// value. Can be used on reference counted types for multiple times.
-    #[inline]
-    pub fn map_mut<F, U>(&self, op: F) -> Result<U, <T::UserData as MapMut>::Err>
-    where
-        T::Base: RefCounted,
-        T::UserData: MapMut,
-        F: FnOnce(&mut T, T::Base) -> U,
-    {
-        self.script
-            .map_mut(|script| op(script, self.owner.new_ref()))
-    }
-
-    /// Calls a function with a NativeClass instance and its owner, and returns its return
-    /// value. Can be used for multiple times via aliasing:
-    ///
-    /// ```ignore
-    /// unsafe {
-    ///     instance.map_aliased(/* ... */);
-    ///     // instance.owner may be invalid now, but you can still:
-    ///     instance.map_aliased(/* ... */);
-    ///     instance.map_aliased(/* ... */); // ...for multiple times
-    /// }
-    /// ```
-    ///
-    /// For reference-counted types behaves like the safe `map`, which should be preferred.
-    #[inline]
-    pub unsafe fn map_aliased<F, U>(&self, op: F) -> Result<U, <T::UserData as Map>::Err>
-    where
         T::UserData: Map,
         F: FnOnce(&T, T::Base) -> U,
     {
@@ -264,20 +228,9 @@ impl<T: NativeClass> Instance<T> {
     }
 
     /// Calls a function with a NativeClass instance and its owner, and returns its return
-    /// value. Can be used for multiple times via aliasing:
-    ///
-    /// ```ignore
-    /// unsafe {
-    ///     instance.map_mut_aliased(/* ... */);
-    ///     // instance.owner may be invalid now, but you can still:
-    ///     instance.map_mut_aliased(/* ... */);
-    ///     instance.map_mut_aliased(/* ... */); // ...for multiple times
-    /// }
-    /// ```
-    ///
-    /// For reference-counted types behaves like the safe `map_mut`, which should be preferred.
+    /// value. Can be used on reference counted types for multiple times.
     #[inline]
-    pub unsafe fn map_mut_aliased<F, U>(&self, op: F) -> Result<U, <T::UserData as MapMut>::Err>
+    pub fn map_mut<F, U>(&self, op: F) -> Result<U, <T::UserData as MapMut>::Err>
     where
         T::UserData: MapMut,
         F: FnOnce(&mut T, T::Base) -> U,

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -537,7 +537,7 @@ macro_rules! godot_wrap_method {
     ) => {
         godot_wrap_method_inner!(
             $type_name,
-            map_mut_aliased,
+            map_mut,
             fn $method_name(
                 $self,
                 $owner: $owner_ty
@@ -559,7 +559,7 @@ macro_rules! godot_wrap_method {
     ) => {
         godot_wrap_method_inner!(
             $type_name,
-            map_aliased,
+            map,
             fn $method_name(
                 $self,
                 $owner: $owner_ty

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -30,18 +30,12 @@ pub unsafe trait GodotObject: crate::private::godot_object::Sealed {
     /// to produce a `'static` wrapper given a reference. For reference-counted types, or classes
     /// that extend `Reference`, this increments the reference count. For manually-managed types,
     /// including all classes that inherit `Node`, this creates an alias.
-    ///
-    /// # Remarks
-    ///
-    /// Although manually-managed types are already `unsafe` to use, like raw pointers, this is
-    /// `unsafe` because some methods expect `&mut self` receivers. In `0.9.0`, all methods will
-    /// take shared references instead, making this safe to call.
     #[inline]
-    unsafe fn claim(&self) -> Self
+    fn claim(&self) -> Self
     where
         Self: Sized,
     {
-        Self::from_sys(self.to_sys())
+        unsafe { Self::from_sys(self.to_sys()) }
     }
 }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -171,7 +171,7 @@ fn test_rust_class_construction() -> bool {
 
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
 
-        let mut base = foo.into_base();
+        let base = foo.into_base();
         assert_eq!(
             Some(42),
             unsafe { base.call("answer".into(), &[]) }.try_to_i64()

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -47,7 +47,7 @@ impl Bar {
     }
 
     #[export]
-    fn set_script_is_not_ub(&mut self, mut owner: Node) -> bool {
+    fn set_script_is_not_ub(&mut self, owner: Node) -> bool {
         unsafe {
             owner.set_script(None);
         }
@@ -72,9 +72,9 @@ fn test_owner_free_ub() -> bool {
 
         let bar = Instance::<Bar>::new();
         unsafe {
-            bar.map_mut_aliased(|bar, _| bar.set_drop_counter(drop_counter.clone()))
+            bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
-            let mut base = bar.into_base();
+            let base = bar.into_base();
             assert_eq!(
                 Some(true),
                 base.call("set_script_is_not_ub".into(), &[]).try_to_bool()
@@ -84,7 +84,7 @@ fn test_owner_free_ub() -> bool {
 
         let bar = Instance::<Bar>::new();
         unsafe {
-            bar.map_mut_aliased(|bar, _| bar.set_drop_counter(drop_counter.clone()))
+            bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
             assert_eq!(
                 Some(true),

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -83,7 +83,7 @@ fn test_register_property() -> bool {
     let ok = std::panic::catch_unwind(|| {
         let obj = Instance::<RegisterProperty>::new();
 
-        let mut base = obj.into_base();
+        let base = obj.into_base();
 
         unsafe {
             assert_eq!(Some(42), base.call("get_value".into(), &[]).try_to_i64());

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -61,7 +61,7 @@ fn test_return_leak() -> bool {
         let drop_counter = Arc::new(AtomicUsize::new(0));
 
         // The object used for its ptrcall getter
-        let mut animation_tree = AnimationTree::new();
+        let animation_tree = AnimationTree::new();
 
         // Create an instance of the probe, and drop the reference after setting the property
         // to it. After this block, the only reference should be the one in `animation_tree`.


### PR DESCRIPTION
- Made `GodotObject::claim` safe.
- Removed unsafe variants of `Instance::map` and `map_mut`.
  `try_from_unsafe_base` is still unsafe because it uses the pointer.

Close #301

This should be followed up by #390.