### PR TITLE
Remove `use gdnative::api::Node;` line from sample code in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ In the `src/lib.rs` file should have the following contents:
 
 ```rust
 use gdnative::*;
-use gdnative::api::Node;
 
 /// The HelloWorld "class"
 #[derive(NativeClass)]


### PR DESCRIPTION
With that line present, `cargo build` fails with:

```
   Compiling GDRust v0.1.0 (/home/amey/Developer/GDRust)
error[E0432]: unresolved import `gdnative::api`
 --> src/lib.rs:2:15
  |
2 | use gdnative::api::Node;
  |               ^^^ could not find `api` in `gdnative`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `GDRust`.
```

Without that line, `cargo build` succeeds. The line is also missing from the Crate's README up on https://crates.io/crates/gdnative.