### PR TITLE
[357]: making internal `fn`s and `struct`s private.

### DIFF
--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -128,7 +128,7 @@ fn generate_class_bindings(
             &mut method_set,
             &class.name,
             class.is_pointer_safe(),
-            true,
+            false,
         )?;
 
         generate_upcast(
@@ -164,8 +164,8 @@ fn generate_class_bindings(
         }
     }
 
-    // methods and method table
-    {
+    // methods and method table for classes with functions
+    if class.instanciable || !class.methods.is_empty() {
         let has_underscore = api.api_underscore.contains(&class.name);
         generate_method_table(output_method_table, class, has_underscore)?;
 

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -59,7 +59,7 @@ pub trait QueueFree: GodotObject {
 pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;
     let api = crate::private::get_api();
-    let addref_method = ReferenceMethodTable::unchecked_get().reference;
+    let addref_method = ReferenceMethodTable::get(api).reference;
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut ok = false;
     let ok_ptr = &mut ok as *mut bool;
@@ -80,11 +80,12 @@ pub unsafe fn add_ref(obj: *mut sys::godot_object) {
 #[inline]
 pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
     use crate::ReferenceMethodTable;
-    let unref_method = ReferenceMethodTable::unchecked_get().unreference;
+    let api = crate::private::get_api();
+    let unref_method = ReferenceMethodTable::get(api).unreference;
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut last_reference = false;
     let ret_ptr = &mut last_reference as *mut bool;
-    (crate::private::get_api().godot_method_bind_ptrcall)(
+    (api.godot_method_bind_ptrcall)(
         unref_method,
         obj,
         argument_buffer.as_mut_ptr() as *mut _,
@@ -98,11 +99,12 @@ pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
 #[inline]
 pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;
-    let init_method = ReferenceMethodTable::unchecked_get().init_ref;
+    let api = crate::private::get_api();
+    let init_method = ReferenceMethodTable::get(api).init_ref;
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut ok = false;
     let ret_ptr = &mut ok as *mut bool;
-    (crate::private::get_api().godot_method_bind_ptrcall)(
+    (api.godot_method_bind_ptrcall)(
         init_method,
         obj,
         argument_buffer.as_mut_ptr() as *mut _,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -3,8 +3,6 @@
 use gdnative::api::*;
 use gdnative::*;
 
-use gdnative::private::get_api;
-
 mod test_derive;
 mod test_free_ub;
 mod test_register;
@@ -90,8 +88,9 @@ fn test_underscore_method_binding() -> bool {
     println!(" -- test_underscore_method_binding");
 
     let ok = std::panic::catch_unwind(|| {
-        let table = gdnative::api::NativeScriptMethodTable::get(get_api());
-        assert_ne!(0, table._new as usize);
+        let script = gdnative::api::NativeScript::new();
+        let result = script._new(&[]);
+        assert_eq!(Variant::new(), result);
     })
     .is_ok();
 


### PR DESCRIPTION
Making the internal function private had a cascading effect:
* MethodTables are now private
* MethodTables that are not instanciable and without methods are no longer created
* `MethodTables::unchecked_get()` was removed, it was replaced by `get()`.
** Was only used in `object::init_ref_count/add_ref/unref()`
