### PR TITLE
move generated bindings under a separate `api` module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In the `src/lib.rs` file should have the following contents:
 
 ```rust
 use gdnative::*;
+use gdnative::api::Node;
 
 /// The HelloWorld "class"
 #[derive(NativeClass)]

--- a/examples/dodge_the_creeps/src/extensions.rs
+++ b/examples/dodge_the_creeps/src/extensions.rs
@@ -1,3 +1,4 @@
+use gdnative::api::Node;
 use gdnative::*;
 
 pub trait NodeExt {

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -1,4 +1,5 @@
 use crate::extensions::NodeExt as _;
+use gdnative::api::*;
 use gdnative::*;
 
 #[derive(NativeClass)]

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -2,6 +2,7 @@ use crate::extensions::NodeExt as _;
 use crate::hud;
 use crate::mob;
 use crate::player;
+use gdnative::api::*;
 use gdnative::*;
 use rand::*;
 use std::f64::consts::PI;

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -1,4 +1,5 @@
 use crate::extensions::NodeExt;
+use gdnative::api::*;
 use gdnative::*;
 use rand::seq::SliceRandom;
 

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -1,4 +1,5 @@
 use crate::extensions::NodeExt as _;
+use gdnative::api::*;
 use gdnative::*;
 
 /// The player "class"

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -2,17 +2,17 @@
 extern crate gdnative;
 
 #[derive(gdnative::NativeClass)]
-#[inherit(gdnative::Node)]
+#[inherit(gdnative::api::Node)]
 struct HelloWorld;
 
 #[gdnative::methods]
 impl HelloWorld {
-    fn _init(_owner: gdnative::Node) -> Self {
+    fn _init(_owner: gdnative::api::Node) -> Self {
         HelloWorld
     }
 
     #[export]
-    fn _ready(&self, _owner: gdnative::Node) {
+    fn _ready(&self, _owner: gdnative::api::Node) {
         godot_print!("hello, world.")
     }
 }

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -3,7 +3,8 @@ extern crate gdnative;
 extern crate euclid;
 
 use euclid::vec3;
-use gdnative::{GodotString, PackedScene, ResourceLoader, Spatial, Variant};
+use gdnative::api::{PackedScene, ResourceLoader, Spatial};
+use gdnative::{GodotString, Variant};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ManageErrs {
@@ -12,7 +13,7 @@ pub enum ManageErrs {
 }
 
 #[derive(gdnative::NativeClass)]
-#[inherit(gdnative::Spatial)]
+#[inherit(Spatial)]
 struct SceneCreate {
     // Store the loaded scene for a very slight performance boost but mostly to show you how.
     template: Option<PackedScene>,
@@ -34,7 +35,7 @@ unsafe impl Send for SceneCreate {}
 
 #[gdnative::methods]
 impl SceneCreate {
-    fn _init(_owner: gdnative::Spatial) -> Self {
+    fn _init(_owner: Spatial) -> Self {
         SceneCreate {
             template: None, // Have not loaded this template yet.
             children_spawned: 0,
@@ -42,7 +43,7 @@ impl SceneCreate {
     }
 
     #[export]
-    fn _ready(&mut self, _owner: gdnative::Spatial) {
+    fn _ready(&mut self, _owner: Spatial) {
         self.template = load_scene("res://Child_scene.tscn");
         match &self.template {
             Some(_scene) => godot_print!("Loaded child scene successfully!"),
@@ -51,7 +52,7 @@ impl SceneCreate {
     }
 
     #[export]
-    unsafe fn spawn_one(&mut self, mut owner: gdnative::Spatial, message: GodotString) {
+    unsafe fn spawn_one(&mut self, mut owner: Spatial, message: GodotString) {
         godot_print!("Called spawn_one({})", message.to_string());
 
         let template = if let Some(template) = &self.template {
@@ -86,7 +87,7 @@ impl SceneCreate {
     }
 
     #[export]
-    unsafe fn remove_one(&mut self, mut owner: gdnative::Spatial, str: GodotString) {
+    unsafe fn remove_one(&mut self, mut owner: Spatial, str: GodotString) {
         godot_print!("Called remove_one({})", str.to_string());
         let num_children = owner.get_child_count();
         if num_children <= 0 {
@@ -139,7 +140,7 @@ where
     }
 }
 
-unsafe fn update_panel(owner: &mut gdnative::Spatial, num_children: i64) {
+unsafe fn update_panel(owner: &mut Spatial, num_children: i64) {
     // Here is how we call into the panel. First we get its node (we might have saved it
     //   from earlier)
     let panel_node_opt = owner

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -1,3 +1,4 @@
+use gdnative::api::{Label, Node};
 use gdnative::*;
 
 #[derive(NativeClass)]
@@ -29,7 +30,7 @@ impl SignalEmitter {
         });
     }
 
-    fn _init(_owner: gdnative::Node) -> Self {
+    fn _init(_owner: Node) -> Self {
         SignalEmitter {
             timer: 0.0,
             data: 100,
@@ -65,7 +66,7 @@ struct SignalSubscriber {
 
 #[methods]
 impl SignalSubscriber {
-    fn _init(_owner: gdnative::Label) -> Self {
+    fn _init(_owner: Label) -> Self {
         SignalSubscriber { times_received: 0 }
     }
 

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate gdnative;
 
+use gdnative::api::MeshInstance;
 use gdnative::init::property::{EnumHint, IntHint, StringHint};
 
 #[derive(gdnative::NativeClass)]
-#[inherit(gdnative::MeshInstance)]
+#[inherit(MeshInstance)]
 #[register_with(my_register_function)]
 struct RustTest {
     start: gdnative::Vector3,
@@ -38,7 +39,7 @@ fn my_register_function(builder: &gdnative::init::ClassBuilder<RustTest>) {
 
 #[gdnative::methods]
 impl RustTest {
-    fn _init(_owner: gdnative::MeshInstance) -> Self {
+    fn _init(_owner: MeshInstance) -> Self {
         RustTest {
             start: gdnative::Vector3::new(0.0, 0.0, 0.0),
             time: 0.0,
@@ -47,7 +48,7 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, mut owner: gdnative::MeshInstance) {
+    unsafe fn _ready(&mut self, mut owner: MeshInstance) {
         owner.set_physics_process(true);
         self.start = owner.translation();
         godot_warn!("Start: {:?}", self.start);
@@ -58,8 +59,8 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _physics_process(&mut self, mut owner: gdnative::MeshInstance, delta: f64) {
-        use gdnative::{Color, SpatialMaterial, Vector3};
+    unsafe fn _physics_process(&mut self, mut owner: MeshInstance, delta: f64) {
+        use gdnative::{api::SpatialMaterial, Color, Vector3};
 
         self.time += delta as f32;
         owner.rotate_y(self.rotate_speed * delta);

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -39,4 +39,5 @@ pub use gdnative_derive::*;
 
 #[doc(inline)]
 #[cfg(feature = "bindings")]
-pub use gdnative_bindings::*;
+/// Bindings for the Godot Class API.
+pub use gdnative_bindings as api;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::blacklisted_name)]
 
+use gdnative::api::*;
 use gdnative::*;
 
 use gdnative::private::get_api;
@@ -89,7 +90,7 @@ fn test_underscore_method_binding() -> bool {
     println!(" -- test_underscore_method_binding");
 
     let ok = std::panic::catch_unwind(|| {
-        let table = gdnative::NativeScriptMethodTable::get(get_api());
+        let table = gdnative::api::NativeScriptMethodTable::get(get_api());
         assert_ne!(0, table._new as usize);
     })
     .is_ok();

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -1,3 +1,4 @@
+use gdnative::api::*;
 use gdnative::*;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -1,3 +1,4 @@
+use gdnative::api::*;
 use gdnative::*;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;


### PR DESCRIPTION
closes #304

This change makes it so that generated bindings for Godot types
no longer fill in the `gdnative` namespace by default.