### PR TITLE
Dictionary and VariantArray now take &self and use typestate

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -20,7 +20,7 @@ impl Api {
 
     pub fn find_class<'a, 'b>(&'a self, name: &'b str) -> Option<&'a GodotClass> {
         for class in &self.classes {
-            if &class.name == name {
+            if class.name == name {
                 return Some(class);
             }
         }
@@ -37,7 +37,7 @@ impl Api {
             return self.class_inherits(parent, base_class_name);
         }
 
-        return false;
+        false
     }
 
     fn strip_leading_underscores(&mut self) {
@@ -57,6 +57,12 @@ impl Api {
                 }
             }
         }
+    }
+}
+
+impl Default for Api {
+    fn default() -> Self {
+        Api::new()
     }
 }
 
@@ -85,7 +91,7 @@ impl GodotClass {
     }
 
     pub fn is_getter(&self, name: &str) -> bool {
-        self.properties.iter().find(|p| p.getter == name).is_some()
+        self.properties.iter().any(|p| p.getter == name)
     }
 }
 
@@ -250,75 +256,75 @@ impl Ty {
 
     pub fn to_rust(&self) -> Option<String> {
         match self {
-            &Ty::Void => Some(String::from("()")),
-            &Ty::String => Some(String::from("GodotString")),
-            &Ty::F64 => Some(String::from("f64")),
-            &Ty::I64 => Some(String::from("i64")),
-            &Ty::Bool => Some(String::from("bool")),
-            &Ty::Vector2 => Some(String::from("Vector2")),
-            &Ty::Vector3 => Some(String::from("Vector3")),
-            &Ty::Quat => Some(String::from("Quat")),
-            &Ty::Transform => Some(String::from("Transform")),
-            &Ty::Transform2D => Some(String::from("Transform2D")),
-            &Ty::Rect2 => Some(String::from("Rect2")),
-            &Ty::Plane => Some(String::from("Plane")),
-            &Ty::Basis => Some(String::from("Basis")),
-            &Ty::Color => Some(String::from("Color")),
-            &Ty::NodePath => Some(String::from("NodePath")),
-            &Ty::Variant => Some(String::from("Variant")),
-            &Ty::Aabb => Some(String::from("Aabb")),
-            &Ty::Rid => Some(String::from("Rid")),
-            &Ty::VariantArray => Some(String::from("VariantArray")),
-            &Ty::Dictionary => Some(String::from("Dictionary")),
-            &Ty::ByteArray => Some(String::from("ByteArray")),
-            &Ty::StringArray => Some(String::from("StringArray")),
-            &Ty::Vector2Array => Some(String::from("Vector2Array")),
-            &Ty::Vector3Array => Some(String::from("Vector3Array")),
-            &Ty::ColorArray => Some(String::from("ColorArray")),
-            &Ty::Int32Array => Some(String::from("Int32Array")),
-            &Ty::Float32Array => Some(String::from("Float32Array")),
-            &Ty::Result => Some(String::from("GodotResult")),
-            &Ty::VariantType => Some(String::from("VariantType")),
-            &Ty::VariantOperator => Some(String::from("VariantOperator")),
-            &Ty::Enum(ref name) => Some(String::from(name.clone())),
-            &Ty::Object(ref name) => Some(format!("Option<{}>", name)),
+            Ty::Void => Some(String::from("()")),
+            Ty::String => Some(String::from("GodotString")),
+            Ty::F64 => Some(String::from("f64")),
+            Ty::I64 => Some(String::from("i64")),
+            Ty::Bool => Some(String::from("bool")),
+            Ty::Vector2 => Some(String::from("Vector2")),
+            Ty::Vector3 => Some(String::from("Vector3")),
+            Ty::Quat => Some(String::from("Quat")),
+            Ty::Transform => Some(String::from("Transform")),
+            Ty::Transform2D => Some(String::from("Transform2D")),
+            Ty::Rect2 => Some(String::from("Rect2")),
+            Ty::Plane => Some(String::from("Plane")),
+            Ty::Basis => Some(String::from("Basis")),
+            Ty::Color => Some(String::from("Color")),
+            Ty::NodePath => Some(String::from("NodePath")),
+            Ty::Variant => Some(String::from("Variant")),
+            Ty::Aabb => Some(String::from("Aabb")),
+            Ty::Rid => Some(String::from("Rid")),
+            Ty::VariantArray => Some(String::from("VariantArray")),
+            Ty::Dictionary => Some(String::from("Dictionary")),
+            Ty::ByteArray => Some(String::from("ByteArray")),
+            Ty::StringArray => Some(String::from("StringArray")),
+            Ty::Vector2Array => Some(String::from("Vector2Array")),
+            Ty::Vector3Array => Some(String::from("Vector3Array")),
+            Ty::ColorArray => Some(String::from("ColorArray")),
+            Ty::Int32Array => Some(String::from("Int32Array")),
+            Ty::Float32Array => Some(String::from("Float32Array")),
+            Ty::Result => Some(String::from("GodotResult")),
+            Ty::VariantType => Some(String::from("VariantType")),
+            Ty::VariantOperator => Some(String::from("VariantOperator")),
+            Ty::Enum(ref name) => Some(name.clone()),
+            Ty::Object(ref name) => Some(format!("Option<{}>", name)),
         }
     }
 
     pub fn to_sys(&self) -> Option<String> {
         match self {
-            &Ty::Void => None,
-            &Ty::String => Some(String::from("sys::godot_string")),
-            &Ty::F64 => Some(String::from("sys::godot_real")),
-            &Ty::I64 => Some(String::from("sys::godot_int")),
-            &Ty::Bool => Some(String::from("sys::godot_bool")),
-            &Ty::Vector2 => Some(String::from("sys::godot_vector2")),
-            &Ty::Vector3 => Some(String::from("sys::godot_vector3")),
-            &Ty::Quat => Some(String::from("sys::godot_quat")),
-            &Ty::Transform => Some(String::from("sys::godot_transform")),
-            &Ty::Transform2D => Some(String::from("sys::godot_transform2d")),
-            &Ty::Rect2 => Some(String::from("sys::godot_rect2")),
-            &Ty::Plane => Some(String::from("sys::godot_plane")),
-            &Ty::Basis => Some(String::from("sys::godot_basis")),
-            &Ty::Color => Some(String::from("sys::godot_color")),
-            &Ty::NodePath => Some(String::from("sys::godot_node_path")),
-            &Ty::Variant => Some(String::from("sys::godot_variant")),
-            &Ty::Aabb => Some(String::from("sys::godot_aabb")),
-            &Ty::Rid => Some(String::from("sys::godot_rid")),
-            &Ty::VariantArray => Some(String::from("sys::godot_array")),
-            &Ty::Dictionary => Some(String::from("sys::godot_dictionary")),
-            &Ty::ByteArray => Some(String::from("sys::godot_pool_byte_array")),
-            &Ty::StringArray => Some(String::from("sys::godot_pool_string_array")),
-            &Ty::Vector2Array => Some(String::from("sys::godot_pool_vector2_array")),
-            &Ty::Vector3Array => Some(String::from("sys::godot_pool_vector3_array")),
-            &Ty::ColorArray => Some(String::from("sys::godot_pool_color_array")),
-            &Ty::Int32Array => Some(String::from("sys::godot_pool_int_array")),
-            &Ty::Float32Array => Some(String::from("sys::godot_pool_real_array")),
-            &Ty::Result => Some(String::from("sys::godot_error")),
-            &Ty::VariantType => Some(String::from("sys::variant_type")),
-            &Ty::VariantOperator => Some(String::from("sys::godot_variant_operator")),
-            &Ty::Enum(_) => None, // TODO
-            &Ty::Object(_) => Some(String::from("sys::godot_object")),
+            Ty::Void => None,
+            Ty::String => Some(String::from("sys::godot_string")),
+            Ty::F64 => Some(String::from("sys::godot_real")),
+            Ty::I64 => Some(String::from("sys::godot_int")),
+            Ty::Bool => Some(String::from("sys::godot_bool")),
+            Ty::Vector2 => Some(String::from("sys::godot_vector2")),
+            Ty::Vector3 => Some(String::from("sys::godot_vector3")),
+            Ty::Quat => Some(String::from("sys::godot_quat")),
+            Ty::Transform => Some(String::from("sys::godot_transform")),
+            Ty::Transform2D => Some(String::from("sys::godot_transform2d")),
+            Ty::Rect2 => Some(String::from("sys::godot_rect2")),
+            Ty::Plane => Some(String::from("sys::godot_plane")),
+            Ty::Basis => Some(String::from("sys::godot_basis")),
+            Ty::Color => Some(String::from("sys::godot_color")),
+            Ty::NodePath => Some(String::from("sys::godot_node_path")),
+            Ty::Variant => Some(String::from("sys::godot_variant")),
+            Ty::Aabb => Some(String::from("sys::godot_aabb")),
+            Ty::Rid => Some(String::from("sys::godot_rid")),
+            Ty::VariantArray => Some(String::from("sys::godot_array")),
+            Ty::Dictionary => Some(String::from("sys::godot_dictionary")),
+            Ty::ByteArray => Some(String::from("sys::godot_pool_byte_array")),
+            Ty::StringArray => Some(String::from("sys::godot_pool_string_array")),
+            Ty::Vector2Array => Some(String::from("sys::godot_pool_vector2_array")),
+            Ty::Vector3Array => Some(String::from("sys::godot_pool_vector3_array")),
+            Ty::ColorArray => Some(String::from("sys::godot_pool_color_array")),
+            Ty::Int32Array => Some(String::from("sys::godot_pool_int_array")),
+            Ty::Float32Array => Some(String::from("sys::godot_pool_real_array")),
+            Ty::Result => Some(String::from("sys::godot_error")),
+            Ty::VariantType => Some(String::from("sys::variant_type")),
+            Ty::VariantOperator => Some(String::from("sys::godot_variant_operator")),
+            Ty::Enum(_) => None, // TODO
+            Ty::Object(_) => Some(String::from("sys::godot_object")),
         }
     }
 }

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -163,7 +163,7 @@ impl QueueFree for {name} {{
 }
 
 pub fn generate_singleton_getter(output: &mut impl Write, class: &GodotClass) -> GeneratorResult {
-    let s_name = if class.name.starts_with("_") {
+    let s_name = if class.name.starts_with('_') {
         &class.name[1..]
     } else {
         class.name.as_ref()

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -162,7 +162,7 @@ impl Main {
                     "start_game".into(),
                     Some(mob_owner.to_object()),
                     "on_start_game".into(),
-                    VariantArray::new(),
+                    VariantArray::new_shared(),
                     0,
                 )
                 .unwrap();

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -81,7 +81,7 @@ impl SignalSubscriber {
                 GodotString::from_str("tick"),
                 Some(*object),
                 GodotString::from_str("notify"),
-                VariantArray::new(),
+                VariantArray::new_shared(),
                 0,
             )
             .unwrap();
@@ -90,7 +90,7 @@ impl SignalSubscriber {
                 GodotString::from_str("tick_with_data"),
                 Some(*object),
                 GodotString::from_str("notify_with_data"),
-                VariantArray::new(),
+                VariantArray::new_shared(),
                 0,
             )
             .unwrap();

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -1,4 +1,5 @@
 use std::iter::{Extend, FromIterator};
+use std::marker::PhantomData;
 
 use crate::private::get_api;
 use crate::sys;
@@ -11,121 +12,164 @@ use crate::Variant;
 use crate::VariantArray;
 use std::fmt;
 
+use crate::thread_access::*;
+
 /// A reference-counted `Dictionary` of `Variant` key-value pairs.
 ///
 /// # Safety
 ///
-/// This is a reference-counted collection with "interior mutability" in Rust parlance. Its use
-/// must follow the official [thread-safety guidelines][thread-safety]. Specifically, it is
-/// undefined behavior to pass an instance to Rust code without locking a mutex if there are
-/// references to it on other threads.
+/// This is a reference-counted collection with "interior mutability" in Rust parlance.
+/// To enforce that the official [thread-safety guidelines][thread-safety] are
+/// followed this type uses the *typestate* pattern. The typestate `Access` tracks
+/// whether there is "unique" access (where pretty much all operations are safe)
+/// or whether the value might be "shared", in which case not all operations are
+/// safe.
 ///
 /// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
-pub struct Dictionary(pub(crate) sys::godot_dictionary);
+pub struct Dictionary<Access: ThreadAccess = Shared> {
+    sys: sys::godot_dictionary,
 
-impl Dictionary {
-    /// Creates an empty `Dictionary`.
-    #[inline]
-    pub fn new() -> Self {
-        Dictionary::default()
-    }
+    /// Marker preventing the compiler from incorrectly deriving `Send` and `Sync`.
+    _marker: PhantomData<Access>,
+}
 
+/// Operations allowed on all Dictionaries at any point in time.
+impl<Access: ThreadAccess> Dictionary<Access> {
     /// Returns `true` if the `Dictionary` contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        unsafe { (get_api().godot_dictionary_empty)(&self.0) }
+        unsafe { (get_api().godot_dictionary_empty)(self.sys()) }
     }
 
     /// Returns the number of elements in the `Dictionary`.
     #[inline]
     pub fn len(&self) -> i32 {
-        unsafe { (get_api().godot_dictionary_size)(&self.0) }
-    }
-
-    /// Clears the `Dictionary`, removing all key-value pairs.
-    #[inline]
-    pub fn clear(&mut self) {
-        unsafe { (get_api().godot_dictionary_clear)(&mut self.0) }
+        unsafe { (get_api().godot_dictionary_size)(self.sys()) }
     }
 
     /// Returns true if the `Dictionary` contains the specified key.
     #[inline]
     pub fn contains(&self, key: &Variant) -> bool {
-        unsafe { (get_api().godot_dictionary_has)(&self.0, &key.0) }
+        unsafe { (get_api().godot_dictionary_has)(self.sys(), key.sys()) }
     }
 
     /// Returns true if the `Dictionary` has all of the keys in the given array.
     #[inline]
-    pub fn contains_all(&self, keys: &VariantArray) -> bool {
-        unsafe { (get_api().godot_dictionary_has_all)(&self.0, &keys.0) }
-    }
-
-    /// Erase a key-value pair in the `Dictionary` by the specified key.
-    #[inline]
-    pub fn erase(&mut self, key: &Variant) {
-        unsafe { (get_api().godot_dictionary_erase)(&mut self.0, &key.0) }
+    pub fn contains_all<ArrAccess: ThreadAccess>(&self, keys: &VariantArray<ArrAccess>) -> bool {
+        unsafe { (get_api().godot_dictionary_has_all)(self.sys(), keys.sys()) }
     }
 
     /// Returns a copy of the value corresponding to the key.
     #[inline]
     pub fn get(&self, key: &Variant) -> Variant {
-        unsafe { Variant((get_api().godot_dictionary_get)(&self.0, &key.0)) }
+        unsafe { Variant((get_api().godot_dictionary_get)(self.sys(), key.sys())) }
     }
 
-    /// Sets a value to the element corresponding to the key.
+    /// Update an existing element corresponding ot the key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the entry for `key` does not exist.
     #[inline]
-    pub fn set(&mut self, key: &Variant, val: &Variant) {
-        unsafe { (get_api().godot_dictionary_set)(&mut self.0, &key.0, &val.0) }
+    pub fn update(&self, key: &Variant, val: &Variant) {
+        assert!(self.contains(key), "Can only update entries that exist");
+        unsafe { (get_api().godot_dictionary_set)(self.sys_mut(), key.sys(), val.sys()) }
     }
 
     /// Returns a reference to the value corresponding to the key.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference.
+    ///
+    /// `Variant` is reference-counted and thus cheaply cloned. Consider using `get` instead.
     #[inline]
-    pub fn get_ref(&self, key: &Variant) -> &Variant {
-        unsafe {
-            Variant::cast_ref((get_api().godot_dictionary_operator_index_const)(
-                &self.0, &key.0,
-            ))
-        }
+    pub unsafe fn get_ref(&self, key: &Variant) -> &Variant {
+        Variant::cast_ref((get_api().godot_dictionary_operator_index_const)(
+            self.sys(),
+            key.sys(),
+        ))
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference. It is possible to create two mutable references to the same memory location
+    /// if the same `key` is provided, causing undefined behavior.
     #[inline]
-    pub fn get_mut_ref(&mut self, key: &Variant) -> &mut Variant {
-        unsafe {
-            Variant::cast_mut_ref((get_api().godot_dictionary_operator_index)(
-                &mut self.0,
-                &key.0,
-            ))
-        }
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn get_mut_ref(&self, key: &Variant) -> &mut Variant {
+        Variant::cast_mut_ref((get_api().godot_dictionary_operator_index)(
+            self.sys_mut(),
+            key.sys(),
+        ))
     }
 
     /// Returns a GodotString of the `Dictionary`.
     #[inline]
     pub fn to_json(&self) -> GodotString {
-        unsafe { GodotString((get_api().godot_dictionary_to_json)(&self.0)) }
+        unsafe { GodotString((get_api().godot_dictionary_to_json)(self.sys())) }
     }
 
     /// Returns an array of the keys in the `Dictionary`.
     #[inline]
-    pub fn keys(&self) -> VariantArray {
-        unsafe { VariantArray((get_api().godot_dictionary_keys)(&self.0)) }
+    pub fn keys(&self) -> VariantArray<Shared> {
+        unsafe { VariantArray::from_sys((get_api().godot_dictionary_keys)(self.sys())) }
     }
 
     /// Returns an array of the values in the `Dictionary`.
     #[inline]
     pub fn values(&self) -> VariantArray {
-        unsafe { VariantArray((get_api().godot_dictionary_values)(&self.0)) }
+        unsafe { VariantArray::from_sys((get_api().godot_dictionary_values)(self.sys())) }
     }
 
     #[inline]
     pub fn get_next(&self, key: &Variant) -> &Variant {
-        unsafe { Variant::cast_ref((get_api().godot_dictionary_next)(&self.0, &key.0)) }
+        unsafe { Variant::cast_ref((get_api().godot_dictionary_next)(self.sys(), key.sys())) }
     }
 
     /// Return a hashed i32 value representing the dictionary's contents.
     #[inline]
     pub fn hash(&self) -> i32 {
-        unsafe { (get_api().godot_dictionary_hash)(&self.0) }
+        unsafe { (get_api().godot_dictionary_hash)(self.sys()) }
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys(&self) -> *const sys::godot_dictionary {
+        &self.sys
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&self) -> *mut sys::godot_dictionary {
+        &self.sys as *const _ as *mut _
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_sys(sys: sys::godot_dictionary) -> Self {
+        Dictionary {
+            sys,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Operations allowed on Dictionaries that might be shared.
+impl Dictionary<Shared> {
+    /// Assume the dictionary is only used/referenced by a single thread.
+    ///
+    ///
+    #[inline]
+    pub unsafe fn assume_unique(self) -> Dictionary<Unique> {
+        Dictionary::<Unique> {
+            sys: self.sys,
+            _marker: PhantomData,
+        }
     }
 
     /// Returns an iterator through all key-value pairs in the `Dictionary`.
@@ -134,64 +178,169 @@ impl Dictionary {
     /// Modifying the same underlying collection while observing the safety assumptions will
     /// not violate memory safely, but may lead to surprising behavior in the iterator.
     #[inline]
-    pub fn iter(&self) -> Iter {
-        Iter::new(self)
+    pub fn iter(&self) -> IterShared {
+        IterShared::new(self)
     }
 
-    #[doc(hidden)]
+    /// Create a copy of the dictionary.
+    ///
+    /// This creates a new dictionary and is **not** a cheap reference count
+    /// increment.
     #[inline]
-    pub fn sys(&self) -> *const sys::godot_dictionary {
-        &self.0
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn from_sys(sys: sys::godot_dictionary) -> Self {
-        Dictionary(sys)
+    pub fn duplicate(&self) -> Dictionary<Unique> {
+        let d = Dictionary::new();
+        for (k, v) in self {
+            d.insert(&k, &v);
+        }
+        d
     }
 }
 
-impl RefCounted for Dictionary {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> Dictionary : godot_dictionary_new_copy;
+/// Operations allowed on non-shared Dictionaries.
+impl Dictionary<Unique> {
+    /// Creates an empty `Dictionary`.
+    #[inline]
+    pub fn new() -> Self {
+        unsafe {
+            let mut sys = sys::godot_dictionary::default();
+            (get_api().godot_dictionary_new)(&mut sys);
+            Self::from_sys(sys)
+        }
+    }
+
+    /// Put this dictionary under the "shared" access type.
+    #[inline]
+    pub fn into_shared(self) -> Dictionary<Shared> {
+        Dictionary::<Shared> {
+            sys: self.sys,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns an iterator through all key-value pairs in the `Dictionary`.
+    ///
+    /// `Dictionary` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
+    #[inline]
+    pub fn into_iter(self) -> IntoIterUnique {
+        IntoIterator::into_iter(self)
+    }
+
+    /// Returns an iterator through all key-value pairs in the `Dictionary`.
+    ///
+    /// `Dictionary` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
+    #[inline]
+    pub fn iter(&self) -> IterUnique {
+        IterUnique::new(self)
+    }
+
+    /// Create a copy of the dictionary.
+    ///
+    /// This creates a new dictionary and is **not** a cheap reference count
+    /// increment.
+    #[inline]
+    pub fn duplicate(&self) -> Dictionary<Unique> {
+        let d = Dictionary::new();
+        for (k, v) in self {
+            d.insert(&k, &v);
+        }
+        d
+    }
+
+    #[inline]
+    /// Inserts or updates the value of the element corresponding to the key.
+    pub fn insert(&self, key: &Variant, val: &Variant) {
+        unsafe { (get_api().godot_dictionary_set)(self.sys_mut(), key.sys(), val.sys()) }
+    }
+
+    /// Erase a key-value pair in the `Dictionary` by the specified key.
+    #[inline]
+    pub fn erase(&self, key: &Variant) {
+        unsafe { (get_api().godot_dictionary_erase)(self.sys_mut(), key.sys()) }
+    }
+
+    /// Clears the `Dictionary`, removing all key-value pairs.
+    #[inline]
+    pub fn clear(&self) {
+        unsafe { (get_api().godot_dictionary_clear)(self.sys_mut()) }
     }
 }
 
-impl_basic_traits!(
-    for Dictionary as godot_dictionary {
-        Drop => godot_dictionary_destroy;
-        Default => godot_dictionary_new;
-        Eq => godot_dictionary_operator_equal;
+impl<Access: ThreadAccess> Drop for Dictionary<Access> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { (get_api().godot_dictionary_destroy)(self.sys_mut()) }
     }
-);
+}
 
-impl fmt::Debug for Dictionary {
+impl Default for Dictionary<Unique> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Default for Dictionary<Shared> {
+    #[inline]
+    fn default() -> Self {
+        Dictionary::<Unique>::default().into_shared()
+    }
+}
+
+impl RefCounted for Dictionary<Shared> {
+    #[inline]
+    fn new_ref(&self) -> Self {
+        unsafe {
+            let mut result = Default::default();
+            (get_api().godot_dictionary_new_copy)(&mut result, self.sys());
+            Self::from_sys(result)
+        }
+    }
+}
+
+impl<A: ThreadAccess, B: ThreadAccess> PartialEq<Dictionary<A>> for Dictionary<B> {
+    fn eq(&self, other: &Dictionary<A>) -> bool {
+        unsafe { (get_api().godot_dictionary_operator_equal)(self.sys(), other.sys()) }
+    }
+}
+
+impl From<Dictionary<Unique>> for Dictionary<Shared> {
+    #[inline]
+    fn from(dict: Dictionary<Unique>) -> Self {
+        dict.into_shared()
+    }
+}
+
+impl<Access: ThreadAccess> fmt::Debug for Dictionary<Access> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.to_json().to_string().fmt(f)
     }
 }
 
-/// Iterator through all key-value pairs in a `Dictionary`.
+/// Iterator through all key-value pairs in a shared `Dictionary`.
 ///
-/// This struct is created by the `iter` method on `Dictionary`.
+/// This struct is created by the `iter` method on `Dictionary<Shared>`.
 #[derive(Debug)]
-pub struct Iter {
-    dic: Dictionary,
+pub struct IterShared {
+    dic: Dictionary<Shared>,
     last_key: Option<Variant>,
 }
 
-impl Iter {
-    fn new(dic: &Dictionary) -> Self {
-        Iter {
+impl IterShared {
+    /// Create an Iterator from a shared Dictionary.
+    fn new(dic: &Dictionary<Shared>) -> Self {
+        IterShared {
             dic: dic.new_ref(),
             last_key: None,
         }
     }
 }
 
-impl Iterator for Iter {
+impl Iterator for IterShared {
     type Item = (Variant, Variant);
 
     #[inline]
@@ -213,7 +362,114 @@ impl Iterator for Iter {
     }
 }
 
-impl<K, V> FromIterator<(K, V)> for Dictionary
+impl<'a> IntoIterator for &'a Dictionary<Shared> {
+    type Item = (Variant, Variant);
+    type IntoIter = IterShared;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator through all key-value pairs in a unique `Dictionary`.
+///
+/// This struct is created by the `into_iter` method on `Dictionary<Unique>`.
+/// This iterator consumes the unique dictionary.
+#[derive(Debug)]
+pub struct IntoIterUnique {
+    dic: Dictionary<Unique>,
+    last_key: Option<Variant>,
+}
+
+impl IntoIterUnique {
+    /// Create an Iterator by consuming a unique Dictionary.
+    fn new(dic: Dictionary<Unique>) -> Self {
+        IntoIterUnique {
+            dic,
+            last_key: None,
+        }
+    }
+}
+
+impl Iterator for IntoIterUnique {
+    type Item = (Variant, Variant);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let last_ptr = self
+            .last_key
+            .as_ref()
+            .map_or(std::ptr::null(), Variant::sys);
+        let next_ptr = unsafe { (get_api().godot_dictionary_next)(self.dic.sys(), last_ptr) };
+
+        if next_ptr.is_null() {
+            None
+        } else {
+            let key = Variant::cast_ref(next_ptr).clone();
+            let value = self.dic.get(&key);
+            self.last_key = Some(key.clone());
+            Some((key, value))
+        }
+    }
+}
+
+impl IntoIterator for Dictionary<Unique> {
+    type Item = (Variant, Variant);
+    type IntoIter = IntoIterUnique;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIterUnique::new(self)
+    }
+}
+
+/// Iterator through all key-value pairs in a unique `Dictionary`.
+///
+/// This struct is created by the `iter` method on `Dictionary<Unique>`.
+#[derive(Debug)]
+pub struct IterUnique<'a> {
+    dic: &'a Dictionary<Unique>,
+    last_key: Option<Variant>,
+}
+
+impl<'a> IterUnique<'a> {
+    /// Create an Iterator from a unique Dictionary.
+    fn new(dic: &'a Dictionary<Unique>) -> Self {
+        IterUnique {
+            dic,
+            last_key: None,
+        }
+    }
+}
+
+impl<'a> Iterator for IterUnique<'a> {
+    type Item = (Variant, Variant);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let last_ptr = self
+            .last_key
+            .as_ref()
+            .map_or(std::ptr::null(), Variant::sys);
+        let next_ptr = unsafe { (get_api().godot_dictionary_next)(self.dic.sys(), last_ptr) };
+
+        if next_ptr.is_null() {
+            None
+        } else {
+            let key = Variant::cast_ref(next_ptr).clone();
+            let value = self.dic.get(&key);
+            self.last_key = Some(key.clone());
+            Some((key, value))
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Dictionary<Unique> {
+    type Item = (Variant, Variant);
+    type IntoIter = IterUnique<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for Dictionary<Unique>
 where
     K: ToVariantEq,
     V: ToVariant,
@@ -226,7 +482,7 @@ where
     }
 }
 
-impl FromIterator<(Variant, Variant)> for Dictionary {
+impl FromIterator<(Variant, Variant)> for Dictionary<Unique> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = (Variant, Variant)>>(iter: I) -> Self {
         let mut dic = Dictionary::new();
@@ -235,7 +491,7 @@ impl FromIterator<(Variant, Variant)> for Dictionary {
     }
 }
 
-impl<K, V> Extend<(K, V)> for Dictionary
+impl<K, V> Extend<(K, V)> for Dictionary<Unique>
 where
     K: ToVariantEq,
     V: ToVariant,
@@ -243,16 +499,16 @@ where
     #[inline]
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (key, value) in iter {
-            self.set(&key.to_variant(), &value.to_variant());
+            self.insert(&key.to_variant(), &value.to_variant());
         }
     }
 }
 
-impl Extend<(Variant, Variant)> for Dictionary {
+impl Extend<(Variant, Variant)> for Dictionary<Unique> {
     #[inline]
     fn extend<I: IntoIterator<Item = (Variant, Variant)>>(&mut self, iter: I) {
         for (key, value) in iter {
-            self.set(&key.to_variant(), &value.to_variant());
+            self.insert(&key.to_variant(), &value.to_variant());
         }
     }
 }
@@ -268,19 +524,19 @@ godot_test!(test_dictionary {
     let x = Variant::from_i64(42);
     let y = Variant::from_i64(1337);
 
-    let mut dict = Dictionary::new();
+    let dict = Dictionary::<Unique>::new();
 
-    dict.set(&foo, &x);
-    dict.set(&bar, &y);
+    dict.insert(&foo, &x);
+    dict.insert(&bar, &y);
 
     assert!(dict.contains(&foo));
     assert!(dict.contains(&bar));
     assert!(!dict.contains(&nope));
 
-    let mut keys_array = dict.keys();
+    let keys_array = unsafe { dict.keys().assume_unique() };
     let baz = Variant::from_str("baz");
     keys_array.push(&baz);
-    dict.set(&baz, &x);
+    dict.insert(&baz, &x);
 
     assert!(dict.contains_all(&keys_array));
 
@@ -288,10 +544,10 @@ godot_test!(test_dictionary {
 
     assert!(!dict.contains_all(&keys_array));
 
-    let variant = Variant::from_dictionary(&dict);
+    let variant = Variant::from_dictionary(&dict.duplicate().into_shared());
     assert!(variant.get_type() == VariantType::Dictionary);
 
-    let dict2 = dict.new_ref();
+    let dict2 = dict.duplicate();
     assert!(dict == dict2);
     assert!(dict2.contains(&foo));
     assert!(dict2.contains(&bar));

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -38,6 +38,7 @@ use std::ptr;
 
 use crate::private::get_api;
 use crate::NativeClass;
+use crate::RefCounted;
 
 use crate::Variant;
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -63,6 +63,7 @@ mod ref_counted;
 mod rid;
 mod string;
 mod string_array;
+pub mod thread_access;
 mod type_tag;
 pub mod typed_array;
 pub mod user_data;

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -28,6 +28,7 @@ impl NodePath {
     /// global scene tree, not within individual scenes. In a relative path, `"."` and `".."`
     /// indicate the current node and its parent.
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(path: &str) -> Self {
         unsafe {
             let mut dest = sys::godot_node_path::default();
@@ -97,12 +98,6 @@ impl NodePath {
         unsafe { GodotString((get_api().godot_node_path_as_string)(&self.0)) }
     }
 
-    /// Returns the `NodePath` as a `String`
-    #[inline]
-    pub fn to_string(&self) -> String {
-        self.to_godot_string().to_string()
-    }
-
     #[doc(hidden)]
     #[inline]
     pub fn sys(&self) -> *const sys::godot_node_path {
@@ -119,6 +114,13 @@ impl NodePath {
     #[inline]
     pub fn from_sys(sys: sys::godot_node_path) -> Self {
         NodePath(sys)
+    }
+}
+
+impl ToString for NodePath {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.to_godot_string().to_string()
     }
 }
 

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -111,15 +111,14 @@ impl NodePath {
 
     #[doc(hidden)]
     #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_node_path {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
     pub fn from_sys(sys: sys::godot_node_path) -> Self {
         NodePath(sys)
-    }
-}
-
-impl RefCounted for NodePath {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> NodePath : godot_node_path_new_copy;
     }
 }
 
@@ -154,10 +153,11 @@ impl Into<GodotString> for NodePath {
     }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for NodePath as godot_node_path {
         Drop => godot_node_path_destroy;
         Eq => godot_node_path_operator_equal;
+        RefCounted => godot_node_path_new_copy;
     }
 );
 

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -46,15 +46,31 @@ pub trait Instanciable: GodotObject {
 
 /// Manually managed Godot classes implementing `free`.
 pub trait Free: GodotObject {
+    /// Deallocate the object.
+    ///
+    /// # Safety
+    ///
+    /// When this function is called no references to this
+    /// object must be held and dereferenced.
     unsafe fn godot_free(self);
 }
 
 /// Manually managed Godot classes implementing `queue_free`.
 pub trait QueueFree: GodotObject {
+    /// Deallocate the object in the near future.
+    ///
+    /// # Safety
+    ///
+    /// When this function is dequeued no references to this
+    /// object must be held and dereferenced.
     unsafe fn godot_queue_free(&mut self);
 }
 
-// This function assumes the godot_object is reference counted.
+/// Increase the reference count of the object.
+///
+/// # Safety
+///
+/// This function assumes the godot_object is reference counted.
 #[inline]
 pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;
@@ -76,7 +92,11 @@ pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     debug_assert!(ok);
 }
 
-// This function assumes the godot_object is reference counted.
+/// Decrease the reference count of the object.
+///
+/// # Safety
+///
+/// This function assumes the godot_object is reference counted.
 #[inline]
 pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
     use crate::ReferenceMethodTable;
@@ -94,7 +114,12 @@ pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
     last_reference
 }
 
-// This function assumes the godot_object is reference counted.
+/// Initialise the reference count of the object.
+///
+/// # Safety
+///
+/// This function assumes the godot_object is reference counted
+/// and that no other references are held at the time.
 #[inline]
 pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;
@@ -112,6 +137,11 @@ pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
     debug_assert!(ok);
 }
 
+/// Checks whether the object is of a certain Godot class.
+///
+/// # Safety
+///
+/// The `obj` pointer must be pointing to a valid Godot object.
 #[inline]
 pub unsafe fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
     let api = crate::private::get_api();
@@ -139,6 +169,11 @@ pub unsafe fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
     ret
 }
 
+/// Attempt to cast a Godot object to a different class type.
+///
+/// # Safety
+///
+/// The `obj` pointer must be pointing to a valid Godot object.
 #[inline]
 pub unsafe fn godot_cast<T>(from: *mut sys::godot_object) -> Option<T>
 where

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -7,6 +7,8 @@ static mut GDNATIVE_LIBRARY_SYS: Option<*mut sys::godot_object> = None;
 
 /// Binds the API struct from `gdnative_init_options`. Returns `true` on success.
 ///
+/// # Safety
+///
 /// This is intended to be an internal interface.
 #[inline]
 pub unsafe fn bind_api(options: *mut sys::godot_gdnative_init_options) -> bool {
@@ -57,6 +59,8 @@ pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
 }
 
 /// Performs library-wide cleanup during `terminate`.
+///
+/// # Safety
 ///
 /// This is intended to be an internal interface.
 #[inline]

--- a/gdnative-core/src/rid.rs
+++ b/gdnative-core/src/rid.rs
@@ -49,7 +49,7 @@ impl Rid {
 
     #[doc(hidden)]
     #[inline]
-    pub fn mut_sys(&mut self) -> *mut sys::godot_rid {
+    pub fn sys_mut(&mut self) -> *mut sys::godot_rid {
         &mut self.0
     }
 
@@ -60,7 +60,7 @@ impl Rid {
     }
 }
 
-impl_basic_traits! {
+impl_basic_traits_as_sys! {
     for Rid as godot_rid {
         Eq => godot_rid_operator_equal;
         Default => godot_rid_new;

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -194,6 +194,12 @@ impl GodotString {
 
     #[doc(hidden)]
     #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_string {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
     pub fn from_sys(sys: sys::godot_string) -> Self {
         GodotString(sys)
     }
@@ -207,18 +213,12 @@ impl Clone for GodotString {
     }
 }
 
-impl RefCounted for GodotString {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> GodotString : godot_string_new_copy;
-    }
-}
-
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for GodotString as godot_string {
         Drop => godot_string_destroy;
         Eq => godot_string_operator_equal;
         Default => godot_string_new;
+        RefCounted => godot_string_new_copy;
     }
 );
 
@@ -278,9 +278,27 @@ impl Utf8String {
     pub fn to_string(&self) -> String {
         String::from(self.as_str())
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys(&self) -> *const sys::godot_char_string {
+        &self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_char_string {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_sys(sys: sys::godot_char_string) -> Self {
+        Self(sys)
+    }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for Utf8String as godot_char_string {
         Drop => godot_char_string_destroy;
     }
@@ -337,9 +355,27 @@ impl StringName {
     pub fn operator_less(&self, s: &StringName) -> bool {
         unsafe { (get_api().godot_string_name_operator_less)(&self.0, &s.0) }
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys(&self) -> *const sys::godot_string_name {
+        &self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn sys_mut(&mut self) -> *mut sys::godot_string_name {
+        &mut self.0
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_sys(sys: sys::godot_string_name) -> Self {
+        Self(sys)
+    }
 }
 
-impl_basic_traits! {
+impl_basic_traits_as_sys! {
     for StringName as godot_string_name {
         Drop => godot_string_name_destroy;
         Eq => godot_string_name_operator_equal;

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -48,6 +48,7 @@ impl GodotString {
     }
 
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str<S>(s: S) -> Self
     where
         S: AsRef<str>,
@@ -274,11 +275,6 @@ impl Utf8String {
         unsafe { str::from_utf8_unchecked(self.as_bytes()) }
     }
 
-    #[inline]
-    pub fn to_string(&self) -> String {
-        String::from(self.as_str())
-    }
-
     #[doc(hidden)]
     #[inline]
     pub fn sys(&self) -> *const sys::godot_char_string {
@@ -295,6 +291,13 @@ impl Utf8String {
     #[inline]
     pub fn from_sys(sys: sys::godot_char_string) -> Self {
         Self(sys)
+    }
+}
+
+impl ToString for Utf8String {
+    #[inline]
+    fn to_string(&self) -> String {
+        String::from(self.as_str())
     }
 }
 

--- a/gdnative-core/src/thread_access.rs
+++ b/gdnative-core/src/thread_access.rs
@@ -1,0 +1,25 @@
+//! Marker types to express thread safety of Godot types.
+
+/// Marker that indicates that a value currently only has a
+/// single unique reference.
+pub struct Unique;
+
+/// Marker that indicates that a value currently might be shared in the same or
+/// over multiple threads.
+///
+/// Using this marker causes the type to be `!Send + !Sync`.
+pub struct Shared(std::marker::PhantomData<*const ()>);
+
+/// Trait to parametrise over the access markers [`Unique`](struct.Unique.html)
+/// and [`Shared`](struct.Shared.html).
+pub trait ThreadAccess: private::Sealed {}
+
+impl ThreadAccess for Unique {}
+impl private::Sealed for Unique {}
+
+impl ThreadAccess for Shared {}
+impl private::Sealed for Shared {}
+
+mod private {
+    pub trait Sealed {}
+}

--- a/gdnative-core/src/typed_array.rs
+++ b/gdnative-core/src/typed_array.rs
@@ -87,7 +87,7 @@ impl<T: Element> TypedArray<T> {
     pub fn from_variant_array(array: &VariantArray) -> Self {
         unsafe {
             let mut inner = T::SysArray::default();
-            (T::new_with_array_fn(get_api()))(&mut inner, &array.0);
+            (T::new_with_array_fn(get_api()))(&mut inner, array.sys());
             TypedArray { inner }
         }
     }

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -311,6 +311,7 @@ impl Variant {
 
     /// Creates a `Variant` wrapping a string.
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str<S>(s: S) -> Variant
     where
         S: AsRef<str>,
@@ -628,11 +629,6 @@ impl Variant {
     }
 
     #[inline]
-    pub fn to_string(&self) -> String {
-        self.to_godot_string().to_string()
-    }
-
-    #[inline]
     pub fn try_to_string(&self) -> Option<String> {
         self.try_to_godot_string().map(|s| s.to_string())
     }
@@ -759,6 +755,13 @@ impl_basic_traits_as_sys!(
         PartialEq => godot_variant_operator_equal;
     }
 );
+
+impl ToString for Variant {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.to_godot_string().to_string()
+    }
+}
 
 impl Default for Variant {
     #[inline]

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::mem::{forget, transmute};
 
 use crate::private::get_api;
+use crate::thread_access::*;
 
 // TODO: implement Debug, PartialEq, etc.
 
@@ -59,22 +60,22 @@ macro_rules! variant_to_type_from_sys {
     (
         $(
             $(#[$to_attr:meta])*
-            pub fn $to_method:ident(&self) -> $ToType:ident : $to_gd_method:ident;
+            pub fn $to_method:ident(&self) -> $ToType:ty : $to_gd_method:ident;
             $(#[$try_attr:meta])*
-            pub fn $try_method:ident(&self) -> Option<$TryType:ident>;
+            pub fn $try_method:ident(&self) -> Option<$TryType:ty>;
         )*
     ) => (
         $(
             $(#[$to_attr])*
             pub fn $to_method(&self) -> $ToType {
                 unsafe {
-                    $ToType::from_sys((get_api().$to_gd_method)(&self.0))
+                    <$ToType>::from_sys((get_api().$to_gd_method)(&self.0))
                 }
             }
 
             $(#[$try_attr])*
             pub fn $try_method(&self) -> Option<$TryType> {
-                $TryType::from_variant(self).ok()
+                <$TryType>::from_variant(self).ok()
             }
         )*
     )
@@ -270,7 +271,7 @@ impl Variant {
         pub fn from_godot_string(&GodotString) -> Self;
         /// Creates an `Variant` wrapping an array of variants.
         #[inline]
-        pub fn from_array(&VariantArray) -> Self;
+        pub fn from_array(&VariantArray<Shared>) -> Self;
         /// Creates a `Variant` wrapping a byte array.
         #[inline]
         pub fn from_byte_array(&ByteArray) -> Self;
@@ -294,7 +295,7 @@ impl Variant {
         pub fn from_color_array(&ColorArray) -> Self;
         /// Creates a `Variant` wrapping a dictionary.
         #[inline]
-        pub fn from_dictionary(&Dictionary) -> Self;
+        pub fn from_dictionary(&Dictionary<Shared>) -> Self;
     );
 
     /// Creates an empty `Variant`.
@@ -540,10 +541,10 @@ impl Variant {
 
         /// Do a best effort to create a `VariantArray` out of the variant, possibly returning a default value.
         #[inline]
-        pub fn to_array(&self) -> VariantArray : godot_variant_as_array;
+        pub fn to_array(&self) -> VariantArray<Shared> : godot_variant_as_array;
         /// Returns `Some(VariantArray)` if this variant is one, `None` otherwise.
         #[inline]
-        pub fn try_to_array(&self) -> Option<VariantArray>;
+        pub fn try_to_array(&self) -> Option<VariantArray<Shared>>;
 
         /// Do a best effort to create a `ByteArray` out of the variant, possibly returning a default value.
         #[inline]
@@ -596,10 +597,10 @@ impl Variant {
 
         /// Do a best effort to create a `Dictionary` out of the variant, possibly returning a default value.
         #[inline]
-        pub fn to_dictionary(&self) -> Dictionary : godot_variant_as_dictionary;
+        pub fn to_dictionary(&self) -> Dictionary<Shared> : godot_variant_as_dictionary;
         /// Returns `Some(Dictionary)` if this variant is one, `None` otherwise.
         #[inline]
-        pub fn try_to_dictionary(&self) -> Option<Dictionary>;
+        pub fn try_to_dictionary(&self) -> Option<Dictionary<Shared>>;
     );
 
     #[inline]
@@ -751,7 +752,7 @@ impl Variant {
     }
 }
 
-impl_basic_traits!(
+impl_basic_traits_as_sys!(
     for Variant as godot_variant {
         Drop => godot_variant_destroy;
         Clone => godot_variant_new_copy;
@@ -822,8 +823,8 @@ variant_from_ref!(
     impl From<&Rid> : from_rid;
     impl From<&NodePath> : from_node_path;
     impl From<&GodotString> : from_godot_string;
-    impl From<&Dictionary> : from_dictionary;
-    impl From<&VariantArray> : from_array;
+    impl From<&Dictionary<Shared>> : from_dictionary;
+    impl From<&VariantArray<Shared>> : from_array;
     impl From<&ByteArray> : from_byte_array;
     impl From<&Int32Array> : from_int32_array;
     impl From<&Float32Array> : from_float32_array;
@@ -1344,7 +1345,7 @@ to_variant_transmute! {
 
 macro_rules! to_variant_as_sys {
     (
-        $(impl ToVariant for $ty:ident: $ctor:ident;)*
+        $(impl ToVariant for $ty:ty: $ctor:ident;)*
     ) => {
         $(
             impl ToVariant for $ty {
@@ -1371,8 +1372,8 @@ to_variant_as_sys! {
     impl ToVariant for Rid : godot_variant_new_rid;
     impl ToVariant for NodePath : godot_variant_new_node_path;
     impl ToVariant for GodotString : godot_variant_new_string;
-    impl ToVariant for VariantArray : godot_variant_new_array;
-    impl ToVariant for Dictionary : godot_variant_new_dictionary;
+    impl ToVariant for VariantArray<Shared> : godot_variant_new_array;
+    impl ToVariant for Dictionary<Shared> : godot_variant_new_dictionary;
 }
 
 impl ToVariantEq for Rid {}
@@ -1411,7 +1412,7 @@ from_variant_transmute!(
 macro_rules! from_variant_from_sys {
     (
         $(
-            impl FromVariant for $TryType:ident : $try_gd_method:ident;
+            impl FromVariant for $TryType:ty as $EnumVar:ident : $try_gd_method:ident;
         )*
     ) => (
         $(
@@ -1419,9 +1420,9 @@ macro_rules! from_variant_from_sys {
                 #[inline]
                 fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
                     unsafe {
-                        variant.try_as_sys_of_type(VariantType::$TryType)
+                        variant.try_as_sys_of_type(VariantType::$EnumVar)
                             .map(|v| (get_api().$try_gd_method)(v))
-                            .map($TryType::from_sys)
+                            .map(<$TryType>::from_sys)
                     }
                 }
             }
@@ -1430,16 +1431,16 @@ macro_rules! from_variant_from_sys {
 }
 
 from_variant_from_sys!(
-    impl FromVariant for Plane : godot_variant_as_plane;
-    impl FromVariant for Transform : godot_variant_as_transform;
-    impl FromVariant for Basis : godot_variant_as_basis;
-    impl FromVariant for Color : godot_variant_as_color;
-    impl FromVariant for Aabb : godot_variant_as_aabb;
-    impl FromVariant for NodePath : godot_variant_as_node_path;
-    impl FromVariant for GodotString : godot_variant_as_string;
-    impl FromVariant for Rid : godot_variant_as_rid;
-    impl FromVariant for VariantArray : godot_variant_as_array;
-    impl FromVariant for Dictionary : godot_variant_as_dictionary;
+    impl FromVariant for Plane as Plane : godot_variant_as_plane;
+    impl FromVariant for Transform as Transform : godot_variant_as_transform;
+    impl FromVariant for Basis as Basis : godot_variant_as_basis;
+    impl FromVariant for Color as Color : godot_variant_as_color;
+    impl FromVariant for Aabb as Aabb : godot_variant_as_aabb;
+    impl FromVariant for NodePath as NodePath : godot_variant_as_node_path;
+    impl FromVariant for GodotString as GodotString: godot_variant_as_string;
+    impl FromVariant for Rid as Rid : godot_variant_as_rid;
+    impl FromVariant for VariantArray<Shared> as VariantArray : godot_variant_as_array;
+    impl FromVariant for Dictionary<Shared> as Dictionary : godot_variant_as_dictionary;
 );
 
 impl<T: crate::typed_array::Element> ToVariant for TypedArray<T> {
@@ -1601,12 +1602,12 @@ impl<T> MaybeNot<T> {
 impl<T: ToVariant, E: ToVariant> ToVariant for Result<T, E> {
     #[inline]
     fn to_variant(&self) -> Variant {
-        let mut dict = Dictionary::new();
+        let dict = Dictionary::new();
         match &self {
-            Ok(val) => dict.set(&"Ok".into(), &val.to_variant()),
-            Err(err) => dict.set(&"Err".into(), &err.to_variant()),
+            Ok(val) => dict.insert(&"Ok".into(), &val.to_variant()),
+            Err(err) => dict.insert(&"Err".into(), &err.to_variant()),
         }
-        dict.to_variant()
+        dict.into_shared().to_variant()
     }
 }
 
@@ -1631,7 +1632,7 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
         }
 
         let keys = dict.keys();
-        let key_variant = keys.get_ref(0);
+        let key_variant = &keys.get(0);
         let key = String::from_variant(key_variant).map_err(|err| FVE::InvalidEnumRepr {
             expected: VariantEnumRepr::ExternallyTagged,
             error: Box::new(err),
@@ -1639,7 +1640,7 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
 
         match key.as_str() {
             "Ok" => {
-                let val = T::from_variant(dict.get_ref(key_variant)).map_err(|err| {
+                let val = T::from_variant(&dict.get(key_variant)).map_err(|err| {
                     FVE::InvalidEnumVariant {
                         variant: "Ok",
                         error: Box::new(err),
@@ -1648,7 +1649,7 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
                 Ok(Ok(val))
             }
             "Err" => {
-                let err = E::from_variant(dict.get_ref(key_variant)).map_err(|err| {
+                let err = E::from_variant(&dict.get(key_variant)).map_err(|err| {
                     FVE::InvalidEnumVariant {
                         variant: "Err",
                         error: Box::new(err),
@@ -1667,12 +1668,12 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
 impl<T: ToVariant> ToVariant for &[T] {
     #[inline]
     fn to_variant(&self) -> Variant {
-        let mut array = VariantArray::new();
+        let array = VariantArray::new();
         for val in self.iter() {
             // there is no real way to avoid CoW allocations right now, as ptrw isn't exposed
             array.push(&val.to_variant());
         }
-        array.to_variant()
+        array.into_shared().to_variant()
     }
 }
 
@@ -1696,7 +1697,7 @@ impl<T: FromVariant> FromVariant for Vec<T> {
         let mut vec = Vec::with_capacity(len);
         for idx in 0..len as i32 {
             let item =
-                T::from_variant(arr.get_ref(idx)).map_err(|e| FromVariantError::InvalidItem {
+                T::from_variant(&arr.get(idx)).map_err(|e| FromVariantError::InvalidItem {
                     index: idx as usize,
                     error: Box::new(e),
                 })?;
@@ -1726,12 +1727,12 @@ macro_rules! impl_variant_for_tuples {
             #[allow(non_snake_case)]
             #[inline]
             fn to_variant(&self) -> Variant {
-                let mut array = VariantArray::new();
+                let array = VariantArray::new();
                 let ($($name,)+) = self;
                 $(
                     array.push(&$name.to_variant());
                 )+
-                array.to_variant()
+                array.into_shared().to_variant()
             }
         }
 
@@ -1749,7 +1750,7 @@ macro_rules! impl_variant_for_tuples {
                 let mut iter = array.iter();
                 let mut index = 0;
                 $(
-                    let $name = $name::from_variant(iter.next().unwrap())
+                    let $name = $name::from_variant(&iter.next().unwrap())
                         .map_err(|err| FromVariantError::InvalidItem {
                             index,
                             error: Box::new(err),
@@ -1798,11 +1799,11 @@ godot_test!(
     test_variant_result {
         let variant = Result::<i64, ()>::Ok(42 as i64).to_variant();
         let dict = variant.try_to_dictionary().expect("should be dic");
-        assert_eq!(Some(42), dict.get_ref(&"Ok".into()).try_to_i64());
+        assert_eq!(Some(42), dict.get(&"Ok".into()).try_to_i64());
 
         let variant = Result::<(), i64>::Err(54 as i64).to_variant();
         let dict = variant.try_to_dictionary().expect("should be dic");
-        assert_eq!(Some(54), dict.get_ref(&"Err".into()).try_to_i64());
+        assert_eq!(Some(54), dict.get(&"Err".into()).try_to_i64());
 
         let variant = Variant::from_bool(true);
         assert_eq!(
@@ -1816,13 +1817,13 @@ godot_test!(
             Result::<(), i64>::from_variant(&variant),
         );
 
-        let mut dict = Dictionary::new();
-        dict.set(&"Ok".into(), &Variant::from_i64(42));
-        assert_eq!(Ok(Ok(42)), Result::<i64, i64>::from_variant(&dict.to_variant()));
+        let dict = Dictionary::new();
+        dict.insert(&"Ok".into(), &Variant::from_i64(42));
+        assert_eq!(Ok(Ok(42)), Result::<i64, i64>::from_variant(&dict.into_shared().to_variant()));
 
-        let mut dict = Dictionary::new();
-        dict.set(&"Err".into(), &Variant::from_i64(54));
-        assert_eq!(Ok(Err(54)), Result::<i64, i64>::from_variant(&dict.to_variant()));
+        let dict = Dictionary::new();
+        dict.insert(&"Err".into(), &Variant::from_i64(54));
+        assert_eq!(Ok(Err(54)), Result::<i64, i64>::from_variant(&dict.into_shared().to_variant()));
     }
 
     test_to_variant_iter {
@@ -1831,13 +1832,13 @@ godot_test!(
         let array = variant.try_to_array().expect("should be array");
         assert_eq!(5, array.len());
         for i in 0..5 {
-            assert_eq!(Some(i), array.get_ref(i as i32).try_to_i64());
+            assert_eq!(Some(i), array.get(i as i32).try_to_i64());
         }
 
         let vec = Vec::<i64>::from_variant(&variant).expect("should succeed");
         assert_eq!(slice, vec.as_slice());
 
-        let mut het_array = VariantArray::new();
+        let het_array = VariantArray::new();
         het_array.push(&Variant::from_i64(42));
         het_array.push(&Variant::new());
 
@@ -1849,10 +1850,10 @@ godot_test!(
                     variant_type: VariantType::Nil,
                 }),
             }),
-            Vec::<i64>::from_variant(&het_array.to_variant()),
+            Vec::<i64>::from_variant(&het_array.duplicate().into_shared().to_variant()),
         );
 
-        assert_eq!(Ok(vec![Some(42), None]), Vec::<Option<i64>>::from_variant(&het_array.to_variant()));
+        assert_eq!(Ok(vec![Some(42), None]), Vec::<Option<i64>>::from_variant(&het_array.duplicate().into_shared().to_variant()));
 
         het_array.push(&f64::to_variant(&54.0));
 
@@ -1864,10 +1865,10 @@ godot_test!(
                     variant_type: VariantType::F64,
                 }),
             }),
-            Vec::<Option<i64>>::from_variant(&het_array.to_variant()),
+            Vec::<Option<i64>>::from_variant(&het_array.duplicate().into_shared().to_variant()),
         );
 
-        let vec_maybe = Vec::<MaybeNot<i64>>::from_variant(&het_array.to_variant()).expect("should succeed");
+        let vec_maybe = Vec::<MaybeNot<i64>>::from_variant(&het_array.into_shared().to_variant()).expect("should succeed");
         assert_eq!(3, vec_maybe.len());
         assert_eq!(Some(&42), vec_maybe[0].as_ref().ok());
         assert_eq!(Some(&Variant::new()), vec_maybe[1].as_ref().err());
@@ -1877,8 +1878,8 @@ godot_test!(
     test_variant_tuple {
         let variant = (42i64, 54i64).to_variant();
         let arr = variant.try_to_array().expect("should be array");
-        assert_eq!(Some(42), arr.get_ref(0).try_to_i64());
-        assert_eq!(Some(54), arr.get_ref(1).try_to_i64());
+        assert_eq!(Some(42), arr.get(0).try_to_i64());
+        assert_eq!(Some(54), arr.get(1).try_to_i64());
 
         let tuple = <(i64, i64)>::from_variant(&variant);
         assert_eq!(Ok((42, 54)), tuple);

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,4 +1,5 @@
 use std::iter::{Extend, FromIterator};
+use std::marker::PhantomData;
 
 use crate::private::get_api;
 use crate::sys;
@@ -7,110 +8,87 @@ use crate::RefCounted;
 use crate::ToVariant;
 use crate::Variant;
 
+use crate::thread_access::*;
+
 use std::fmt;
 
 /// A reference-counted `Variant` vector. Godot's generic array data type.
 /// Negative indices can be used to count from the right.
-pub struct VariantArray(pub(crate) sys::godot_array);
+///
+/// # Safety
+///
+/// This is a reference-counted collection with "interior mutability" in Rust parlance.
+/// To enforce that the official [thread-safety guidelines][thread-safety] are
+/// followed this type uses the *typestate* pattern. The typestate `Access` tracks
+/// whether there is "unique" access (where pretty much all operations are safe)
+/// or whether the value might be "shared", in which case not all operations are
+/// safe.
+///
+/// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
+pub struct VariantArray<Access: ThreadAccess = Shared> {
+    sys: sys::godot_array,
 
-impl VariantArray {
-    /// Creates an empty `VariantArray`.
-    #[inline]
-    pub fn new() -> Self {
-        VariantArray::default()
-    }
+    /// Marker preventing the compiler from incorrectly deriving `Send` and `Sync`.
+    _marker: PhantomData<Access>,
+}
 
+impl<Access: ThreadAccess> VariantArray<Access> {
     /// Sets the value of the element at the given offset.
     #[inline]
-    pub fn set(&mut self, idx: i32, val: &Variant) {
-        unsafe { (get_api().godot_array_set)(&mut self.0, idx, &val.0) }
+    pub fn set(&self, idx: i32, val: &Variant) {
+        unsafe { (get_api().godot_array_set)(self.sys_mut(), idx, val.sys()) }
     }
 
     /// Returns a copy of the element at the given offset.
     #[inline]
-    pub fn get_val(&mut self, idx: i32) -> Variant {
-        unsafe { Variant((get_api().godot_array_get)(&self.0, idx)) }
+    pub fn get(&self, idx: i32) -> Variant {
+        unsafe { Variant((get_api().godot_array_get)(self.sys(), idx)) }
     }
 
     /// Returns a reference to the element at the given offset.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference.
+    ///
+    /// `Variant` is reference-counted and thus cheaply cloned. Consider using `get` instead.
     #[inline]
-    pub fn get_ref(&self, idx: i32) -> &Variant {
-        unsafe { Variant::cast_ref((get_api().godot_array_operator_index_const)(&self.0, idx)) }
+    pub unsafe fn get_ref(&self, idx: i32) -> &Variant {
+        Variant::cast_ref((get_api().godot_array_operator_index_const)(
+            self.sys(),
+            idx,
+        ))
     }
 
     /// Returns a mutable reference to the element at the given offset.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is invalidated if the same container is mutated through another
+    /// reference. It is possible to create two mutable references to the same memory location
+    /// if the same `idx` is provided, causing undefined behavior.
     #[inline]
-    pub fn get_mut_ref(&mut self, idx: i32) -> &mut Variant {
-        unsafe { Variant::cast_mut_ref((get_api().godot_array_operator_index)(&mut self.0, idx)) }
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn get_mut_ref(&self, idx: i32) -> &mut Variant {
+        Variant::cast_mut_ref((get_api().godot_array_operator_index)(self.sys_mut(), idx))
     }
 
     #[inline]
-    pub fn count(&mut self, val: &Variant) -> i32 {
-        unsafe { (get_api().godot_array_count)(&mut self.0, &val.0) }
-    }
-
-    /// Clears the array, resizing to 0.
-    #[inline]
-    pub fn clear(&mut self) {
-        unsafe {
-            (get_api().godot_array_clear)(&mut self.0);
-        }
-    }
-
-    #[inline]
-    pub fn remove(&mut self, idx: i32) {
-        unsafe { (get_api().godot_array_remove)(&mut self.0, idx) }
-    }
-
-    #[inline]
-    pub fn erase(&mut self, val: &Variant) {
-        unsafe { (get_api().godot_array_erase)(&mut self.0, &val.0) }
+    pub fn count(&self, val: &Variant) -> i32 {
+        unsafe { (get_api().godot_array_count)(self.sys(), val.sys()) }
     }
 
     /// Returns `true` if the `VariantArray` contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        unsafe { (get_api().godot_array_empty)(&self.0) }
+        unsafe { (get_api().godot_array_empty)(self.sys()) }
     }
 
     /// Returns the number of elements in the array.
     #[inline]
     pub fn len(&self) -> i32 {
-        unsafe { (get_api().godot_array_size)(&self.0) }
-    }
-
-    /// Appends an element at the end of the array.
-    #[inline]
-    pub fn push(&mut self, val: &Variant) {
-        unsafe {
-            (get_api().godot_array_push_back)(&mut self.0, &val.0);
-        }
-    }
-
-    /// Removes an element at the end of the array.
-    #[inline]
-    pub fn pop(&mut self) -> Variant {
-        unsafe { Variant((get_api().godot_array_pop_back)(&mut self.0)) }
-    }
-
-    /// Appends an element to the front of the array.
-    #[inline]
-    pub fn push_front(&mut self, val: &Variant) {
-        unsafe {
-            (get_api().godot_array_push_front)(&mut self.0, &val.0);
-        }
-    }
-
-    /// Removes an element at the front of the array.
-    #[inline]
-    pub fn pop_front(&mut self) -> Variant {
-        unsafe { Variant((get_api().godot_array_pop_front)(&mut self.0)) }
-    }
-
-    /// Insert a new int at a given position in the array.
-    #[inline]
-    pub fn insert(&mut self, at: i32, val: &Variant) {
-        unsafe { (get_api().godot_array_insert)(&mut self.0, at, &val.0) }
+        unsafe { (get_api().godot_array_size)(self.sys()) }
     }
 
     /// Searches the array for a value and returns its index.
@@ -118,18 +96,13 @@ impl VariantArray {
     /// Returns `-1` if value is not found.
     #[inline]
     pub fn find(&self, what: &Variant, from: i32) -> i32 {
-        unsafe { (get_api().godot_array_find)(&self.0, &what.0, from) }
+        unsafe { (get_api().godot_array_find)(self.sys(), what.sys(), from) }
     }
 
     /// Returns true if the `VariantArray` contains the specified value.
     #[inline]
     pub fn contains(&self, what: &Variant) -> bool {
-        unsafe { (get_api().godot_array_has)(&self.0, &what.0) }
-    }
-
-    #[inline]
-    pub fn resize(&mut self, size: i32) {
-        unsafe { (get_api().godot_array_resize)(&mut self.0, size) }
+        unsafe { (get_api().godot_array_has)(self.sys(), what.sys()) }
     }
 
     /// Searches the array in reverse order.
@@ -137,31 +110,43 @@ impl VariantArray {
     /// If negative, the start index is considered relative to the end of the array.
     #[inline]
     pub fn rfind(&self, what: &Variant, from: i32) -> i32 {
-        unsafe { (get_api().godot_array_rfind)(&self.0, &what.0, from) }
+        unsafe { (get_api().godot_array_rfind)(self.sys(), what.sys(), from) }
     }
 
     /// Searches the array in reverse order for a value.
     /// Returns its index or `-1` if not found.
     #[inline]
     pub fn find_last(&self, what: &Variant) -> i32 {
-        unsafe { (get_api().godot_array_find_last)(&self.0, &what.0) }
+        unsafe { (get_api().godot_array_find_last)(self.sys(), what.sys()) }
     }
 
     /// Inverts the order of the elements in the array.
     #[inline]
-    pub fn invert(&mut self) {
-        unsafe { (get_api().godot_array_invert)(&mut self.0) }
+    pub fn invert(&self) {
+        unsafe { (get_api().godot_array_invert)(self.sys_mut()) }
     }
 
     /// Return a hashed i32 value representing the array contents.
     #[inline]
     pub fn hash(&self) -> i32 {
-        unsafe { (get_api().godot_array_hash)(&self.0) }
+        unsafe { (get_api().godot_array_hash)(self.sys()) }
     }
 
     #[inline]
-    pub fn sort(&mut self) {
-        unsafe { (get_api().godot_array_sort)(&mut self.0) }
+    pub fn sort(&self) {
+        unsafe { (get_api().godot_array_sort)(self.sys_mut()) }
+    }
+
+    /// Create a copy of the array.
+    ///
+    /// This creates a new array and is **not** a cheap reference count
+    /// increment.
+    #[inline]
+    pub fn duplicate(&self) -> VariantArray<Unique> {
+        unsafe {
+            let sys = (get_api().godot_array_duplicate)(self.sys(), false);
+            VariantArray::<Unique>::from_sys(sys)
+        }
     }
 
     // TODO
@@ -171,7 +156,7 @@ impl VariantArray {
 
     // pub fn bsearch(&mut self, val: (), before: bool) -> i32 {
     //     unsafe {
-    //         (get_api().godot_array_bsearch)(&mut self.0, val, before)
+    //         (get_api().godot_array_bsearch)(self.sys_mut(), val, before)
     //     }
     // }
 
@@ -179,68 +164,216 @@ impl VariantArray {
     //     unimplemented!();
     // }
 
+    #[doc(hidden)]
     #[inline]
-    pub fn iter(&self) -> Iter {
-        Iter {
-            arr: self,
-            range: 0..self.len(),
-        }
-    }
-
-    #[inline]
-    pub fn iter_mut(&mut self) -> IterMut {
-        let len = self.len();
-        IterMut {
-            arr: self,
-            range: 0..len,
-        }
+    pub fn sys(&self) -> *const sys::godot_array {
+        &self.sys
     }
 
     #[doc(hidden)]
     #[inline]
-    pub fn sys(&self) -> *const sys::godot_array {
-        &self.0
+    pub fn sys_mut(&self) -> *mut sys::godot_array {
+        &self.sys as *const _ as *mut _
     }
 
     #[doc(hidden)]
     #[inline]
     pub fn from_sys(sys: sys::godot_array) -> Self {
-        VariantArray(sys)
+        VariantArray {
+            sys,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl RefCounted for VariantArray {
-    impl_common_methods! {
-        #[inline]
-        fn new_ref(&self) -> VariantArray : godot_array_new_copy;
+impl VariantArray<Unique> {
+    /// Creates an empty `VariantArray`.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn into_shared(self) -> VariantArray<Shared> {
+        VariantArray::<Shared> {
+            sys: self.sys,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Clears the array, resizing to 0.
+    #[inline]
+    pub fn clear(&self) {
+        unsafe {
+            (get_api().godot_array_clear)(self.sys_mut());
+        }
+    }
+
+    /// Removes the element at `idx`.
+    #[inline]
+    pub fn remove(&self, idx: i32) {
+        unsafe { (get_api().godot_array_remove)(self.sys_mut(), idx) }
+    }
+
+    /// Removed the first occurrence of `val`.
+    #[inline]
+    pub fn erase(&self, val: &Variant) {
+        unsafe { (get_api().godot_array_erase)(self.sys_mut(), val.sys()) }
+    }
+
+    #[inline]
+    pub fn resize(&self, size: i32) {
+        unsafe { (get_api().godot_array_resize)(self.sys_mut(), size) }
+    }
+
+    /// Appends an element at the end of the array.
+    #[inline]
+    pub fn push(&self, val: &Variant) {
+        unsafe {
+            (get_api().godot_array_push_back)(self.sys_mut(), val.sys());
+        }
+    }
+
+    /// Removes an element at the end of the array.
+    #[inline]
+    pub fn pop(&self) -> Variant {
+        unsafe { Variant((get_api().godot_array_pop_back)(self.sys_mut())) }
+    }
+
+    /// Appends an element to the front of the array.
+    #[inline]
+    pub fn push_front(&self, val: &Variant) {
+        unsafe {
+            (get_api().godot_array_push_front)(self.sys_mut(), val.sys());
+        }
+    }
+
+    /// Removes an element at the front of the array.
+    #[inline]
+    pub fn pop_front(&self) -> Variant {
+        unsafe { Variant((get_api().godot_array_pop_front)(self.sys_mut())) }
+    }
+
+    /// Insert a new int at a given position in the array.
+    #[inline]
+    pub fn insert(&self, at: i32, val: &Variant) {
+        unsafe { (get_api().godot_array_insert)(self.sys_mut(), at, val.sys()) }
+    }
+
+    /// Returns an iterator through all values in the `VariantArray`.
+    ///
+    /// `VariantArray` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
+    #[inline]
+    pub fn iter(&self) -> IterUnique {
+        IterUnique {
+            arr: self,
+            range: 0..self.len(),
+        }
+    }
+
+    /// Returns an iterator through all values in the `VariantArray`.
+    ///
+    /// `VariantArray` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
+    #[inline]
+    pub fn into_iter(self) -> IntoIterUnique {
+        let len = self.len();
+        IntoIterUnique {
+            arr: self,
+            range: 0..len,
+        }
     }
 }
 
-impl_basic_traits!(
-    for VariantArray as godot_array {
-        Drop => godot_array_destroy;
-        Default => godot_array_new;
+impl VariantArray<Shared> {
+    #[inline]
+    pub fn new_shared() -> Self {
+        VariantArray::<Unique>::new().into_shared()
     }
-);
 
-impl fmt::Debug for VariantArray {
+    #[inline]
+    pub unsafe fn assume_unique(self) -> VariantArray<Unique> {
+        VariantArray::<Unique> {
+            sys: self.sys,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns an iterator through all values in the `VariantArray`.
+    ///
+    /// `VariantArray` is reference-counted and have interior mutability in Rust parlance.
+    /// Modifying the same underlying collection while observing the safety assumptions will
+    /// not violate memory safely, but may lead to surprising behavior in the iterator.
+    #[inline]
+    pub fn iter(&self) -> IterShared {
+        IterShared {
+            arr: self.new_ref(),
+            range: 0..self.len(),
+        }
+    }
+}
+
+impl Default for VariantArray<Unique> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Default for VariantArray<Shared> {
+    #[inline]
+    fn default() -> Self {
+        VariantArray::new_shared()
+    }
+}
+
+impl RefCounted for VariantArray<Shared> {
+    #[inline]
+    fn new_ref(&self) -> Self {
+        unsafe {
+            let mut result = Default::default();
+            (get_api().godot_array_new_copy)(&mut result, self.sys());
+            Self::from_sys(result)
+        }
+    }
+}
+
+impl<Access: ThreadAccess> Drop for VariantArray<Access> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { (get_api().godot_array_destroy)(self.sys_mut()) }
+    }
+}
+
+impl fmt::Debug for VariantArray<Unique> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }
 
-pub struct Iter<'a> {
-    arr: &'a VariantArray,
+impl fmt::Debug for VariantArray<Shared> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+// #[derive(Debug)]
+pub struct IterShared {
+    arr: VariantArray<Shared>,
     range: std::ops::Range<i32>,
 }
 
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Variant;
+impl Iterator for IterShared {
+    type Item = Variant;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(|idx| self.arr.get_ref(idx))
+        self.range.next().map(|idx| self.arr.get(idx))
     }
 
     #[inline]
@@ -249,20 +382,18 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-pub struct IterMut<'a> {
-    arr: &'a mut VariantArray,
+// #[derive(Debug)]
+pub struct IterUnique<'a> {
+    arr: &'a VariantArray<Unique>,
     range: std::ops::Range<i32>,
 }
 
-impl<'a> Iterator for IterMut<'a> {
-    type Item = &'a mut Variant;
+impl<'a> Iterator for IterUnique<'a> {
+    type Item = Variant;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(|idx| {
-            let short_ref: &'_ mut Variant = self.arr.get_mut_ref(idx);
-            unsafe { std::mem::transmute::<_, &'a mut Variant>(short_ref) }
-        })
+        self.range.next().map(|idx| self.arr.get(idx))
     }
 
     #[inline]
@@ -271,7 +402,27 @@ impl<'a> Iterator for IterMut<'a> {
     }
 }
 
-impl<T: ToVariant> FromIterator<T> for VariantArray {
+// #[derive(Debug)]
+pub struct IntoIterUnique {
+    arr: VariantArray<Unique>,
+    range: std::ops::Range<i32>,
+}
+
+impl Iterator for IntoIterUnique {
+    type Item = Variant;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|idx| self.arr.get(idx))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<T: ToVariant> FromIterator<T> for VariantArray<Unique> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut arr = Self::new();
@@ -280,7 +431,7 @@ impl<T: ToVariant> FromIterator<T> for VariantArray {
     }
 }
 
-impl<T: ToVariant> Extend<T> for VariantArray {
+impl<T: ToVariant> Extend<T> for VariantArray<Unique> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         for elem in iter {
@@ -294,7 +445,7 @@ godot_test!(test_array {
     let bar = Variant::from_str("bar");
     let nope = Variant::from_str("nope");
 
-    let mut array = VariantArray::new(); // []
+    let array = VariantArray::new(); // []
 
     assert!(array.is_empty());
     assert_eq!(array.len(), 0);
@@ -311,8 +462,8 @@ godot_test!(test_array {
     array.set(0, &bar); // [&bar, &bar]
     array.set(1, &foo); // [&bar, &foo]
 
-    assert_eq!(array.get_ref(0), &bar);
-    assert_eq!(array.get_ref(1), &foo);
+    assert_eq!(&array.get(0), &bar);
+    assert_eq!(&array.get(1), &foo);
 
     array.pop(); // [&bar]
     array.pop(); // []
@@ -332,12 +483,12 @@ godot_test!(test_array {
 
     array.invert(); // [&x, &y, &z, &z]
 
-    assert_eq!(array.get_ref(0), &x);
+    assert_eq!(&array.get(0), &x);
 
     array.pop_front(); // [&y, &z, &z]
     array.pop_front(); // [&z, &z]
 
-    assert_eq!(array.get_ref(0), &z);
+    assert_eq!(&array.get(0), &z);
 
     array.resize(0); // []
     assert!(array.is_empty());
@@ -345,12 +496,12 @@ godot_test!(test_array {
     array.push(&foo); // [&foo]
     array.push(&bar); // [&foo, &bar]
 
-    let array2 = array.new_ref();
+    let array2 = array.duplicate();
     assert!(array2.contains(&foo));
     assert!(array2.contains(&bar));
     assert!(!array2.contains(&nope));
 
-    let mut array3 = VariantArray::new(); // []
+    let array3 = VariantArray::new(); // []
 
     array3.push(&Variant::from_i64(42));
     array3.push(&Variant::from_i64(1337));
@@ -360,20 +511,11 @@ godot_test!(test_array {
         &[42, 1337, 512],
         array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
     );
-
-    for v in array3.iter_mut() {
-        *v = Variant::from_i64(54);
-    }
-
-    assert_eq!(
-        &[54, 54, 54],
-        array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
-    );
 });
 
 godot_test!(
     test_array_debug {
-        let mut arr = VariantArray::new(); // []
+        let arr = VariantArray::new(); // []
         arr.push(&Variant::from_str("hello world"));
         arr.push(&Variant::from_bool(true));
         arr.push(&Variant::from_i64(42));

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -114,6 +114,7 @@ fn parse_method_export(_meta: TokenStream, input: TokenStream) -> (ItemImpl, Cla
 }
 
 /// Extract the data to export from the impl block.
+#[allow(clippy::single_match)]
 fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
     // the ast input is used for inspecting.
     // this clone is used to remove all attributes so that the resulting
@@ -153,7 +154,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                             .last()
                             .map(|i| i.ident.to_string());
 
-                        if let Some("export") = last_seg.as_ref().map(String::as_str) {
+                        if let Some("export") = last_seg.as_deref() {
                             let _export_args = export_args.get_or_insert_with(ExportArgs::default);
                             if !attr.tokens.is_empty() {
                                 use quote::ToTokens;
@@ -184,11 +185,8 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                 for MetaNameValue { path, .. } in pairs.into_iter() {
                                     let last =
                                         path.segments.last().expect("the path should not be empty");
-                                    match last.ident.to_string().as_str() {
-                                        unexpected => {
-                                            panic!("unknown option for export: `{}`", unexpected)
-                                        }
-                                    }
+                                    let unexpected = last.ident.to_string();
+                                    panic!("unknown option for export: `{}`", unexpected);
                                 }
                             }
 
@@ -225,10 +223,8 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                             }
 
                             *optional_args.get_or_insert(0) += 1;
-                        } else {
-                            if optional_args.is_some() {
-                                panic!("cannot add required parameters after optional ones");
-                            }
+                        } else if optional_args.is_some() {
+                            panic!("cannot add required parameters after optional ones");
                         }
                     }
 

--- a/gdnative-derive/src/variant/attr.rs
+++ b/gdnative-derive/src/variant/attr.rs
@@ -85,6 +85,7 @@ impl AttrBuilder {
             }
         }
 
+        #[allow(clippy::single_match)]
         match name.as_str() {
             "skip" => {
                 self.skip_to_variant = true;
@@ -102,6 +103,7 @@ impl AttrBuilder {
         self.errors.extend(err);
     }
 
+    #[allow(clippy::single_match)]
     fn try_set_pair(&mut self, pair: &syn::MetaNameValue) -> Result<(), syn::Error> {
         let syn::MetaNameValue { path, lit, .. } = pair;
 

--- a/gdnative-derive/src/variant/bounds.rs
+++ b/gdnative-derive/src/variant/bounds.rs
@@ -47,7 +47,7 @@ pub(crate) fn extend_bounds(
         .collect();
 
     let mut visitor = Visitor {
-        all_type_params: all_type_params,
+        all_type_params,
         used: HashSet::new(),
     };
 
@@ -107,7 +107,7 @@ pub(crate) fn extend_bounds(
         .cloned()
         .map(|bounded_ty| where_predicate(syn::Type::Path(bounded_ty), bound.clone()));
 
-    let mut generics = generics.clone();
+    let mut generics = generics;
     generics
         .make_where_clause()
         .predicates

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -72,7 +72,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
                         })
                     }
                     else {
-                        let __key = String::from_variant(__keys.get_ref(0))
+                        let __key = String::from_variant(&__keys.get(0))
                             .map_err(|__err| FVE::InvalidEnumRepr {
                                 expected: VariantEnumRepr::ExternallyTagged,
                                 error: Box::new(__err),
@@ -80,7 +80,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
                         match __key.as_str() {
                             #(
                                 #ref_var_ident_string_literals => {
-                                    let #var_input_ident_iter = __dict.get_ref(__keys.get_ref(0));
+                                    let #var_input_ident_iter = &__dict.get(&__keys.get(0));
                                     (#var_from_variants).map_err(|err| FVE::InvalidEnumVariant {
                                         variant: "Ok",
                                         error: Box::new(err),

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -41,11 +41,11 @@ pub(crate) fn expand_to_variant(derive_data: DeriveData) -> TokenStream {
                         let var_ident_string_literal = Literal::string(&var_ident_string);
                         quote! {
                             #ident::#var_ident #destructure_pattern => {
-                                let mut __dict = ::gdnative::Dictionary::new();
+                                let __dict = ::gdnative::Dictionary::new();
                                 let __key = ::gdnative::GodotString::from(#var_ident_string_literal).to_variant();
                                 let __value = #to_variant;
-                                __dict.set(&__key, &__value);
-                                __dict.to_variant()
+                                __dict.insert(&__key, &__value);
+                                __dict.into_shared().to_variant()
                             }
                         }
                     });

--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -159,6 +159,7 @@ mod header_binding {
         false
     }
 
+    #[allow(clippy::single_match)]
     pub(crate) fn generate(manifest_dir: &str, out_dir: &str) {
         // on mac/iOS this will be modified, so it is marked as mutable.
         // on all other targets, this `mut` will be unused and the complainer compiles.t s
@@ -403,7 +404,8 @@ mod api_wrapper {
     ) {
         let from_json = from_json.as_ref();
         let to = to.as_ref();
-        let api_json_file = File::open(from_json).expect(&format!("No such file: {:?}", from_json));
+        let api_json_file =
+            File::open(from_json).unwrap_or_else(|_| panic!("No such file: {:?}", from_json));
         let api_root: ApiRoot = serde_json::from_reader(api_json_file)
             .expect(&"File ({:?}) does not contain expected JSON");
         let struct_fields = godot_api_functions(&api_root);
@@ -416,10 +418,8 @@ mod api_wrapper {
                 #impl_constructor
             }
         };
-        let mut wrapper_file = File::create(to.join(file_name)).expect(&format!(
-            "Couldn't create output file: {:?}",
-            to.join(file_name)
-        ));
+        let mut wrapper_file = File::create(to.join(file_name))
+            .unwrap_or_else(|_| panic!("Couldn't create output file: {:?}", to.join(file_name)));
         write!(wrapper_file, "{}", wrapper).unwrap();
     }
 
@@ -485,7 +485,7 @@ mod api_wrapper {
         }
         c_type = c_type.trim();
         let mut ptr_count = 0;
-        while c_type.ends_with("*") {
+        while c_type.ends_with('*') {
             ptr_count += 1;
             c_type = c_type[..c_type.len() - 1].trim();
         }

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -104,8 +104,8 @@ fn test_derive_to_variant() -> bool {
         let tuple_array = variant.try_to_array().expect("should be array");
 
         assert_eq!(2, tuple_array.len());
-        assert_eq!(Some(1), tuple_array.get_ref(0).try_to_i64());
-        assert_eq!(Some(false), tuple_array.get_ref(1).try_to_bool());
+        assert_eq!(Some(1), tuple_array.get(0).try_to_i64());
+        assert_eq!(Some(false), tuple_array.get(1).try_to_bool());
         assert_eq!(
             Ok(ToVarTuple::<f64, i128>(1, 0, false)),
             ToVarTuple::from_variant(&variant)

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -14,10 +14,10 @@ fn test_variant_ops() -> bool {
     println!(" -- test_variant_ops");
 
     let ok = std::panic::catch_unwind(|| {
-        let mut arr = VariantArray::new();
+        let arr = VariantArray::new();
         arr.push(&"bar".to_variant());
         arr.push(&"baz".to_variant());
-        let arr = arr.to_variant();
+        let arr = arr.into_shared().to_variant();
 
         assert_eq!(
             Ok(42.to_variant()),


### PR DESCRIPTION
The typestate is used to track which operations are safe to use
respecting the Godot thread-safety guidelines.

Based on commits by @toasteater:

- All methods of `Dictionary` and `VariantArray` now take `&self`.
- Removed `VariantArray::iter_mut` because it's too easy to use in
  an unsound way and has no clear use cases.
- This also replaces the older `impl_basic_trait` macro with the
  more versatile `impl_basic_trait_as_sys`.