### PR TITLE
Returning TokenStream to build.rs

### DIFF
--- a/bindings_generator/src/documentation.rs
+++ b/bindings_generator/src/documentation.rs
@@ -1,6 +1,7 @@
 use crate::api::*;
 use crate::GeneratorResult;
 
+use proc_macro2::TokenStream;
 use quote::quote;
 
 use std::io::Write;
@@ -18,11 +19,7 @@ pub fn official_doc_url(class: &GodotClass) -> String {
     )
 }
 
-pub fn generate_class_documentation(
-    output: &mut impl Write,
-    api: &Api,
-    class: &GodotClass,
-) -> GeneratorResult {
+pub fn generate_class_documentation(api: &Api, class: &GodotClass) -> TokenStream {
     let has_parent = class.base_class != "";
     let singleton_str = if class.singleton { "singleton " } else { "" };
     let ownership_type = if class.is_refcounted() {
@@ -127,18 +124,14 @@ references to it on other threads.
 [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html"#,
     );
 
-    let code = quote! {
+    quote! {
         #[doc=#summary_doc]
         #[doc=#official_docs]
         #[doc=#memory_management_docs]
         #[doc=#base_class_docs]
         #[doc=#tools_docs]
         #[doc=#safety_doc]
-    };
-    generated_at!(output);
-    write!(output, "{}", code)?;
-
-    Ok(())
+    }
 }
 
 fn list_base_classes(output: &mut impl Write, api: &Api, parent_name: &str) -> GeneratorResult {

--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -2,54 +2,41 @@ use gdnative_bindings_generator::*;
 
 use std::env;
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, Write as _};
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let bindings_types_rs = out_path.join("bindings_types.rs");
-    let bindings_traits_rs = out_path.join("bindings_traits.rs");
-    let bindings_methods_rs = out_path.join("bindings_methods.rs");
+    let output_rs = out_path.join("generated.rs");
 
-    let mut types_output = BufWriter::new(File::create(&bindings_types_rs).unwrap());
-    let mut traits_output = BufWriter::new(File::create(&bindings_traits_rs).unwrap());
-    let mut methods_output = BufWriter::new(File::create(&bindings_methods_rs).unwrap());
+    {
+        let mut output = BufWriter::new(File::create(&output_rs).unwrap());
 
-    // gdnative-core already implements all dependencies of Object
-    let to_ignore = { strongly_connected_components(&Api::new(), "Object", None) };
+        // gdnative-core already implements all dependencies of Object
+        let to_ignore = strongly_connected_components(&Api::new(), "Object", None);
 
-    generate_bindings(
-        &mut types_output,
-        &mut traits_output,
-        &mut methods_output,
-        Some(to_ignore),
-    )
-    .unwrap();
+        let code = generate_bindings(Some(to_ignore));
+        write!(&mut output, "{}", code).unwrap();
+    }
 
-    drop(types_output);
-    drop(traits_output);
-    drop(methods_output);
-
-    for file in &[bindings_types_rs, bindings_traits_rs, bindings_methods_rs] {
-        print!(
-            "Formatting generated file: {}... ",
-            file.file_name().map(|s| s.to_str()).flatten().unwrap()
-        );
-        match Command::new("rustup")
-            .arg("run")
-            .arg("stable")
-            .arg("rustfmt")
-            .arg("--edition=2018")
-            .arg(file)
-            .output()
-        {
-            Ok(_) => println!("Done"),
-            Err(err) => {
-                println!("Failed");
-                println!("Error: {}", err);
-            }
+    print!(
+        "Formatting generated file: {}... ",
+        output_rs.file_name().map(|s| s.to_str()).flatten().unwrap()
+    );
+    match Command::new("rustup")
+        .arg("run")
+        .arg("stable")
+        .arg("rustfmt")
+        .arg("--edition=2018")
+        .arg(output_rs)
+        .output()
+    {
+        Ok(_) => println!("Done"),
+        Err(err) => {
+            println!("Failed");
+            println!("Error: {}", err);
         }
     }
 }

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -15,6 +15,4 @@ use libc;
 use std::ops::*;
 use std::sync::Once;
 
-include!(concat!(env!("OUT_DIR"), "/bindings_types.rs"));
-include!(concat!(env!("OUT_DIR"), "/bindings_traits.rs"));
-include!(concat!(env!("OUT_DIR"), "/bindings_methods.rs"));
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -30,3 +30,4 @@ parking_lot = { version = "0.9.0", optional = true }
 
 [build-dependencies]
 gdnative_bindings_generator = { path = "../bindings_generator", version = "0.8.1" }
+quote = "1.0.2"

--- a/gdnative-core/build.rs
+++ b/gdnative-core/build.rs
@@ -1,38 +1,31 @@
 use gdnative_bindings_generator::*;
+
+use quote::quote;
+
 use std::env;
 use std::fs::File;
+use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let core_types_rs = out_path.join("core_types.rs");
-    let core_traits_rs = out_path.join("core_traits.rs");
-    let core_methods_rs = out_path.join("core_methods.rs");
+    let generated_rs = out_path.join("generated.rs");
 
-    let mut types_output = File::create(&core_types_rs).unwrap();
-    let mut traits_output = File::create(&core_traits_rs).unwrap();
-    let mut methods_output = File::create(&core_methods_rs).unwrap();
+    {
+        let mut output = File::create(&generated_rs).unwrap();
 
-    let classes = strongly_connected_components(&Api::new(), "Object", None);
+        let classes = strongly_connected_components(&Api::new(), "Object", None);
 
-    for class in classes {
-        generate_class(
-            &mut types_output,
-            &mut traits_output,
-            &mut methods_output,
-            &class,
-        )
-        .unwrap();
+        let code = classes.iter().map(|class| generate_class(&class));
+        let code = quote! {
+            #(#code)*
+        };
+        write!(&mut output, "{}", code).unwrap();
     }
 
-    // Close the files
-    drop(types_output);
-    drop(traits_output);
-    drop(methods_output);
-
-    for file in &[core_types_rs, core_traits_rs, core_methods_rs] {
+    for file in &[generated_rs] {
         let output = Command::new("rustup")
             .arg("run")
             .arg("stable")

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)] // because of the generated bindings.
 #![allow(unused_imports)]
 #![allow(unused_unsafe)]
-
 // False positives on generated drops that enforce lifetime
 #![allow(clippy::drop_copy)]
 // Disable non-critical lints for generated code.
@@ -19,6 +18,4 @@ use std::sync::Once;
 use std::os::raw::c_char;
 use std::ptr;
 
-include!(concat!(env!("OUT_DIR"), "/core_types.rs"));
-include!(concat!(env!("OUT_DIR"), "/core_traits.rs"));
-include!(concat!(env!("OUT_DIR"), "/core_methods.rs"));
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));


### PR DESCRIPTION
No passing in the `Write` will make it easier to turn into a macro later, or build a module file per class, etc.