### PR TITLE
Semantic revamp of Godot objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ script:
     fi
 
   - if [[ "$CI_STAGE_CARGO_CLIPPY" == "yes" ]]; then
-      cargo clippy --all --all-features;
+      cargo clippy --all --all-features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
     fi
 
   - if [[ "$CI_STAGE_CARGO_TEST" == "yes" ]]; then

--- a/bindings_generator/src/dependency.rs
+++ b/bindings_generator/src/dependency.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 ///
 /// If many classes should be checked, a previous result can be
 /// passed to avoid unnecessary checks.
+#[allow(clippy::implicit_hasher)]
 pub fn strongly_connected_components(
     api: &Api,
     class: &str,

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -25,6 +25,7 @@ use std::io;
 
 pub type GeneratorResult<T = ()> = Result<T, io::Error>;
 
+#[allow(clippy::implicit_hasher)]
 pub fn generate_bindings(ignore: Option<HashSet<String>>) -> TokenStream {
     let to_ignore = ignore.unwrap_or_default();
 
@@ -60,8 +61,8 @@ pub fn generate_class(class_name: &str) -> TokenStream {
 
     let class = api.find_class(class_name);
 
-    if let Some(mut class) = class {
-        generate_class_bindings(&api, &mut class)
+    if let Some(class) = class {
+        generate_class_bindings(&api, &class)
     } else {
         Default::default()
     }
@@ -173,7 +174,7 @@ pub(crate) mod test_prelude {
         ($buffer:ident) => {
             $buffer.flush().unwrap();
             let content = std::str::from_utf8($buffer.get_ref()).unwrap();
-            if let Err(_) = syn::parse_file(&content) {
+            if syn::parse_file(&content).is_err() {
                 let mut code_file = std::env::temp_dir();
                 code_file.set_file_name("bad_code.rs");
                 std::fs::write(&code_file, &content).unwrap();

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -97,7 +97,7 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
     let traits = {
         let object_impl = generate_godot_object_impl(class);
 
-        let free_impl = generate_free_impl(&api, class);
+        let free_impl = generate_queue_free_impl(&api, class);
 
         let base_class = if !class.base_class.is_empty() {
             generate_deref_impl(class)
@@ -105,19 +105,10 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
             Default::default()
         };
 
-        // RefCounted
-        let ref_counted = if class.is_refcounted() {
-            let ref_counted = generate_impl_ref_counted(class);
-            let ref_clone = generate_reference_clone(class);
-            let gen_drop = generate_drop(class);
-
-            quote! {
-                #ref_counted
-                #ref_clone
-                #gen_drop
-            }
+        let mem_type = if class.is_refcounted() {
+            generate_impl_ref_counted(class)
         } else {
-            Default::default()
+            generate_impl_manually_managed(class)
         };
 
         // Instantiable
@@ -126,11 +117,12 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
         } else {
             Default::default()
         };
+
         quote! {
             #object_impl
             #free_impl
             #base_class
-            #ref_counted
+            #mem_type
             #instantiable
         }
     };
@@ -142,7 +134,7 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
         let methods = class
             .methods
             .iter()
-            .map(|method| generate_method_impl(class, method));
+            .map(|method| generate_method_impl(&api, class, method));
 
         quote! {
             #table
@@ -227,7 +219,7 @@ pub(crate) mod test_prelude {
             write!(&mut buffer, "{}", code).unwrap();
             validate_and_clear_buffer!(buffer);
 
-            let code = generate_free_impl(&api, &class);
+            let code = generate_queue_free_impl(&api, &class);
             write!(&mut buffer, "{}", code).unwrap();
             validate_and_clear_buffer!(buffer);
 
@@ -242,12 +234,8 @@ pub(crate) mod test_prelude {
                 let code = generate_impl_ref_counted(&class);
                 write!(&mut buffer, "{}", code).unwrap();
                 validate_and_clear_buffer!(buffer);
-
-                let code = generate_reference_clone(&class);
-                write!(&mut buffer, "{}", code).unwrap();
-                validate_and_clear_buffer!(buffer);
-
-                let code = generate_drop(&class);
+            } else {
+                let code = generate_impl_manually_managed(&class);
                 write!(&mut buffer, "{}", code).unwrap();
                 validate_and_clear_buffer!(buffer);
             }
@@ -265,7 +253,7 @@ pub(crate) mod test_prelude {
             validate_and_clear_buffer!(buffer);
 
             for method in &class.methods {
-                let code = generate_method_impl(&class, method);
+                let code = generate_method_impl(&api, &class, method);
                 write!(&mut buffer, "{}", code).unwrap();
                 validate_and_clear_buffer!(buffer);
             }

--- a/examples/dodge_the_creeps/src/extensions.rs
+++ b/examples/dodge_the_creeps/src/extensions.rs
@@ -2,11 +2,20 @@ use gdnative::api::Node;
 use gdnative::*;
 
 pub trait NodeExt {
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> Option<T>;
+    /// Gets a node at `path`, assumes that it's safe to use, and casts it to `T`.
+    ///
+    /// # Safety
+    ///
+    /// See `Ptr::assume_safe`.
+    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> &T;
 }
 
 impl NodeExt for Node {
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> Option<T> {
-        self.get_node(path.into()).and_then(|node| node.cast())
+    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> &T {
+        self.get_node(path.into())
+            .expect("node should exist")
+            .assume_safe()
+            .cast()
+            .expect("node should be of the correct type")
     }
 }

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -17,64 +17,47 @@ impl HUD {
         });
     }
 
-    fn _init(_owner: CanvasLayer) -> Self {
+    fn _init(_owner: &CanvasLayer) -> Self {
         HUD
     }
 
     #[export]
-    pub unsafe fn show_message(&self, owner: CanvasLayer, text: String) {
-        let message_label: Label = owner
-            .get_typed_node("message_label")
-            .expect("Cannot cast to Label");
-
+    pub fn show_message(&self, owner: &CanvasLayer, text: String) {
+        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
         message_label.set_text(text.into());
         message_label.show();
 
-        owner
-            .get_typed_node::<Timer, _>("message_timer")
-            .expect("Cannot cast to Timer")
-            .start(0.0);
+        let timer: &Timer = unsafe { owner.get_typed_node("message_timer") };
+        timer.start(0.0);
     }
 
-    pub unsafe fn show_game_over(&self, owner: CanvasLayer) {
+    pub fn show_game_over(&self, owner: &CanvasLayer) {
         self.show_message(owner, "Game Over".into());
 
-        let message_label: Label = owner
-            .get_typed_node("message_label")
-            .expect("Cannot cast to Label");
-
+        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
         message_label.set_text("Dodge the\nCreeps!".into());
         message_label.show();
 
-        owner
-            .get_typed_node::<Button, _>("start_button")
-            .expect("Cannot cast to Button")
-            .show();
+        let button: &Button = unsafe { owner.get_typed_node("start_button") };
+        button.show();
     }
 
     #[export]
-    pub unsafe fn update_score(&self, owner: CanvasLayer, score: i64) {
-        owner
-            .get_typed_node::<Label, _>("score_label")
-            .expect("Cannot cast to Label")
-            .set_text(score.to_string().into());
+    pub fn update_score(&self, owner: &CanvasLayer, score: i64) {
+        let label: &Label = unsafe { owner.get_typed_node("score_label") };
+        label.set_text(score.to_string().into());
     }
 
     #[export]
-    unsafe fn on_start_button_pressed(&self, owner: CanvasLayer) {
-        owner
-            .get_typed_node::<Button, _>("start_button")
-            .expect("Cannot cast to Button")
-            .hide();
-
+    fn on_start_button_pressed(&self, owner: &CanvasLayer) {
+        let button: &Button = unsafe { owner.get_typed_node("start_button") };
+        button.hide();
         owner.emit_signal("start_game".into(), &[]);
     }
 
     #[export]
-    unsafe fn on_message_timer_timeout(&self, owner: CanvasLayer) {
-        owner
-            .get_typed_node::<Label, _>("message_label")
-            .expect("Cannot cast to Label")
-            .hide()
+    fn on_message_timer_timeout(&self, owner: &CanvasLayer) {
+        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
+        message_label.hide()
     }
 }

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -34,7 +34,7 @@ const MOB_TYPES: [MobType; 3] = [MobType::Walk, MobType::Swim, MobType::Fly];
 
 #[methods]
 impl Mob {
-    fn _init(_owner: RigidBody2D) -> Self {
+    fn _init(_owner: &RigidBody2D) -> Self {
         Mob {
             min_speed: 150.0,
             max_speed: 250.0,
@@ -42,22 +42,23 @@ impl Mob {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, owner: RigidBody2D) {
+    fn _ready(&mut self, owner: &RigidBody2D) {
         let mut rng = rand::thread_rng();
-        let animated_sprite: AnimatedSprite = owner
-            .get_typed_node("animated_sprite")
-            .expect("Unable to cast to AnimatedSprite");
-
+        let animated_sprite: &AnimatedSprite = unsafe { owner.get_typed_node("animated_sprite") };
         animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str().into())
     }
 
     #[export]
-    unsafe fn on_visibility_screen_exited(&self, owner: RigidBody2D) {
-        owner.queue_free()
+    fn on_visibility_screen_exited(&self, owner: &RigidBody2D) {
+        unsafe {
+            owner.claim().queue_free();
+        }
     }
 
     #[export]
-    unsafe fn on_start_game(&self, owner: RigidBody2D) {
-        owner.queue_free();
+    fn on_start_game(&self, owner: &RigidBody2D) {
+        unsafe {
+            owner.claim().queue_free();
+        }
     }
 }

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -23,7 +23,7 @@ impl Player {
         });
     }
 
-    fn _init(_owner: Area2D) -> Self {
+    fn _init(_owner: &Area2D) -> Self {
         Player {
             speed: 400.0,
             screen_size: Vector2::new(0.0, 0.0),
@@ -31,16 +31,15 @@ impl Player {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, owner: Area2D) {
-        self.screen_size = owner.get_viewport().unwrap().size();
+    fn _ready(&mut self, owner: &Area2D) {
+        let viewport = unsafe { owner.get_viewport().unwrap().assume_safe() };
+        self.screen_size = viewport.size();
         owner.hide();
     }
 
     #[export]
-    unsafe fn _process(&mut self, owner: Area2D, delta: f32) {
-        let animated_sprite: AnimatedSprite = owner
-            .get_typed_node("animated_sprite")
-            .expect("Unable to cast to AnimatedSprite");
+    fn _process(&mut self, owner: &Area2D, delta: f32) {
+        let animated_sprite: &AnimatedSprite = unsafe { owner.get_typed_node("animated_sprite") };
 
         let input = Input::godot_singleton();
         let mut velocity = Vector2::new(0.0, 0.0);
@@ -86,25 +85,23 @@ impl Player {
     }
 
     #[export]
-    unsafe fn on_player_body_entered(&self, owner: Area2D, _body: PhysicsBody2D) {
+    fn on_player_body_entered(&self, owner: &Area2D, _body: Ptr<PhysicsBody2D>) {
         owner.hide();
         owner.emit_signal("hit".into(), &[]);
 
-        let collision_shape: CollisionShape2D = owner
-            .get_typed_node("collision_shape_2d")
-            .expect("Unable to cast to CollisionShape2D");
+        let collision_shape: &CollisionShape2D =
+            unsafe { owner.get_typed_node("collision_shape_2d") };
 
         collision_shape.set_deferred("disabled".into(), true.into());
     }
 
     #[export]
-    pub unsafe fn start(&self, owner: Area2D, pos: Vector2) {
+    pub fn start(&self, owner: &Area2D, pos: Vector2) {
         owner.set_global_position(pos);
         owner.show();
 
-        let collision_shape: CollisionShape2D = owner
-            .get_typed_node("collision_shape_2d")
-            .expect("Unable to cast to CollisionShape2D");
+        let collision_shape: &CollisionShape2D =
+            unsafe { owner.get_typed_node("collision_shape_2d") };
 
         collision_shape.set_disabled(false);
     }

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -7,12 +7,12 @@ struct HelloWorld;
 
 #[gdnative::methods]
 impl HelloWorld {
-    fn _init(_owner: gdnative::api::Node) -> Self {
+    fn _init(_owner: &gdnative::api::Node) -> Self {
         HelloWorld
     }
 
     #[export]
-    fn _ready(&self, _owner: gdnative::api::Node) {
+    fn _ready(&self, _owner: &gdnative::api::Node) {
         godot_print!("hello, world.")
     }
 }

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -4,7 +4,7 @@ extern crate euclid;
 
 use euclid::vec3;
 use gdnative::api::{PackedScene, ResourceLoader, Spatial};
-use gdnative::{GodotString, Variant};
+use gdnative::{GodotObject, GodotString, Ref, Variant};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ManageErrs {
@@ -16,12 +16,9 @@ pub enum ManageErrs {
 #[inherit(Spatial)]
 struct SceneCreate {
     // Store the loaded scene for a very slight performance boost but mostly to show you how.
-    template: Option<PackedScene>,
+    template: Option<Ref<PackedScene>>,
     children_spawned: u32,
 }
-
-// Assume godot objects are safe to Send
-unsafe impl Send for SceneCreate {}
 
 // Demonstrates Scene creation, calling to/from gdscript
 //
@@ -35,7 +32,7 @@ unsafe impl Send for SceneCreate {}
 
 #[gdnative::methods]
 impl SceneCreate {
-    fn _init(_owner: Spatial) -> Self {
+    fn _init(_owner: &Spatial) -> Self {
         SceneCreate {
             template: None, // Have not loaded this template yet.
             children_spawned: 0,
@@ -43,7 +40,7 @@ impl SceneCreate {
     }
 
     #[export]
-    fn _ready(&mut self, _owner: Spatial) {
+    fn _ready(&mut self, _owner: &Spatial) {
         self.template = load_scene("res://Child_scene.tscn");
         match &self.template {
             Some(_scene) => godot_print!("Loaded child scene successfully!"),
@@ -52,7 +49,7 @@ impl SceneCreate {
     }
 
     #[export]
-    unsafe fn spawn_one(&mut self, owner: Spatial, message: GodotString) {
+    fn spawn_one(&mut self, owner: &Spatial, message: GodotString) {
         godot_print!("Called spawn_one({})", message.to_string());
 
         let template = if let Some(template) = &self.template {
@@ -87,7 +84,7 @@ impl SceneCreate {
     }
 
     #[export]
-    unsafe fn remove_one(&mut self, owner: Spatial, str: GodotString) {
+    fn remove_one(&mut self, owner: &Spatial, str: GodotString) {
         godot_print!("Called remove_one({})", str.to_string());
         let num_children = owner.get_child_count();
         if num_children <= 0 {
@@ -99,7 +96,9 @@ impl SceneCreate {
 
         let last_child = owner.get_child(num_children - 1);
         if let Some(node) = last_child {
-            node.queue_free();
+            unsafe {
+                node.queue_free();
+            }
             self.children_spawned -= 1;
         }
 
@@ -111,7 +110,7 @@ fn init(handle: gdnative::init::InitHandle) {
     handle.add_class::<SceneCreate>();
 }
 
-pub fn load_scene(path: &str) -> Option<PackedScene> {
+pub fn load_scene(path: &str) -> Option<Ref<PackedScene>> {
     let scene = ResourceLoader::godot_singleton().load(
         GodotString::from_str(path), // could also use path.into() here
         GodotString::from_str("PackedScene"),
@@ -123,13 +122,14 @@ pub fn load_scene(path: &str) -> Option<PackedScene> {
 
 /// Root here is needs to be the same type (or a parent type) of the node that you put in the child
 ///   scene as the root. For instance Spatial is used for this example.
-unsafe fn instance_scene<Root>(scene: &PackedScene) -> Result<Root, ManageErrs>
+fn instance_scene<Root>(scene: &PackedScene) -> Result<&Root, ManageErrs>
 where
     Root: gdnative::GodotObject,
 {
     let inst_option = scene.instance(0); // 0 - GEN_EDIT_STATE_DISABLED
 
     if let Some(instance) = inst_option {
+        let instance = unsafe { instance.assume_safe() };
         if let Some(instance_root) = instance.cast::<Root>() {
             Ok(instance_root)
         } else {
@@ -140,15 +140,19 @@ where
     }
 }
 
-unsafe fn update_panel(owner: Spatial, num_children: i64) {
+fn update_panel(owner: &Spatial, num_children: i64) {
     // Here is how we call into the panel. First we get its node (we might have saved it
     //   from earlier)
-    let panel_node_opt = owner
-        .get_parent()
-        .and_then(|parent| parent.find_node(GodotString::from_str("Panel"), true, false));
+    let panel_node_opt = owner.get_parent().and_then(|parent| {
+        let parent = unsafe { parent.assume_safe() };
+        parent.find_node(GodotString::from_str("Panel"), true, false)
+    });
+
     if let Some(panel_node) = panel_node_opt {
+        let panel_node = unsafe { panel_node.assume_safe() };
+
         // Put the Node
-        let mut as_variant = Variant::from_object(&panel_node);
+        let mut as_variant = Variant::from_object(panel_node);
         match as_variant.call(
             &GodotString::from_str("set_num_children"),
             &[Variant::from_u64(num_children as u64)],

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -6,7 +6,7 @@ use gdnative::init::property::{EnumHint, IntHint, StringHint};
 
 #[derive(gdnative::NativeClass)]
 #[inherit(MeshInstance)]
-#[register_with(my_register_function)]
+#[register_with(register_properties)]
 struct RustTest {
     start: gdnative::Vector3,
     time: f32,
@@ -14,7 +14,7 @@ struct RustTest {
     rotate_speed: f64,
 }
 
-fn my_register_function(builder: &gdnative::init::ClassBuilder<RustTest>) {
+fn register_properties(builder: &gdnative::init::ClassBuilder<RustTest>) {
     builder
         .add_property::<String>("test/test_enum")
         .with_hint(StringHint::Enum(EnumHint::new(vec![
@@ -39,7 +39,7 @@ fn my_register_function(builder: &gdnative::init::ClassBuilder<RustTest>) {
 
 #[gdnative::methods]
 impl RustTest {
-    fn _init(_owner: MeshInstance) -> Self {
+    fn _init(_owner: &MeshInstance) -> Self {
         RustTest {
             start: gdnative::Vector3::new(0.0, 0.0, 0.0),
             time: 0.0,
@@ -48,18 +48,12 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _ready(&mut self, owner: MeshInstance) {
+    fn _ready(&mut self, owner: &MeshInstance) {
         owner.set_physics_process(true);
-        self.start = owner.translation();
-        godot_warn!("Start: {:?}", self.start);
-        godot_warn!(
-            "Parent name: {:?}",
-            owner.get_parent().expect("Missing parent").name()
-        );
     }
 
     #[export]
-    unsafe fn _physics_process(&mut self, owner: MeshInstance, delta: f64) {
+    fn _physics_process(&mut self, owner: &MeshInstance, delta: f64) {
         use gdnative::{api::SpatialMaterial, Color, Vector3};
 
         self.time += delta as f32;

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -6,10 +6,11 @@
 // Disable non-critical lints for generated code.
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
-pub use gdnative_core::*;
-
-use crate::private::get_api;
-use crate::sys;
+use gdnative_core::object::{self, PersistentRef};
+use gdnative_core::private::get_api;
+use gdnative_core::sys;
+use gdnative_core::sys::GodotApi;
+use gdnative_core::*;
 
 use libc;
 use std::ops::*;

--- a/gdnative-core/src/core_types/access.rs
+++ b/gdnative-core/src/core_types/access.rs
@@ -287,6 +287,8 @@ mod tests {
             let mut write = access.into_owned();
             let slice = write.as_mut_slice();
             assert_eq!(8, slice.len());
+
+            #[allow(clippy::needless_range_loop)]
             for i in 0..8 {
                 slice[i] = (i * 2) as i64;
             }

--- a/gdnative-core/src/core_types/byte_array.rs
+++ b/gdnative-core/src/core_types/byte_array.rs
@@ -5,7 +5,7 @@ pub type ByteArray = TypedArray<u8>;
 
 godot_test!(
     test_byte_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = (0..8).collect::<ByteArray>();
 

--- a/gdnative-core/src/core_types/color_array.rs
+++ b/gdnative-core/src/core_types/color_array.rs
@@ -6,7 +6,7 @@ pub type ColorArray = TypedArray<Color>;
 
 godot_test!(
     test_color_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = ColorArray::from_vec(vec![
             Color::rgb(1.0, 0.0, 0.0),

--- a/gdnative-core/src/core_types/dictionary.rs
+++ b/gdnative-core/src/core_types/dictionary.rs
@@ -5,7 +5,7 @@ use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
 
-use crate::RefCounted;
+use crate::NewRef;
 use crate::ToVariant;
 use crate::ToVariantEq;
 use crate::Variant;
@@ -299,7 +299,7 @@ impl Default for Dictionary<Shared> {
     }
 }
 
-impl RefCounted for Dictionary<Shared> {
+impl NewRef for Dictionary<Shared> {
     #[inline]
     fn new_ref(&self) -> Self {
         unsafe {

--- a/gdnative-core/src/core_types/float32_array.rs
+++ b/gdnative-core/src/core_types/float32_array.rs
@@ -5,7 +5,7 @@ pub type Float32Array = TypedArray<f32>;
 
 godot_test!(
     test_float32_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = (0..8).map(|i| i as f32).collect::<Float32Array>();
 

--- a/gdnative-core/src/core_types/int32_array.rs
+++ b/gdnative-core/src/core_types/int32_array.rs
@@ -5,7 +5,7 @@ pub type Int32Array = TypedArray<i32>;
 
 godot_test!(
     test_int32_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = (0..8).collect::<Int32Array>();
 

--- a/gdnative-core/src/core_types/node_path.rs
+++ b/gdnative-core/src/core_types/node_path.rs
@@ -1,7 +1,7 @@
 use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
-use crate::RefCounted;
+use crate::NewRef;
 use std::fmt;
 
 /// A reference-counted relative or absolute path in a scene tree, for use with `Node.get_node()` and similar
@@ -159,7 +159,7 @@ impl_basic_traits_as_sys!(
     for NodePath as godot_node_path {
         Drop => godot_node_path_destroy;
         Eq => godot_node_path_operator_equal;
-        RefCounted => godot_node_path_new_copy;
+        NewRef => godot_node_path_new_copy;
     }
 );
 

--- a/gdnative-core/src/core_types/rid.rs
+++ b/gdnative-core/src/core_types/rid.rs
@@ -16,22 +16,22 @@ impl Rid {
     }
 
     #[inline]
-    pub fn get_id(&self) -> i32 {
+    pub fn get_id(self) -> i32 {
         unsafe { (get_api().godot_rid_get_id)(&self.0) }
     }
 
     #[inline]
-    pub fn operator_less(&self, b: &Rid) -> bool {
+    pub fn operator_less(self, b: Rid) -> bool {
         unsafe { (get_api().godot_rid_operator_less)(&self.0, &b.0) }
     }
 
     #[inline]
-    pub fn is_valid(&self) -> bool {
+    pub fn is_valid(self) -> bool {
         self.to_u64() != 0
     }
 
     #[inline]
-    fn to_u64(&self) -> u64 {
+    fn to_u64(self) -> u64 {
         unsafe {
             // std::mem::transmute needs source and destination types to have the same size. On 32
             // bit systems sizeof(void *) != size_of<u64>() so this fails to compile. The bindings
@@ -43,7 +43,7 @@ impl Rid {
 
     #[doc(hidden)]
     #[inline]
-    pub fn sys(&self) -> *const sys::godot_rid {
+    pub fn sys(self) -> *const sys::godot_rid {
         &self.0
     }
 

--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -1,6 +1,6 @@
 use crate::private::get_api;
 use crate::sys;
-use crate::RefCounted;
+use crate::NewRef;
 
 use std::cmp::Ordering;
 use std::ffi::CStr;
@@ -219,7 +219,7 @@ impl_basic_traits_as_sys!(
         Drop => godot_string_destroy;
         Eq => godot_string_operator_equal;
         Default => godot_string_new;
-        RefCounted => godot_string_new_copy;
+        NewRef => godot_string_new_copy;
     }
 );
 

--- a/gdnative-core/src/core_types/string_array.rs
+++ b/gdnative-core/src/core_types/string_array.rs
@@ -6,7 +6,7 @@ pub type StringArray = TypedArray<GodotString>;
 
 godot_test!(
     test_string_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = StringArray::from_vec(vec![
             GodotString::from("foo"),

--- a/gdnative-core/src/core_types/typed_array.rs
+++ b/gdnative-core/src/core_types/typed_array.rs
@@ -6,7 +6,7 @@ use gdnative_impl_proc_macros as macros;
 
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::private::get_api;
-use crate::RefCounted;
+use crate::NewRef;
 use crate::{Color, GodotString, VariantArray, Vector2, Vector2Godot, Vector3, Vector3Godot};
 
 /// A reference-counted CoW typed vector using Godot's pool allocator, generic over possible
@@ -59,7 +59,7 @@ impl<T: Element> Clone for TypedArray<T> {
     }
 }
 
-impl<T: Element> RefCounted for TypedArray<T> {
+impl<T: Element> NewRef for TypedArray<T> {
     /// Creates a new reference to this reference-counted instance.
     #[inline]
     fn new_ref(&self) -> Self {

--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use crate::private::get_api;
 use crate::sys;
 
-use crate::RefCounted;
+use crate::NewRef;
 use crate::ToVariant;
 use crate::Variant;
 
@@ -332,7 +332,7 @@ impl Default for VariantArray<Shared> {
     }
 }
 
-impl RefCounted for VariantArray<Shared> {
+impl NewRef for VariantArray<Shared> {
     #[inline]
     fn new_ref(&self) -> Self {
         unsafe {

--- a/gdnative-core/src/core_types/vector2_array.rs
+++ b/gdnative-core/src/core_types/vector2_array.rs
@@ -6,7 +6,7 @@ pub type Vector2Array = TypedArray<Vector2>;
 
 godot_test!(
     test_vector2_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = Vector2Array::from_vec(vec![
             Vector2::new(1.0, 2.0),

--- a/gdnative-core/src/core_types/vector3_array.rs
+++ b/gdnative-core/src/core_types/vector3_array.rs
@@ -6,7 +6,7 @@ pub type Vector3Array = TypedArray<Vector3>;
 
 godot_test!(
     test_vector3_array_access {
-        use crate::RefCounted as _;
+        use crate::NewRef as _;
 
         let arr = Vector3Array::from_vec(vec![
             Vector3::new(1.0, 2.0, 3.0),

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 use super::*;
+use crate::object::{self, PersistentRef};
 use crate::private::get_api;
 use crate::sys;
 use crate::sys::GodotApi;

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -263,9 +263,9 @@ macro_rules! impl_basic_trait_as_sys {
     };
 
     (
-        RefCounted for $Type:ty as $GdType:ident : $gd_method:ident
+        NewRef for $Type:ty as $GdType:ident : $gd_method:ident
     ) => {
-        impl RefCounted for $Type {
+        impl NewRef for $Type {
             #[inline]
             fn new_ref(&self) -> $Type {
                 unsafe {

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -64,7 +64,7 @@ impl InitHandle {
 
     /// Registers a new class to the engine.
     #[inline]
-    pub fn add_class<C>(&self)
+    pub fn add_class<C>(self)
     where
         C: NativeClassMethods,
     {
@@ -73,7 +73,7 @@ impl InitHandle {
 
     /// Registers a new tool class to the engine.
     #[inline]
-    pub fn add_tool_class<C>(&self)
+    pub fn add_tool_class<C>(self)
     where
         C: NativeClassMethods,
     {
@@ -81,7 +81,7 @@ impl InitHandle {
     }
 
     #[inline]
-    fn add_maybe_tool_class<C>(&self, is_tool: bool)
+    fn add_maybe_tool_class<C>(self, is_tool: bool)
     where
         C: NativeClassMethods,
     {

--- a/gdnative-core/src/nativescript/init/property.rs
+++ b/gdnative-core/src/nativescript/init/property.rs
@@ -1,7 +1,5 @@
 //! Property registration.
 
-use std::mem;
-
 use crate::nativescript::{Instance, NativeClass};
 use crate::object::{GodotObject, RefCounted};
 use crate::private::get_api;
@@ -311,8 +309,8 @@ bitflags::bitflags! {
 
 impl Usage {
     #[inline]
-    pub fn to_sys(&self) -> sys::godot_property_usage_flags {
-        unsafe { mem::transmute(*self) }
+    pub fn to_sys(self) -> sys::godot_property_usage_flags {
+        self.bits() as sys::godot_property_usage_flags
     }
 }
 

--- a/gdnative-core/src/nativescript/init/property.rs
+++ b/gdnative-core/src/nativescript/init/property.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use crate::nativescript::{Instance, NativeClass};
-use crate::object::GodotObject;
+use crate::object::{GodotObject, RefCounted};
 use crate::private::get_api;
 use crate::*;
 
@@ -427,9 +427,20 @@ mod impl_export {
         }
     }
 
-    impl<T> Export for T
+    impl<T> Export for Ref<T>
     where
-        T: GodotObject + ToVariant,
+        T: GodotObject + RefCounted,
+    {
+        type Hint = ();
+        #[inline]
+        fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
+            ExportInfo::resource_type::<T>()
+        }
+    }
+
+    impl<T> Export for Ptr<T>
+    where
+        T: GodotObject + ManuallyManaged,
     {
         type Hint = ();
         #[inline]
@@ -441,7 +452,7 @@ mod impl_export {
     impl<T> Export for Instance<T>
     where
         T: NativeClass,
-        T::Base: ToVariant,
+        Instance<T>: ToVariant,
     {
         type Hint = ();
         #[inline]

--- a/gdnative-core/src/nativescript/init/property/accessor.rs
+++ b/gdnative-core/src/nativescript/init/property/accessor.rs
@@ -1,13 +1,13 @@
 //! Types and traits for property accessors.
-
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 
 use crate::nativescript::user_data::UserData;
 use crate::nativescript::Map;
 use crate::nativescript::MapMut;
 use crate::nativescript::NativeClass;
-use crate::object::GodotObject;
+use crate::object::{GodotObject, RawObject};
 use crate::*;
 
 mod invalid;
@@ -70,18 +70,24 @@ pub struct Mut;
 /// Helper trait for setters, generic over `self` argument mutability.
 pub trait MapSet<C: NativeClass, F, T> {
     type Err: Debug;
-    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err>;
+    fn map_set(user_data: &C::UserData, op: &F, owner: &C::Base, value: T)
+        -> Result<(), Self::Err>;
 }
 
 impl<C, F, T> MapSet<C, F, T> for Shr
 where
     C: NativeClass,
     C::UserData: Map,
-    F: 'static + Fn(&C, C::Base, T),
+    F: 'static + Fn(&C, &C::Base, T),
 {
     type Err = <C::UserData as Map>::Err;
     #[inline]
-    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err> {
+    fn map_set(
+        user_data: &C::UserData,
+        op: &F,
+        owner: &C::Base,
+        value: T,
+    ) -> Result<(), Self::Err> {
         user_data.map(|rust_ty| op(rust_ty, owner, value))
     }
 }
@@ -90,11 +96,16 @@ impl<C, F, T> MapSet<C, F, T> for Mut
 where
     C: NativeClass,
     C::UserData: MapMut,
-    F: 'static + Fn(&mut C, C::Base, T),
+    F: 'static + Fn(&mut C, &C::Base, T),
 {
     type Err = <C::UserData as MapMut>::Err;
     #[inline]
-    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err> {
+    fn map_set(
+        user_data: &C::UserData,
+        op: &F,
+        owner: &C::Base,
+        value: T,
+    ) -> Result<(), Self::Err> {
         user_data.map_mut(|rust_ty| op(rust_ty, owner, value))
     }
 }
@@ -107,7 +118,7 @@ pub struct Ref;
 /// Helper trait for setters, generic over `self` argument mutability and return kind.
 pub trait MapGet<C: NativeClass, F, T> {
     type Err: Debug;
-    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err>;
+    fn map_get(user_data: &C::UserData, op: &F, owner: &C::Base) -> Result<Variant, Self::Err>;
 }
 
 impl<C, F, T> MapGet<C, F, T> for (Shr, Owned)
@@ -115,11 +126,11 @@ where
     C: NativeClass,
     C::UserData: Map,
     T: ToVariant,
-    F: 'static + Fn(&C, C::Base) -> T,
+    F: 'static + Fn(&C, &C::Base) -> T,
 {
     type Err = <C::UserData as Map>::Err;
     #[inline]
-    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+    fn map_get(user_data: &C::UserData, op: &F, owner: &C::Base) -> Result<Variant, Self::Err> {
         user_data.map(|rust_ty| op(rust_ty, owner).to_variant())
     }
 }
@@ -129,11 +140,11 @@ where
     C: NativeClass,
     C::UserData: Map,
     T: ToVariant,
-    F: 'static + Fn(&C, C::Base) -> &T,
+    F: 'static + for<'r> Fn(&'r C, &C::Base) -> &'r T,
 {
     type Err = <C::UserData as Map>::Err;
     #[inline]
-    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+    fn map_get(user_data: &C::UserData, op: &F, owner: &C::Base) -> Result<Variant, Self::Err> {
         user_data.map(|rust_ty| op(rust_ty, owner).to_variant())
     }
 }
@@ -143,11 +154,11 @@ where
     C: NativeClass,
     C::UserData: MapMut,
     T: ToVariant,
-    F: 'static + Fn(&mut C, C::Base) -> T,
+    F: 'static + Fn(&mut C, &C::Base) -> T,
 {
     type Err = <C::UserData as MapMut>::Err;
     #[inline]
-    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+    fn map_get(user_data: &C::UserData, op: &F, owner: &C::Base) -> Result<Variant, Self::Err> {
         user_data.map_mut(|rust_ty| op(rust_ty, owner).to_variant())
     }
 }
@@ -157,11 +168,11 @@ where
     C: NativeClass,
     C::UserData: MapMut,
     T: ToVariant,
-    F: 'static + Fn(&mut C, C::Base) -> &T,
+    F: 'static + for<'r> Fn(&'r mut C, &C::Base) -> &'r T,
 {
     type Err = <C::UserData as MapMut>::Err;
     #[inline]
-    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+    fn map_get(user_data: &C::UserData, op: &F, owner: &C::Base) -> Result<Variant, Self::Err> {
         user_data.map_mut(|rust_ty| op(rust_ty, owner).to_variant())
     }
 }
@@ -196,9 +207,20 @@ where
                 return;
             }
 
+            let this = match NonNull::new(this) {
+                Some(this) => this,
+                None => {
+                    godot_error!(
+                        "gdnative-core: owner pointer for {} is null",
+                        C::class_name(),
+                    );
+                    return;
+                }
+            };
+
             let result = std::panic::catch_unwind(|| unsafe {
                 let user_data = C::UserData::clone_from_user_data_unchecked(class as *const _);
-                let owner = C::Base::from_sys(this);
+                let owner = C::Base::cast_ref(RawObject::from_sys_ref_unchecked(this));
                 let func = &*(method as *const F);
 
                 match T::from_variant(Variant::cast_ref(val)) {
@@ -260,9 +282,20 @@ where
                 return Variant::new().forget();
             }
 
+            let this = match NonNull::new(this) {
+                Some(this) => this,
+                None => {
+                    godot_error!(
+                        "gdnative-core: owner pointer for {} is null",
+                        C::class_name(),
+                    );
+                    return Variant::new().forget();
+                }
+            };
+
             let result = std::panic::catch_unwind(|| unsafe {
                 let user_data = C::UserData::clone_from_user_data_unchecked(class as *const _);
-                let owner = C::Base::from_sys(this);
+                let owner = C::Base::cast_ref(RawObject::from_sys_ref_unchecked(this));
                 let func = &*(method as *const F);
 
                 match <(SelfArg, RetKind)>::map_get(&user_data, func, owner) {

--- a/gdnative-core/src/nativescript/init/property/hint.rs
+++ b/gdnative-core/src/nativescript/init/property/hint.rs
@@ -72,8 +72,7 @@ where
     }
 
     /// Formats the hint as a Godot hint string.
-    #[inline]
-    pub fn to_godot_hint_string(&self) -> GodotString {
+    fn to_godot_hint_string(&self) -> GodotString {
         let mut s = String::new();
 
         write!(s, "{},{}", self.min, self.max).unwrap();
@@ -127,8 +126,7 @@ impl EnumHint {
     }
 
     /// Formats the hint as a Godot hint string.
-    #[inline]
-    pub fn to_godot_hint_string(&self) -> GodotString {
+    fn to_godot_hint_string(&self) -> GodotString {
         let mut s = String::new();
 
         let mut iter = self.values.iter();
@@ -242,8 +240,7 @@ impl ExpEasingHint {
     }
 
     /// Formats the hint as a Godot hint string.
-    #[inline]
-    pub fn to_godot_hint_string(&self) -> GodotString {
+    fn to_godot_hint_string(self) -> GodotString {
         let mut s = String::new();
 
         if self.is_attenuation {

--- a/gdnative-core/src/new_ref.rs
+++ b/gdnative-core/src/new_ref.rs
@@ -1,5 +1,5 @@
 /// A trait for incrementing the reference count to a Godot object.
-pub trait RefCounted {
+pub trait NewRef {
     /// Creates a new reference to the underlying object.
     fn new_ref(&self) -> Self;
 }

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -1,6 +1,17 @@
+use std::fmt::{self, Debug};
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::{self, NonNull};
+
+use crate::private::get_api;
 use crate::sys;
+use crate::GodotString;
 use crate::ObjectMethodTable;
-use std::ptr;
+use crate::ToVariant;
+
+#[cfg(feature = "nativescript")]
+use crate::nativescript::{Instance, NativeClass, RefInstance};
 
 /// Trait for Godot API objects. This trait is sealed, and implemented for generated wrapper
 /// types.
@@ -9,20 +20,49 @@ use std::ptr;
 ///
 /// The `cast` method on Godot object types is only for conversion between engine types.
 /// To downcast a `NativeScript` type from its base type, see `Instance::try_from_base`.
-pub unsafe trait GodotObject: crate::private::godot_object::Sealed {
-    fn class_name() -> &'static str;
-    #[doc(hidden)]
-    unsafe fn to_sys(&self) -> *mut sys::godot_object;
-    #[doc(hidden)]
-    unsafe fn from_sys(obj: *mut sys::godot_object) -> Self;
+pub unsafe trait GodotObject:
+    Sized + ToVariant + crate::private::godot_object::Sealed
+{
+    /// The "persistent" form of this type. For reference-counted classes, this is `Ref<Self>`.
+    /// For manually-managed classes, this is `Ptr<Self>` instead.
+    type PersistentRef: PersistentRef<Target = Self>;
 
-    /// Convert from a pointer returned from a ptrcall. For reference-counted types, this takes
-    /// the ownership of the returned reference, in Rust parlance. For non-reference-counted
-    /// types, its behavior should be exactly the same as `from_sys`. This is needed for
-    /// reference-counted types to be properly freed, since any references returned from
-    /// ptrcalls are leaked in the process of being cast into a pointer.
+    fn class_name() -> &'static str;
+
+    /// Performs a dynamic reference cast to target type.
+    #[inline]
+    fn cast<T: GodotObject>(&self) -> Option<&T> {
+        self.as_raw().cast().map(T::cast_ref)
+    }
+
+    /// Convenience method to downcast to `RefInstance` where `self` is the base object.
+    #[inline]
+    #[cfg(feature = "nativescript")]
+    fn cast_instance<T>(&self) -> Option<RefInstance<'_, T>>
+    where
+        T: NativeClass<Base = Self>,
+    {
+        RefInstance::try_from_base(self)
+    }
+
+    /// Creates a reference to `Self` given a `RawObject` reference.
     #[doc(hidden)]
-    unsafe fn from_return_position_sys(obj: *mut sys::godot_object) -> Self;
+    #[inline]
+    fn cast_ref(raw: &RawObject<Self>) -> &Self {
+        unsafe { &*(raw as *const _ as *const _) }
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    fn as_raw(&self) -> &RawObject<Self> {
+        unsafe { &*(self as *const _ as *const _) }
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    fn as_ptr(&self) -> *mut sys::godot_object {
+        self.as_raw().sys().as_ptr()
+    }
 
     /// Creates a wrapper around the same Godot object that has `'static` lifetime.
     ///
@@ -31,31 +71,73 @@ pub unsafe trait GodotObject: crate::private::godot_object::Sealed {
     /// that extend `Reference`, this increments the reference count. For manually-managed types,
     /// including all classes that inherit `Node`, this creates an alias.
     #[inline]
-    fn claim(&self) -> Self
+    fn claim(&self) -> Self::PersistentRef
     where
         Self: Sized,
     {
-        unsafe { Self::from_sys(self.to_sys()) }
+        unsafe { Self::PersistentRef::from_sys(self.as_raw().sys()) }
     }
+}
+
+/// Marker trait for reference-counted Godot API objects.
+pub unsafe trait RefCounted: GodotObject {}
+
+/// Marker trait for manually-managed Godot API objects.
+pub unsafe trait ManuallyManaged: GodotObject {}
+
+/// Trait for persistent references to Godot API objects. This trait is sealed and meant to be
+/// an internal interface.
+pub trait PersistentRef: Clone + Debug + ToVariant + private::Sealed {
+    type Target;
+
+    #[doc(hidden)]
+    fn sys(&self) -> *mut sys::godot_object;
+
+    /// Convert to a `RawObject` reference.
+    ///
+    /// # Safety
+    ///
+    /// `self` must point to a valid object of the correct type.
+    #[doc(hidden)]
+    unsafe fn as_raw(&self) -> &RawObject<Self::Target>;
+
+    /// Convert from a raw pointer, incrementing the reference counter if reference-counted.
+    ///
+    /// # Safety
+    ///
+    /// `obj` must point to a valid object of the correct type.
+    #[doc(hidden)]
+    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self;
+
+    /// Convert from a pointer returned from a ptrcall. For reference-counted types, this takes
+    /// the ownership of the returned reference, in Rust parlance. For non-reference-counted
+    /// types, its behavior should be exactly the same as `from_sys`. This is needed for
+    /// reference-counted types to be properly freed, since any references returned from
+    /// ptrcalls are leaked in the process of being cast into a pointer.
+    ///
+    /// # Safety
+    ///
+    /// `obj` must point to a valid object of the correct type.
+    #[doc(hidden)]
+    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self;
+
+    /// Convert from a pointer returned from a constructor of a reference-counted type. For
+    /// non-reference-counted types, its behavior should be exactly the same as `from_sys`.
+    ///
+    /// # Safety
+    ///
+    /// `obj` must point to a valid object of the correct type, and must be the only reference.
+    #[doc(hidden)]
+    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self;
 }
 
 /// GodotObjects that have a zero argument constructor.
 pub trait Instanciable: GodotObject {
-    fn construct() -> Self;
+    fn construct() -> Self::PersistentRef;
 }
 
-/// Manually managed Godot classes implementing `free`.
-pub trait Free: GodotObject {
-    /// Deallocate the object.
-    ///
-    /// # Safety
-    ///
-    /// When this function is called no references to this
-    /// object must be held and dereferenced.
-    unsafe fn godot_free(self);
-}
-
-/// Manually managed Godot classes implementing `queue_free`.
+/// Manually managed Godot classes implementing `queue_free`. This trait has no public
+/// interface. See `Ptr::queue_free`.
 pub trait QueueFree: GodotObject {
     /// Deallocate the object in the near future.
     ///
@@ -63,89 +145,610 @@ pub trait QueueFree: GodotObject {
     ///
     /// When this function is dequeued no references to this
     /// object must be held and dereferenced.
-    unsafe fn godot_queue_free(&mut self);
+    #[doc(hidden)]
+    unsafe fn godot_queue_free(sys: *mut sys::godot_object);
 }
 
-/// Increase the reference count of the object.
+/// A pointer to a manually-managed Godot object. This is semantically equivalent to a non-null
+/// raw pointer, except that it also implements `Send` and `Sync`.
 ///
-/// # Safety
-///
-/// This function assumes the godot_object is reference counted.
-#[inline]
-pub unsafe fn add_ref(obj: *mut sys::godot_object) {
-    use crate::ReferenceMethodTable;
-    let api = crate::private::get_api();
-    let addref_method = ReferenceMethodTable::get(api).reference;
-    let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-    let mut ok = false;
-    let ok_ptr = &mut ok as *mut bool;
-    (api.godot_method_bind_ptrcall)(
-        addref_method,
-        obj,
-        argument_buffer.as_mut_ptr() as *mut _,
-        ok_ptr as *mut _,
-    );
-
-    // If this assertion blows up it means there is a reference counting bug
-    // and we tried to increment the ref count of a dead object (who's ref
-    // count is equal to zero).
-    debug_assert!(ok);
+/// It's impossible to call API methods directly on `Ptr`s. In order to obtain a safe view
+/// to the underlying object, see the `assume_safe` and `assume_safe_during` methods and follow
+/// the safety guidelines there.
+pub struct Ptr<T: GodotObject + ManuallyManaged> {
+    ptr: NonNull<sys::godot_object>,
+    _marker: PhantomData<*const T>,
 }
 
-/// Decrease the reference count of the object.
-///
-/// # Safety
-///
-/// This function assumes the godot_object is reference counted.
-#[inline]
-pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
-    use crate::ReferenceMethodTable;
-    let api = crate::private::get_api();
-    let unref_method = ReferenceMethodTable::get(api).unreference;
-    let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-    let mut last_reference = false;
-    let ret_ptr = &mut last_reference as *mut bool;
-    (api.godot_method_bind_ptrcall)(
-        unref_method,
-        obj,
-        argument_buffer.as_mut_ptr() as *mut _,
-        ret_ptr as *mut _,
-    );
+unsafe impl<T: GodotObject + ManuallyManaged> Send for Ptr<T> {}
+unsafe impl<T: GodotObject + ManuallyManaged> Sync for Ptr<T> {}
 
-    last_reference
+impl<T: GodotObject + ManuallyManaged> Copy for Ptr<T> {}
+impl<T: GodotObject + ManuallyManaged> Clone for Ptr<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Ptr {
+            ptr: self.ptr,
+            _marker: PhantomData,
+        }
+    }
 }
 
-/// Initialise the reference count of the object.
-///
-/// # Safety
-///
-/// This function assumes the godot_object is reference counted
-/// and that no other references are held at the time.
-#[inline]
-pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
-    use crate::ReferenceMethodTable;
-    let api = crate::private::get_api();
-    let init_method = ReferenceMethodTable::get(api).init_ref;
-    let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-    let mut ok = false;
-    let ret_ptr = &mut ok as *mut bool;
-    (api.godot_method_bind_ptrcall)(
-        init_method,
-        obj,
-        argument_buffer.as_mut_ptr() as *mut _,
-        ret_ptr as *mut _,
-    );
-
-    debug_assert!(ok);
+impl<T: GodotObject<PersistentRef = Self> + ManuallyManaged + Instanciable> Ptr<T> {
+    /// Creates a new instance of `T`.
+    ///
+    /// The lifetime of the returned object is *not* automatically managed.
+    ///
+    /// Immediately after creation, the object is owned by the caller, and can be
+    /// passed to the engine (in which case the engine will be responsible for
+    /// destroying the object) or destroyed manually using `Ptr::free`, or preferably
+    /// `Ptr::queue_free` if it is a `Node`.
+    #[inline]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        T::construct()
+    }
 }
 
-/// Checks whether the object is of a certain Godot class.
+impl<T: GodotObject + ManuallyManaged> Ptr<T> {
+    unsafe fn as_raw<'a>(self) -> &'a RawObject<T> {
+        RawObject::from_sys_ref_unchecked(self.ptr)
+    }
+
+    /// Returns the underlying raw pointer. This is an internal interface.
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_ptr(self) -> *mut sys::godot_object {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns `true` if the pointer currently points to a valid object of the correct type.
+    /// **This does NOT guarantee that it's safe to use this pointer.**
+    ///
+    /// # Safety
+    ///
+    /// This thread must have exclusive access to the object during the call.
+    #[inline]
+    pub unsafe fn is_instance_sane(self) -> bool {
+        let api = get_api();
+        if !(api.godot_is_instance_valid)(self.as_ptr()) {
+            return false;
+        }
+
+        self.as_raw().is_class::<T>()
+    }
+
+    /// Assume that `self` is safe to use during the `'a` lifetime. This lifetime is unbounded
+    /// and inferred by the compiler unless given explicitly.
+    ///
+    /// This is guaranteed to be a no-op at runtime if `debug_assertions` is disabled. Runtime
+    /// sanity checks may be added in debug builds to help catch bugs.
+    ///
+    /// # Safety
+    ///
+    /// It's safe to call `assume_safe` only if:
+    ///
+    /// 1. During the entirety of `'a`, the underlying object will always be valid.
+    ///
+    ///     This means that any methods called on the resulting reference will not free it,
+    ///     unless it's the last operation within the lifetime.
+    ///
+    ///     If any script methods are called, the code ran as a consequence will also not free
+    ///     it. This can happen via virtual method calls on other objects, or signals connected
+    ///     in a non-deferred way.
+    ///
+    /// 2. During the entirety of 'a, the thread from which `assume_safe` is called has
+    ///    exclusive access to the underlying object.
+    ///
+    ///     This is because all Godot objects have "interior mutability" in Rust parlance,
+    ///     and can't be shared across threads. The best way to guarantee this is to follow
+    ///     the official [thread-safety guidelines][thread-safety] across the codebase.
+    ///
+    /// Failure to satisfy either of the conditions will lead to undefined behavior.
+    ///
+    /// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
+    #[inline(always)]
+    pub unsafe fn assume_safe<'a>(self) -> &'a T {
+        debug_assert!(
+            self.is_instance_sane(),
+            "assume_safe called on an invalid pointer"
+        );
+        self.assume_safe_unchecked::<'a>()
+    }
+
+    /// Assume that `self` is safe to use during the `'a` lifetime, if a sanity check using
+    /// `is_instance_sane` passed. This lifetime is unbounded and inferred by the compiler
+    /// unless given explicitly.
+    ///
+    /// # Safety
+    ///
+    /// The same safety constraints as `assume_safe` applies. **The sanity check does NOT
+    /// guarantee that the operation is safe.**
+    #[inline]
+    pub unsafe fn assume_safe_if_sane<'a>(self) -> Option<&'a T> {
+        if self.is_instance_sane() {
+            Some(self.assume_safe_unchecked())
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn assume_safe_unchecked<'a>(self) -> &'a T {
+        T::cast_ref(self.as_raw())
+    }
+
+    /// Assume that `self` is safe to use during the lifetime of the input reference. The
+    /// input reference is unused and may be anything. This is a convenience wrapper around
+    /// `assume_safe`.
+    ///
+    /// This is guaranteed to be a no-op at runtime if `debug_assertions` is disabled. Runtime
+    /// sanity checks may be added in debug builds to help catch bugs.
+    ///
+    /// # Safety
+    ///
+    /// The same safety constraints as `assume_safe` applies.
+    #[inline(always)]
+    pub unsafe fn assume_safe_during<'a, L: 'a>(self, _lifetime: &'a L) -> &'a T {
+        self.assume_safe::<'a>()
+    }
+
+    /// Assume that `self` is safe to use during the lifetime of the input reference, if a
+    /// sanity check using `is_instance_sane` passed. The input reference is unused and may
+    /// be anything. This is a convenience wrapper around `assume_safe_if_sane`.
+    ///
+    /// # Safety
+    ///
+    /// The same safety constraints as `assume_safe` applies. **The sanity check does NOT
+    /// guarantee that the operation is safe.**
+    #[inline(always)]
+    pub unsafe fn assume_safe_during_if_sane<'a, L: 'a>(self, _lifetime: &'a L) -> Option<&'a T> {
+        self.assume_safe_if_sane::<'a>()
+    }
+
+    /// Manually frees the object.
+    ///
+    /// # Safety
+    ///
+    /// During the call, the underlying object must be valid, and this thread must have
+    /// exclusive access to the object. This pointer must never be used again.
+    #[inline]
+    pub unsafe fn free(self) {
+        self.as_raw().free();
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged + QueueFree> Ptr<T> {
+    /// Queues the object for deallocation in the near future. This is preferable for `Node`s
+    /// compared to `Ptr::free`.
+    ///
+    /// # Safety
+    ///
+    /// During the call, the underlying object must be valid, and this thread must have
+    /// exclusive access to the object. This pointer must never be used again.
+    #[inline]
+    pub unsafe fn queue_free(self) {
+        T::godot_queue_free(self.as_ptr())
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> private::Sealed for Ptr<T> {}
+impl<T: GodotObject + ManuallyManaged> PersistentRef for Ptr<T> {
+    type Target = T;
+
+    #[inline]
+    fn sys(&self) -> *mut sys::godot_object {
+        self.ptr.as_ptr()
+    }
+
+    #[inline]
+    unsafe fn as_raw(&self) -> &RawObject<Self::Target> {
+        RawObject::from_sys_ref_unchecked(self.ptr)
+    }
+
+    #[inline]
+    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        Ptr {
+            ptr: obj,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        Self::from_sys(obj)
+    }
+
+    #[inline]
+    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        Self::from_sys(obj)
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> Eq for Ptr<T> {}
+impl<T: GodotObject + ManuallyManaged> PartialEq for Ptr<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> Ord for Ptr<T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.ptr.cmp(&other.ptr)
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> PartialOrd for Ptr<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.ptr.partial_cmp(&other.ptr)
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> Hash for Ptr<T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_usize(self.ptr.as_ptr() as usize)
+    }
+}
+
+impl<T: GodotObject + ManuallyManaged> Debug for Ptr<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({:p})", T::class_name(), self.ptr)
+    }
+}
+
+/// A reference to a reference-counted Godot object. This is semantically analogous to a `Rc`
+/// wrapper.
+///
+/// It's possible to call API methods in safe contexts directly on `Ref`.
+pub struct Ref<T: GodotObject + RefCounted> {
+    ptr: NonNull<sys::godot_object>,
+    _marker: PhantomData<*const T>,
+}
+
+impl<T: GodotObject + RefCounted> Deref for Ref<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { T::cast_ref(self.as_raw()) }
+    }
+}
+
+impl<T: GodotObject + RefCounted> AsRef<T> for Ref<T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        unsafe { T::cast_ref(self.as_raw()) }
+    }
+}
+
+impl<T: GodotObject + RefCounted> Clone for Ref<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        unsafe { Self::from_sys(self.ptr) }
+    }
+}
+
+impl<T: GodotObject + RefCounted> Drop for Ref<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            self.as_raw().unref_and_free_if_last();
+        }
+    }
+}
+
+impl<T: GodotObject<PersistentRef = Self> + RefCounted + Instanciable> Ref<T> {
+    /// Creates a new instance of `T`.
+    ///
+    /// The returned object is automatically managed for reference-counted types.
+    #[inline]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        T::construct()
+    }
+}
+
+impl<T: GodotObject<PersistentRef = Self> + RefCounted> Ref<T> {
+    /// Performs a dynamic reference cast to target type, keeping the reference count.
+    #[inline]
+    pub fn cast<U: GodotObject>(self) -> Option<Ref<U>>
+    where
+        U: GodotObject + RefCounted,
+    {
+        unsafe {
+            if self.as_raw().is_class::<U>() {
+                let ret = Some(Ref::move_from_sys(self.ptr));
+                std::mem::forget(self);
+                ret
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Performs a downcast to a `NativeClass` instance, keeping the reference count.
+    #[inline]
+    pub fn cast_instance<C>(self) -> Option<Instance<C>>
+    where
+        C: NativeClass<Base = T>,
+    {
+        Instance::try_from_ref_base(self)
+    }
+}
+
+impl<T: GodotObject + RefCounted> private::Sealed for Ref<T> {}
+impl<T: GodotObject + RefCounted> PersistentRef for Ref<T> {
+    type Target = T;
+
+    #[inline]
+    fn sys(&self) -> *mut sys::godot_object {
+        self.ptr.as_ptr()
+    }
+
+    #[inline]
+    unsafe fn as_raw(&self) -> &RawObject<Self::Target> {
+        RawObject::from_sys_ref_unchecked(self.ptr)
+    }
+
+    #[inline]
+    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        let ret = Self::move_from_sys(obj);
+        ret.as_raw().add_ref();
+        ret
+    }
+
+    #[inline]
+    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        Ref {
+            ptr: obj,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        let ret = Self::move_from_sys(obj);
+        ret.as_raw().init_ref_count();
+        ret
+    }
+}
+
+impl<T: GodotObject + RefCounted> Debug for Ref<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({:p})", T::class_name(), self.ptr)
+    }
+}
+
+/// An opaque struct representing Godot objects. This should never be created on the stack.
+///
+/// This is an internal interface. Users are expected to use references to named generated types
+/// instead.
+#[repr(C)]
+pub struct RawObject<T> {
+    _opaque: [u8; 0],
+    _marker: PhantomData<T>,
+}
+
+impl<T: GodotObject> RawObject<T> {
+    /// Creates a typed reference from a pointer, without checking the type of the pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `obj` pointer must be pointing to a valid Godot object of type `T` during the
+    /// entirety of `'a`.
+    #[inline]
+    pub unsafe fn from_sys_ref_unchecked<'a>(obj: NonNull<sys::godot_object>) -> &'a Self {
+        &*(obj.as_ptr() as *mut Self)
+    }
+
+    /// Creates a typed reference from a pointer if the pointer is pointing to an object of
+    /// the correct type. Returns `None` otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The `obj` pointer must be pointing to a valid Godot object during the entirety of `'a`.
+    #[inline]
+    pub unsafe fn try_from_sys_ref<'a>(obj: NonNull<sys::godot_object>) -> Option<&'a Self> {
+        if ptr_is_class(obj.as_ptr(), T::class_name()) {
+            Some(Self::from_sys_ref_unchecked(obj))
+        } else {
+            None
+        }
+    }
+
+    /// Casts a reference to this opaque object to `*const sys::godot_object`.
+    #[inline]
+    pub fn sys(&self) -> NonNull<sys::godot_object> {
+        // SAFETY: references should never be null
+        unsafe { NonNull::new_unchecked(self as *const _ as *mut _) }
+    }
+
+    /// Checks whether the object is of a certain Godot class.
+    #[inline]
+    pub fn is_class<U: GodotObject>(&self) -> bool {
+        self.is_class_by_name(U::class_name())
+    }
+
+    /// Checks whether the object is of a certain Godot class by name.
+    #[inline]
+    pub fn is_class_by_name(&self, class_name: &str) -> bool {
+        unsafe { ptr_is_class(self.sys().as_ptr(), class_name) }
+    }
+
+    /// Returns the class name of this object dynamically using `Object::get_class`.
+    #[inline]
+    pub fn class_name(&self) -> String {
+        let api = crate::private::get_api();
+        let get_class_method = ObjectMethodTable::get(api).get_class;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut class_name = sys::godot_string::default();
+        let ret_ptr = &mut class_name as *mut sys::godot_string;
+
+        unsafe {
+            (api.godot_method_bind_ptrcall)(
+                get_class_method,
+                self.sys().as_ptr(),
+                argument_buffer.as_mut_ptr() as *mut _,
+                ret_ptr as *mut _,
+            );
+        }
+
+        let string = GodotString::from_sys(class_name);
+        string.to_string()
+    }
+
+    /// Attempt to cast a Godot object to a different class type.
+    #[inline]
+    pub fn cast<U>(&self) -> Option<&RawObject<U>>
+    where
+        U: GodotObject,
+    {
+        unsafe { RawObject::try_from_sys_ref(self.sys()) }
+    }
+
+    /// Attempt to cast a Godot object to a different class type without checking the type at
+    /// runtime.
+    ///
+    /// # Safety
+    ///
+    /// The types must be compatible.
+    #[inline]
+    pub unsafe fn cast_unchecked<U>(&self) -> &RawObject<U>
+    where
+        U: GodotObject,
+    {
+        RawObject::from_sys_ref_unchecked(self.sys())
+    }
+
+    /// Free the underlying object.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference.
+    #[inline]
+    pub unsafe fn free(&self) {
+        (get_api().godot_object_destroy)(self.sys().as_ptr());
+    }
+}
+
+impl<T: GodotObject + RefCounted> RawObject<T> {
+    /// Increase the reference count of the object.
+    #[inline]
+    pub fn add_ref(&self) {
+        use crate::ReferenceMethodTable;
+
+        let api = crate::private::get_api();
+        let addref_method = ReferenceMethodTable::get(api).reference;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut ok = false;
+        let ok_ptr = &mut ok as *mut bool;
+
+        unsafe {
+            (api.godot_method_bind_ptrcall)(
+                addref_method,
+                self.sys().as_ptr(),
+                argument_buffer.as_mut_ptr() as *mut _,
+                ok_ptr as *mut _,
+            );
+        }
+
+        // If this assertion blows up it means there is a reference counting bug
+        // and we tried to increment the ref count of a dead object (who's ref
+        // count is equal to zero).
+        debug_assert!(ok);
+    }
+
+    /// Decrease the reference count of the object. Returns `true` if this is the last
+    /// reference.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference if this is the last
+    /// reference.
+    #[inline]
+    pub unsafe fn unref(&self) -> bool {
+        use crate::ReferenceMethodTable;
+
+        let api = crate::private::get_api();
+        let unref_method = ReferenceMethodTable::get(api).unreference;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut last_reference = false;
+        let ret_ptr = &mut last_reference as *mut bool;
+        (api.godot_method_bind_ptrcall)(
+            unref_method,
+            self.sys().as_ptr(),
+            argument_buffer.as_mut_ptr() as *mut _,
+            ret_ptr as *mut _,
+        );
+
+        last_reference
+    }
+
+    /// Decrease the reference count of the object. Frees the object and returns `true` if this
+    /// is the last reference.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference if this is the last
+    /// reference.
+    #[inline]
+    pub unsafe fn unref_and_free_if_last(&self) -> bool {
+        let last_reference = self.unref();
+
+        if last_reference {
+            self.free();
+        }
+
+        last_reference
+    }
+
+    /// Initialize the reference count of the object.
+    ///
+    /// # Safety
+    ///
+    /// This function assumes that no other references are held at the time.
+    #[inline]
+    pub unsafe fn init_ref_count(&self) {
+        use crate::ReferenceMethodTable;
+
+        let obj = self.sys().as_ptr();
+
+        let api = crate::private::get_api();
+        let init_method = ReferenceMethodTable::get(api).init_ref;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut ok = false;
+        let ret_ptr = &mut ok as *mut bool;
+        (api.godot_method_bind_ptrcall)(
+            init_method,
+            obj,
+            argument_buffer.as_mut_ptr() as *mut _,
+            ret_ptr as *mut _,
+        );
+
+        debug_assert!(ok);
+    }
+}
+
+impl<T: GodotObject> Debug for RawObject<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({:p})", T::class_name(), self.sys())
+    }
+}
+
+/// Checks whether the raw object pointer is of a certain Godot class.
 ///
 /// # Safety
 ///
 /// The `obj` pointer must be pointing to a valid Godot object.
 #[inline]
-pub unsafe fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
+unsafe fn ptr_is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
     let api = crate::private::get_api();
     let method_bind = ObjectMethodTable::get(api).is_class;
 
@@ -171,19 +774,6 @@ pub unsafe fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
     ret
 }
 
-/// Attempt to cast a Godot object to a different class type.
-///
-/// # Safety
-///
-/// The `obj` pointer must be pointing to a valid Godot object.
-#[inline]
-pub unsafe fn godot_cast<T>(from: *mut sys::godot_object) -> Option<T>
-where
-    T: GodotObject,
-{
-    if !is_class(from, T::class_name()) {
-        return None;
-    }
-
-    Some(T::from_sys(from))
+mod private {
+    pub trait Sealed {}
 }

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -54,7 +54,7 @@ pub(crate) fn derive_native_class(input: TokenStream) -> TokenStream {
                     #name_str
                 }
 
-                fn init(owner: Self::Base) -> Self {
+                fn init(owner: &Self::Base) -> Self {
                     Self::_init(owner)
                 }
 

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -4,33 +4,51 @@
 //! Some of the types were automatically generated from the engine's JSON API description,
 //! and some other types are hand made wrappers around the core C types.
 //!
-//! ## Memory management
+//! ## Memory management for core types
 //!
-//! ### Reference counting
-//!
-//! A lot of the types provided by the engine are internally reference counted and
-//! allow mutable aliasing.
-//! In rust parlance this means that a type such as `gdnative::ConcavePolygonShape2D`
-//! is functionally equivalent to a `Rc<Cell<Something>>` rather than `Rc<Something>`.
+//! Wrappers for most core types expose safe Rust interfaces, and it's unnecessary to mind
+//! memory management most of the times. The exceptions are `VariantArray` and `Dictionary`,
+//! internally reference-counted collections with "interior mutability" in Rust parlance. These
+//! types are modelled using the "typestate" pattern to enforce that the official
+//! [thread-safety guidelines][thread-safety]. For more information, read the type-level
+//! documentation for these types.
 //!
 //! Since it is easy to expect containers and other types to allocate a copy of their
-//! content when using the `Clone` trait, most of these types do not implement `Clone`
-//! and instead implement [`RefCounted`](./trait.RefCounted.html) which provides a
-//! `new_ref(&self) -> Self` method to create references to the same collection or object.
+//! content when using the `Clone` trait, some types do not implement `Clone` and instead
+//! implement [`NewRef`](./trait.NewRef.html) which provides a `new_ref(&self) -> Self` method
+//! to create references to the same collection or object.
 //!
-//! ### Manually managed objects
+//! ## Generated API types
 //!
-//! Some types are manually managed. This means that ownership can be passed to the
-//! engine or the object must be carefully deallocated using the object's `free`  method.
+//! The `api` module contains high-level wrappers for all the API types generated from a
+//! JSON description of the API. The generated types are tied to a specific version, which
+//! is currently `3.2.1-stable` for the crates.io version. If you want to use the bindings
+//! with another version of the engine, see the instructions [here][custom-version] on
+//! generating custom bindings.
 //!
-
-// TODO: document feature flags
+//! ### Memory management
+//!
+//! API types may be reference-counted or manually-managed. This is indicated by the
+//! `RefCounted` and `ManuallyManaged` marker traits.
+//!
+//! The API types may exist in two reference forms: bare and "persistent". Bare references
+//! to API types, like `&'a Node`, represent valid and safe references to Godot objects.
+//! As such, API methods may be called safely on them. Persistent references, like `Ptr<Node>`
+//! or `Ref<Reference>`, have `'static` lifetime and can be persisted, but are not always safe
+//! to use. For more information on how to use persistent references to manually-managed objects
+//! safely, see the documentation on `Ptr::assume_safe`.
+//!
+//! ## Feature flags
+//!
+//! ### `bindings`
+//!
+//! *Enabled* by default. Includes the crates.io version of the bindings in the `api` module.
+//!
+//! [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
+//! [custom-version]: https://github.com/godot-rust/godot-rust/#other-versions-or-custom-builds
+//!
 
 // TODO: add logo using #![doc(html_logo_url = "https://<url>")]
-
-// TODO: currently the generated classes are not showing in the the gdnative crate
-// documentation, and are only appearing in the sub-crates. It would make the doc
-// a lot easier to navigate if we could gather all classes here.
 
 #[doc(inline)]
 pub use gdnative_core::*;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -75,9 +75,14 @@ fn test_constructor() -> bool {
     let lib = GDNativeLibrary::new();
     let _ = lib.is_singleton();
 
-    unsafe {
-        let path = Path2D::new();
+    let path = Path2D::new();
+
+    {
+        let path = unsafe { path.assume_safe() };
         let _ = path.z_index();
+    }
+
+    unsafe {
         path.free();
     }
 
@@ -109,7 +114,7 @@ impl NativeClass for Foo {
     fn class_name() -> &'static str {
         "Foo"
     }
-    fn init(_owner: Reference) -> Foo {
+    fn init(_owner: &Reference) -> Foo {
         Foo(42)
     }
     fn register_properties(_builder: &init::ClassBuilder<Self>) {}
@@ -123,7 +128,7 @@ impl NativeClass for NotFoo {
     fn class_name() -> &'static str {
         "NotFoo"
     }
-    fn init(_owner: Reference) -> NotFoo {
+    fn init(_owner: &Reference) -> NotFoo {
         NotFoo
     }
     fn register_properties(_builder: &init::ClassBuilder<Self>) {}
@@ -132,14 +137,14 @@ impl NativeClass for NotFoo {
 #[methods]
 impl Foo {
     #[export]
-    fn answer(&self, _owner: Reference) -> i64 {
+    fn answer(&self, _owner: &Reference) -> i64 {
         self.0
     }
 
     #[export]
     fn choose(
         &self,
-        _owner: Reference,
+        _owner: &Reference,
         a: GodotString,
         which: bool,
         b: GodotString,
@@ -152,7 +157,7 @@ impl Foo {
     }
 
     #[export]
-    fn choose_variant(&self, _owner: Reference, a: i32, what: Variant, b: f64) -> Variant {
+    fn choose_variant(&self, _owner: &Reference, a: i32, what: Variant, b: f64) -> Variant {
         let what = what.try_to_string().expect("should be string");
         match what.as_str() {
             "int" => a.to_variant(),
@@ -171,16 +176,13 @@ fn test_rust_class_construction() -> bool {
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
 
         let base = foo.into_base();
-        assert_eq!(
-            Some(42),
-            unsafe { base.call("answer".into(), &[]) }.try_to_i64()
-        );
+        assert_eq!(Some(42), base.call("answer".into(), &[]).try_to_i64());
 
-        let foo = Instance::<Foo>::try_from_base(base).expect("should be able to downcast");
+        let foo = Instance::<Foo>::try_from_base(&*base).expect("should be able to downcast");
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
 
         let base = foo.into_base();
-        assert!(Instance::<NotFoo>::try_from_base(base).is_none());
+        assert!(Instance::<NotFoo>::try_from_base(&*base).is_none());
     })
     .is_ok();
 
@@ -196,7 +198,7 @@ fn test_rust_class_construction() -> bool {
 struct OptionalArgs;
 
 impl OptionalArgs {
-    fn _init(_owner: Reference) -> Self {
+    fn _init(_owner: &Reference) -> Self {
         OptionalArgs
     }
 }
@@ -207,7 +209,7 @@ impl OptionalArgs {
     #[allow(clippy::many_single_char_names)]
     fn opt_sum(
         &self,
-        _owner: Reference,
+        _owner: &Reference,
         a: i64,
         b: i64,
         #[opt] c: i64,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -224,12 +224,12 @@ fn init(handle: init::InitHandle) {
     handle.add_class::<Foo>();
     handle.add_class::<OptionalArgs>();
 
-    test_derive::register(&handle);
-    test_free_ub::register(&handle);
-    test_register::register(&handle);
-    test_return_leak::register(&handle);
-    test_variant_call_args::register(&handle);
-    test_variant_ops::register(&handle);
+    test_derive::register(handle);
+    test_free_ub::register(handle);
+    test_register::register(handle);
+    test_return_leak::register(handle);
+    test_variant_call_args::register(handle);
+    test_variant_ops::register(handle);
 }
 
 godot_gdnative_init!();

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -8,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(_handle: &init::InitHandle) {}
+pub(crate) fn register(_handle: init::InitHandle) {}
 
 fn test_derive_to_variant() -> bool {
     println!(" -- test_derive_to_variant");
@@ -54,6 +54,7 @@ fn test_derive_to_variant() -> bool {
     mod variant_with {
         use gdnative::{FromVariantError, GodotString, ToVariant, Variant};
 
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         pub fn to_variant(_ptr: &*mut ()) -> Variant {
             GodotString::from("*mut ()").to_variant()
         }

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -11,7 +11,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: &init::InitHandle) {
+pub(crate) fn register(handle: init::InitHandle) {
     handle.add_class::<Bar>();
 }
 

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -23,7 +23,7 @@ impl NativeClass for Bar {
     fn class_name() -> &'static str {
         "Bar"
     }
-    fn init(_owner: Node) -> Bar {
+    fn init(_owner: &Node) -> Bar {
         Bar(42, None)
     }
     fn register_properties(_builder: &init::ClassBuilder<Self>) {}
@@ -38,19 +38,17 @@ impl Bar {
 #[methods]
 impl Bar {
     #[export]
-    fn free_is_not_ub(&mut self, owner: Node) -> bool {
+    fn free_is_not_ub(&mut self, owner: &Node) -> bool {
         unsafe {
-            owner.free();
+            owner.claim().free();
         }
         assert_eq!(42, self.0, "self should not point to garbage");
         true
     }
 
     #[export]
-    fn set_script_is_not_ub(&mut self, owner: Node) -> bool {
-        unsafe {
-            owner.set_script(None);
-        }
+    fn set_script_is_not_ub(&mut self, owner: &Node) -> bool {
+        owner.set_script(None);
         assert_eq!(42, self.0, "self should not point to garbage");
         true
     }
@@ -70,27 +68,34 @@ fn test_owner_free_ub() -> bool {
     let ok = std::panic::catch_unwind(|| {
         let drop_counter = Arc::new(AtomicUsize::new(0));
 
-        let bar = Instance::<Bar>::new();
-        unsafe {
+        {
+            let bar = Instance::<Bar>::new();
+            let bar = unsafe { bar.assume_safe() };
+
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
-            let base = bar.into_base();
+
             assert_eq!(
                 Some(true),
-                base.call("set_script_is_not_ub".into(), &[]).try_to_bool()
+                bar.base()
+                    .call("set_script_is_not_ub".into(), &[])
+                    .try_to_bool()
             );
-            base.free();
+
+            unsafe {
+                bar.claim().free();
+            }
         }
 
-        let bar = Instance::<Bar>::new();
-        unsafe {
+        {
+            let bar = Instance::<Bar>::new();
+            let bar = unsafe { bar.assume_safe() };
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
+
             assert_eq!(
                 Some(true),
-                bar.into_base()
-                    .call("free_is_not_ub".into(), &[])
-                    .try_to_bool()
+                bar.base().call("free_is_not_ub".into(), &[]).try_to_bool()
             );
         }
 

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -8,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: &init::InitHandle) {
+pub(crate) fn register(handle: init::InitHandle) {
     handle.add_class::<RegisterSignal>();
     handle.add_class::<RegisterProperty>();
 }

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -22,7 +22,7 @@ impl NativeClass for RegisterSignal {
     fn class_name() -> &'static str {
         "RegisterSignal"
     }
-    fn init(_owner: Reference) -> RegisterSignal {
+    fn init(_owner: &Reference) -> RegisterSignal {
         RegisterSignal
     }
     fn register_properties(builder: &init::ClassBuilder<Self>) {
@@ -51,7 +51,7 @@ impl NativeClass for RegisterProperty {
     fn class_name() -> &'static str {
         "RegisterProperty"
     }
-    fn init(_owner: Reference) -> RegisterProperty {
+    fn init(_owner: &Reference) -> RegisterProperty {
         RegisterProperty { value: 42 }
     }
     fn register_properties(builder: &init::ClassBuilder<Self>) {
@@ -67,12 +67,12 @@ impl NativeClass for RegisterProperty {
 #[methods]
 impl RegisterProperty {
     #[export]
-    fn set_value(&mut self, _owner: Reference, value: i64) {
+    fn set_value(&mut self, _owner: &Reference, value: i64) {
         self.value = value;
     }
 
     #[export]
-    fn get_value(&self, _owner: Reference) -> i64 {
+    fn get_value(&self, _owner: &Reference) -> i64 {
         self.value
     }
 }
@@ -85,17 +85,15 @@ fn test_register_property() -> bool {
 
         let base = obj.into_base();
 
-        unsafe {
-            assert_eq!(Some(42), base.call("get_value".into(), &[]).try_to_i64());
+        assert_eq!(Some(42), base.call("get_value".into(), &[]).try_to_i64());
 
-            base.set("value".into(), 54.to_variant());
+        base.set("value".into(), 54.to_variant());
 
-            assert_eq!(Some(54), base.call("get_value".into(), &[]).try_to_i64());
+        assert_eq!(Some(54), base.call("get_value".into(), &[]).try_to_i64());
 
-            base.call("set_value".into(), &[4242.to_variant()]);
+        base.call("set_value".into(), &[4242.to_variant()]);
 
-            assert_eq!(Some(4242), base.call("get_value".into(), &[]).try_to_i64());
-        }
+        assert_eq!(Some(4242), base.call("get_value".into(), &[]).try_to_i64());
     })
     .is_ok();
 

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -31,7 +31,7 @@ impl NativeClass for Probe {
         "ReturnLeakProbe"
     }
 
-    fn init(_owner: AnimationNodeAdd2) -> Probe {
+    fn init(_owner: &AnimationNodeAdd2) -> Probe {
         Probe { drop_count: None }
     }
 
@@ -66,15 +66,15 @@ fn test_return_leak() -> bool {
         // Create an instance of the probe, and drop the reference after setting the property
         // to it. After this block, the only reference should be the one in `animation_tree`.
         {
+            let animation_tree = unsafe { animation_tree.assume_safe() };
+
             let probe = Instance::<Probe>::new();
             probe
                 .map_mut(|probe, _| probe.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
 
-            unsafe {
-                let base = probe.into_base();
-                animation_tree.set_tree_root(Some(base.cast().unwrap()));
-            }
+            let base = probe.into_base();
+            animation_tree.set_tree_root(Some(&*base.cast().unwrap()));
         }
 
         assert_eq!(0, drop_counter.load(AtomicOrdering::Acquire));
@@ -82,8 +82,12 @@ fn test_return_leak() -> bool {
         // Take the reference out of the property and drop it. The probe should be dropped after
         // this block.
         {
-            // This happens via ptrcall, which is what's being tested.
-            let _probe_reference = unsafe { animation_tree.tree_root().unwrap() };
+            let _probe_reference = {
+                let animation_tree = unsafe { animation_tree.assume_safe() };
+
+                // This happens via ptrcall, which is what's being tested.
+                animation_tree.tree_root().unwrap()
+            };
 
             // Free `animation_tree` so the reference inside is dropped.
             unsafe {

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -11,7 +11,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: &init::InitHandle) {
+pub(crate) fn register(handle: init::InitHandle) {
     handle.add_class::<Probe>();
 }
 

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -20,7 +20,7 @@ impl NativeClass for VariantCallArgs {
     fn class_name() -> &'static str {
         "VariantCallArgs"
     }
-    fn init(_owner: Reference) -> VariantCallArgs {
+    fn init(_owner: &Reference) -> VariantCallArgs {
         VariantCallArgs
     }
     fn register_properties(_builder: &init::ClassBuilder<Self>) {}
@@ -29,22 +29,22 @@ impl NativeClass for VariantCallArgs {
 #[methods]
 impl VariantCallArgs {
     #[export]
-    fn zero(&mut self, _owner: Reference) -> i32 {
+    fn zero(&mut self, _owner: &Reference) -> i32 {
         42
     }
 
     #[export]
-    fn one(&mut self, _owner: Reference, a: i32) -> i32 {
+    fn one(&mut self, _owner: &Reference, a: i32) -> i32 {
         a * 42
     }
 
     #[export]
-    fn two(&mut self, _owner: Reference, a: i32, b: i32) -> i32 {
+    fn two(&mut self, _owner: &Reference, a: i32, b: i32) -> i32 {
         a * 42 + b
     }
 
     #[export]
-    fn three(&mut self, _owner: Reference, a: i32, b: i32, c: i32) -> i32 {
+    fn three(&mut self, _owner: &Reference, a: i32, b: i32, c: i32) -> i32 {
         a * 42 + b * c
     }
 }

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -8,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: &init::InitHandle) {
+pub(crate) fn register(handle: init::InitHandle) {
     handle.add_class::<VariantCallArgs>();
 }
 

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -8,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(_handle: &init::InitHandle) {}
+pub(crate) fn register(_handle: init::InitHandle) {}
 
 fn test_variant_ops() -> bool {
     println!(" -- test_variant_ops");


### PR DESCRIPTION
- Added the `Ptr` and `Ref` wrappers for manually-managed and reference-counted objects, moving memory management code out of generator.
- Introduced `ManuallyManaged` and `RefCounted` marker traits for objects.
- Renamed the original `RefCounted` trait to `NewRef` for clairity.
- "Assume-safe" interface for manually-managed objects.
- Added `RefInstance`.
- A lot of interface changes.

Close #390. Close #204. Close #375.