### PR TITLE
Relax version constraint

### DIFF
--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = { version = "0.54.0", default-features = false, features = ["runtime"] }
+bindgen = { version = ">=0.53, <0.55", default-features = false, features = ["runtime"] }
 proc-macro2 = "1.0.6"
 quote = "1.0.2"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Better solution for #431. I have tested compatibility with `opencv`, and bindgen 0.54 causes dependency hell because `clang` which `opencv` uses relies on a different version of `clang-sys` from `bindgen-0.54.0`. Relaxing to `>=0.53, <0.55` should fix the problem.

Note that `bindgen-0.53` introduces a breaking change from `bindgen-0.52`.