### PR TITLE
Implement ThreadAccess typestate for Ref<T>

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -316,7 +316,7 @@ impl Ty {
         match self {
             Ty::Object(ref name) => {
                 let name = format_ident!("{}", name);
-                syn::parse_quote! { Option<Ref<#name, thread_access::Shared>> }
+                syn::parse_quote! { impl AsArg<Target = #name> }
             }
             _ => self.to_rust(),
         }

--- a/bindings_generator/src/documentation.rs
+++ b/bindings_generator/src/documentation.rs
@@ -67,8 +67,8 @@ The lifetime of this object is automatically managed through reference counting.
 
 Non reference counted objects such as the ones of this type are usually owned by the engine.
 
-`{name}` is a reference-only type. As it is not reference counted, persistent references can
-only exist in the unsafe `Ptr<{name}>` form.
+`{name}` is a reference-only type. Persistent references can
+only exist in the unsafe `Ref<{name}>` form.
 
 In the cases where Rust code owns an object of this type, for example if the object was just
 created on the Rust side and not passed to the engine yet, ownership should be either given

--- a/bindings_generator/src/documentation.rs
+++ b/bindings_generator/src/documentation.rs
@@ -112,10 +112,12 @@ This class is used to interact with Godot's editor."#
     let safety_doc = r#"
 ## Safety
 
-All types in the Godot API have "interior mutability" in Rust parlance. Their use
-must follow the official [thread-safety guidelines][thread-safety]. Specifically, it is
-undefined behavior to pass an instance to Rust code without locking a mutex if there are
-active references to it on other threads.
+All types in the Godot API have "interior mutability" in Rust parlance.
+To enforce that the official [thread-safety guidelines][thread-safety] are
+followed, the typestate pattern is used in the `Ref` and `TRef` smart pointers,
+and the `Instance` API. The typestate `Access` in these types tracks whether the
+access is unique, shared, or exclusive to the current thread. For more information,
+see the type-level documentation on `Ref`.
 
 [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html"#;
 

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -106,12 +106,6 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
             Default::default()
         };
 
-        let mem_type = if class.is_refcounted() {
-            generate_impl_ref_counted(class)
-        } else {
-            generate_impl_manually_managed(class)
-        };
-
         // Instantiable
         let instantiable = if class.instantiable {
             generate_instantiable_impl(class)
@@ -123,7 +117,6 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
             #object_impl
             #free_impl
             #base_class
-            #mem_type
             #instantiable
         }
     };
@@ -226,17 +219,6 @@ pub(crate) mod test_prelude {
 
             if !class.base_class.is_empty() {
                 let code = generate_deref_impl(&class);
-                write!(&mut buffer, "{}", code).unwrap();
-                validate_and_clear_buffer!(buffer);
-            }
-
-            // RefCounted
-            if class.is_refcounted() {
-                let code = generate_impl_ref_counted(&class);
-                write!(&mut buffer, "{}", code).unwrap();
-                validate_and_clear_buffer!(buffer);
-            } else {
-                let code = generate_impl_manually_managed(&class);
                 write!(&mut buffer, "{}", code).unwrap();
                 validate_and_clear_buffer!(buffer);
             }

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -124,14 +124,14 @@ pub fn generate_method_impl(api: &Api, class: &GodotClass, method: &GodotMethod)
     }
 
     let rust_ret_type = if method.has_varargs {
-        Ty::Variant.to_rust(api)
+        Ty::Variant.to_rust()
     } else {
-        method.get_return_type().to_rust(api)
+        method.get_return_type().to_rust()
     };
 
     let args = method.arguments.iter().map(|argument| {
         let name = format_ident!("{}", rust_safe_name(&argument.name));
-        let typ = argument.get_type().to_rust_arg(api);
+        let typ = argument.get_type().to_rust_arg();
         quote! {
             #name: #typ
         }
@@ -282,7 +282,7 @@ pub fn generate_methods(
                 continue;
             }
 
-            let mut rust_ret_type = method.get_return_type().to_rust(api);
+            let mut rust_ret_type = method.get_return_type().to_rust();
 
             // Ensure that methods are not injected several times.
             let method_name_string = method_name.to_string();
@@ -294,7 +294,7 @@ pub fn generate_methods(
             let mut params_decl = TokenStream::new();
             let mut params_use = TokenStream::new();
             for argument in &method.arguments {
-                let ty = argument.get_type().to_rust_arg(api);
+                let ty = argument.get_type().to_rust_arg();
                 let name = rust_safe_name(&argument.name);
                 params_decl.extend(quote! {
                     , #name: #ty

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -157,9 +157,7 @@ pub fn generate_method_impl(api: &Api, class: &GodotClass, method: &GodotMethod)
             let new_var = match arg.get_type() {
                 Ty::Object(_) => {
                     quote! {
-                        let #name: Variant = if let Some(o) = &#name {
-                           o.to_variant()
-                       } else { Variant::new() };
+                        let #name: Variant = #name.to_arg_variant();
                     }
                 }
                 Ty::String => {
@@ -389,11 +387,7 @@ fn generate_argument_pre(ty: &Ty, name: proc_macro2::Ident) -> TokenStream {
         }
         &Ty::Object(_) => {
             quote! {
-                if let Some(arg) = &#name {
-                    arg.as_ptr() as *const _ as *const _
-                } else {
-                    ptr::null()
-                }
+                #name.as_arg_ptr() as *const _ as *const _
             }
         }
         _ => Default::default(),

--- a/examples/dodge_the_creeps/src/extensions.rs
+++ b/examples/dodge_the_creeps/src/extensions.rs
@@ -7,11 +7,17 @@ pub trait NodeExt {
     /// # Safety
     ///
     /// See `Ptr::assume_safe`.
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> &T;
+    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
+        &self,
+        path: P,
+    ) -> TRef<'_, T, thread_access::Shared>;
 }
 
 impl NodeExt for Node {
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(&self, path: P) -> &T {
+    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
+        &self,
+        path: P,
+    ) -> TRef<'_, T, thread_access::Shared> {
         self.get_node(path.into())
             .expect("node should exist")
             .assume_safe()

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -23,41 +23,41 @@ impl HUD {
 
     #[export]
     pub fn show_message(&self, owner: &CanvasLayer, text: String) {
-        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
+        let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
         message_label.set_text(text.into());
         message_label.show();
 
-        let timer: &Timer = unsafe { owner.get_typed_node("message_timer") };
+        let timer = unsafe { owner.get_typed_node::<Timer, _>("message_timer") };
         timer.start(0.0);
     }
 
     pub fn show_game_over(&self, owner: &CanvasLayer) {
         self.show_message(owner, "Game Over".into());
 
-        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
+        let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
         message_label.set_text("Dodge the\nCreeps!".into());
         message_label.show();
 
-        let button: &Button = unsafe { owner.get_typed_node("start_button") };
+        let button = unsafe { owner.get_typed_node::<Button, _>("start_button") };
         button.show();
     }
 
     #[export]
     pub fn update_score(&self, owner: &CanvasLayer, score: i64) {
-        let label: &Label = unsafe { owner.get_typed_node("score_label") };
+        let label = unsafe { owner.get_typed_node::<Label, _>("score_label") };
         label.set_text(score.to_string().into());
     }
 
     #[export]
     fn on_start_button_pressed(&self, owner: &CanvasLayer) {
-        let button: &Button = unsafe { owner.get_typed_node("start_button") };
+        let button = unsafe { owner.get_typed_node::<Button, _>("start_button") };
         button.hide();
         owner.emit_signal("start_game".into(), &[]);
     }
 
     #[export]
     fn on_message_timer_timeout(&self, owner: &CanvasLayer) {
-        let message_label: &Label = unsafe { owner.get_typed_node("message_label") };
+        let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
         message_label.hide()
     }
 }

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -29,13 +29,13 @@ impl Main {
 
     #[export]
     fn game_over(&self, owner: &Node) {
-        let score_timer: &Timer = unsafe { owner.get_typed_node("score_timer") };
-        let mob_timer: &Timer = unsafe { owner.get_typed_node("mob_timer") };
+        let score_timer = unsafe { owner.get_typed_node::<Timer, _>("score_timer") };
+        let mob_timer = unsafe { owner.get_typed_node::<Timer, _>("mob_timer") };
 
         score_timer.stop();
         mob_timer.stop();
 
-        let hud_node: &CanvasLayer = unsafe { owner.get_typed_node("hud") };
+        let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
         hud_node
             .cast_instance::<hud::HUD>()
             .and_then(|hud| hud.map(|x, o| x.show_game_over(o)).ok())
@@ -44,9 +44,9 @@ impl Main {
 
     #[export]
     fn new_game(&mut self, owner: &Node) {
-        let start_position: &Position2D = unsafe { owner.get_typed_node("start_position") };
-        let player: &Area2D = unsafe { owner.get_typed_node("player") };
-        let start_timer: &Timer = unsafe { owner.get_typed_node("start_timer") };
+        let start_position = unsafe { owner.get_typed_node::<Position2D, _>("start_position") };
+        let player = unsafe { owner.get_typed_node::<Area2D, _>("player") };
+        let start_timer = unsafe { owner.get_typed_node::<Timer, _>("start_timer") };
 
         self.score = 0;
 
@@ -61,7 +61,7 @@ impl Main {
 
         start_timer.start(0.0);
 
-        let hud_node: &CanvasLayer = unsafe { owner.get_typed_node("hud") };
+        let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
         hud_node
             .cast_instance::<hud::HUD>()
             .and_then(|hud| {
@@ -76,8 +76,8 @@ impl Main {
 
     #[export]
     fn on_start_timer_timeout(&self, owner: &Node) {
-        let mob_timer: &Timer = unsafe { owner.get_typed_node("mob_timer") };
-        let score_timer: &Timer = unsafe { owner.get_typed_node("score_timer") };
+        let mob_timer = unsafe { owner.get_typed_node::<Timer, _>("mob_timer") };
+        let score_timer = unsafe { owner.get_typed_node::<Timer, _>("score_timer") };
         mob_timer.start(0.0);
         score_timer.start(0.0);
     }
@@ -86,7 +86,7 @@ impl Main {
     fn on_score_timer_timeout(&mut self, owner: &Node) {
         self.score += 1;
 
-        let hud_node: &CanvasLayer = unsafe { owner.get_typed_node("hud") };
+        let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
         hud_node
             .cast_instance::<hud::HUD>()
             .and_then(|hud| hud.map(|x, o| x.update_score(o, self.score)).ok())
@@ -95,8 +95,8 @@ impl Main {
 
     #[export]
     fn on_mob_timer_timeout(&self, owner: &Node) {
-        let mob_spawn_location: &PathFollow2D =
-            unsafe { owner.get_typed_node("mob_path/mob_spawn_locations") };
+        let mob_spawn_location =
+            unsafe { owner.get_typed_node::<PathFollow2D, _>("mob_path/mob_spawn_locations") };
 
         let mob_scene: Ref<RigidBody2D, _> = instance_scene(&self.mob);
 
@@ -122,13 +122,13 @@ impl Main {
             mob_owner
                 .set_linear_velocity(mob_owner.linear_velocity().rotated(Angle { radians: d }));
 
-            let hud_node: &CanvasLayer = unsafe { owner.get_typed_node("hud") };
+            let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
             let hud = hud_node.cast_instance::<hud::HUD>().unwrap();
 
             hud.map(|_, o| {
                 o.connect(
                     "start_game".into(),
-                    Some(unsafe { mob_owner.to_object().assume_shared() }),
+                    unsafe { mob_owner.to_object().assume_shared() },
                     "on_start_game".into(),
                     VariantArray::new_shared(),
                     0,
@@ -139,10 +139,7 @@ impl Main {
         })
         .unwrap();
 
-        owner.add_child(
-            Some(mob.into_base().cast::<Node>().unwrap().into_shared()),
-            false,
-        );
+        owner.add_child(mob.into_base().cast::<Node>().unwrap().into_shared(), false);
     }
 }
 

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -44,7 +44,8 @@ impl Mob {
     #[export]
     fn _ready(&mut self, owner: &RigidBody2D) {
         let mut rng = rand::thread_rng();
-        let animated_sprite: &AnimatedSprite = unsafe { owner.get_typed_node("animated_sprite") };
+        let animated_sprite =
+            unsafe { owner.get_typed_node::<AnimatedSprite, _>("animated_sprite") };
         animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str().into())
     }
 

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -51,14 +51,14 @@ impl Mob {
     #[export]
     fn on_visibility_screen_exited(&self, owner: &RigidBody2D) {
         unsafe {
-            owner.claim().queue_free();
+            owner.assume_unique().queue_free();
         }
     }
 
     #[export]
     fn on_start_game(&self, owner: &RigidBody2D) {
         unsafe {
-            owner.claim().queue_free();
+            owner.assume_unique().queue_free();
         }
     }
 }

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -39,7 +39,8 @@ impl Player {
 
     #[export]
     fn _process(&mut self, owner: &Area2D, delta: f32) {
-        let animated_sprite: &AnimatedSprite = unsafe { owner.get_typed_node("animated_sprite") };
+        let animated_sprite =
+            unsafe { owner.get_typed_node::<AnimatedSprite, _>("animated_sprite") };
 
         let input = Input::godot_singleton();
         let mut velocity = Vector2::new(0.0, 0.0);
@@ -89,8 +90,8 @@ impl Player {
         owner.hide();
         owner.emit_signal("hit".into(), &[]);
 
-        let collision_shape: &CollisionShape2D =
-            unsafe { owner.get_typed_node("collision_shape_2d") };
+        let collision_shape =
+            unsafe { owner.get_typed_node::<CollisionShape2D, _>("collision_shape_2d") };
 
         collision_shape.set_deferred("disabled".into(), true.into());
     }
@@ -100,8 +101,8 @@ impl Player {
         owner.set_global_position(pos);
         owner.show();
 
-        let collision_shape: &CollisionShape2D =
-            unsafe { owner.get_typed_node("collision_shape_2d") };
+        let collision_shape =
+            unsafe { owner.get_typed_node::<CollisionShape2D, _>("collision_shape_2d") };
 
         collision_shape.set_disabled(false);
     }

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -85,7 +85,7 @@ impl Player {
     }
 
     #[export]
-    fn on_player_body_entered(&self, owner: &Area2D, _body: Ptr<PhysicsBody2D>) {
+    fn on_player_body_entered(&self, owner: &Area2D, _body: Ref<PhysicsBody2D>) {
         owner.hide();
         owner.emit_signal("hit".into(), &[]);
 

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -76,7 +76,7 @@ impl SceneCreate {
                 // You need to parent the new scene under some node if you want it in the scene.
                 //   We parent it under ourselves.
                 let node = unsafe { spatial.to_node().assume_shared() };
-                owner.add_child(Some(node), false);
+                owner.add_child(node, false);
                 self.children_spawned += 1;
             }
             Err(err) => godot_print!("Could not instance Child : {:?}", err),

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -3,10 +3,10 @@ extern crate gdnative;
 extern crate euclid;
 
 use euclid::vec3;
-use gdnative::api::{PackedScene, ResourceLoader, Spatial};
+use gdnative::api::{Node, PackedScene, ResourceLoader, Spatial};
 use gdnative::ref_kind::ManuallyManaged;
 use gdnative::thread_access::{ThreadLocal, Unique};
-use gdnative::{GodotObject, GodotString, Ref, Variant};
+use gdnative::{GodotString, Ref, Variant};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ManageErrs {
@@ -75,8 +75,8 @@ impl SceneCreate {
 
                 // You need to parent the new scene under some node if you want it in the scene.
                 //   We parent it under ourselves.
-                let node = unsafe { spatial.to_node().assume_shared() };
-                owner.add_child(node, false);
+                let node: Ref<Node, _> = spatial.cast().unwrap();
+                owner.add_child(node.into_shared(), false);
                 self.children_spawned += 1;
             }
             Err(err) => godot_print!("Could not instance Child : {:?}", err),

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -4,6 +4,8 @@ extern crate euclid;
 
 use euclid::vec3;
 use gdnative::api::{PackedScene, ResourceLoader, Spatial};
+use gdnative::ref_kind::ManuallyManaged;
+use gdnative::thread_access::{ThreadLocal, Unique};
 use gdnative::{GodotObject, GodotString, Ref, Variant};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -16,7 +18,7 @@ pub enum ManageErrs {
 #[inherit(Spatial)]
 struct SceneCreate {
     // Store the loaded scene for a very slight performance boost but mostly to show you how.
-    template: Option<Ref<PackedScene>>,
+    template: Option<Ref<PackedScene, ThreadLocal>>,
     children_spawned: u32,
 }
 
@@ -73,7 +75,8 @@ impl SceneCreate {
 
                 // You need to parent the new scene under some node if you want it in the scene.
                 //   We parent it under ourselves.
-                owner.add_child(Some(spatial.to_node()), false);
+                let node = unsafe { spatial.to_node().assume_shared() };
+                owner.add_child(Some(node), false);
                 self.children_spawned += 1;
             }
             Err(err) => godot_print!("Could not instance Child : {:?}", err),
@@ -97,7 +100,7 @@ impl SceneCreate {
         let last_child = owner.get_child(num_children - 1);
         if let Some(node) = last_child {
             unsafe {
-                node.queue_free();
+                node.assume_unique().queue_free();
             }
             self.children_spawned -= 1;
         }
@@ -110,34 +113,32 @@ fn init(handle: gdnative::init::InitHandle) {
     handle.add_class::<SceneCreate>();
 }
 
-pub fn load_scene(path: &str) -> Option<Ref<PackedScene>> {
+pub fn load_scene(path: &str) -> Option<Ref<PackedScene, ThreadLocal>> {
     let scene = ResourceLoader::godot_singleton().load(
         GodotString::from_str(path), // could also use path.into() here
         GodotString::from_str("PackedScene"),
         false,
-    );
+    )?;
 
-    scene.and_then(|s| s.cast::<PackedScene>())
+    let scene = unsafe { scene.assume_thread_local() };
+
+    scene.cast::<PackedScene>()
 }
 
 /// Root here is needs to be the same type (or a parent type) of the node that you put in the child
 ///   scene as the root. For instance Spatial is used for this example.
-fn instance_scene<Root>(scene: &PackedScene) -> Result<&Root, ManageErrs>
+fn instance_scene<Root>(scene: &PackedScene) -> Result<Ref<Root, Unique>, ManageErrs>
 where
-    Root: gdnative::GodotObject,
+    Root: gdnative::GodotObject<RefKind = ManuallyManaged>,
 {
-    let inst_option = scene.instance(0); // 0 - GEN_EDIT_STATE_DISABLED
+    let instance = scene
+        .instance(PackedScene::GEN_EDIT_STATE_DISABLED)
+        .ok_or(ManageErrs::CouldNotMakeInstance)?;
+    let instance = unsafe { instance.assume_unique() };
 
-    if let Some(instance) = inst_option {
-        let instance = unsafe { instance.assume_safe() };
-        if let Some(instance_root) = instance.cast::<Root>() {
-            Ok(instance_root)
-        } else {
-            Err(ManageErrs::RootClassNotSpatial(instance.name().to_string()))
-        }
-    } else {
-        Err(ManageErrs::CouldNotMakeInstance)
-    }
+    instance
+        .try_cast::<Root>()
+        .map_err(|instance| ManageErrs::RootClassNotSpatial(instance.name().to_string()))
 }
 
 fn update_panel(owner: &Spatial, num_children: i64) {

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -70,13 +70,13 @@ impl SignalSubscriber {
     }
 
     #[export]
-    fn _ready(&mut self, owner: &Label) {
+    fn _ready(&mut self, owner: TRef<Label>) {
         let emitter = &mut owner
             .get_node(NodePath::from_str("../SignalEmitter"))
             .unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
-        let object = unsafe { owner.to_object().assume_shared() };
+        let object = owner.cast().unwrap();
         emitter
             .connect(
                 GodotString::from_str("tick"),

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -80,7 +80,7 @@ impl SignalSubscriber {
         emitter
             .connect(
                 GodotString::from_str("tick"),
-                Some(object),
+                object,
                 GodotString::from_str("notify"),
                 VariantArray::new_shared(),
                 0,
@@ -89,7 +89,7 @@ impl SignalSubscriber {
         emitter
             .connect(
                 GodotString::from_str("tick_with_data"),
-                Some(object),
+                object,
                 GodotString::from_str("notify_with_data"),
                 VariantArray::new_shared(),
                 0,

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -76,11 +76,11 @@ impl SignalSubscriber {
             .unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
-        let object = &owner.to_object();
+        let object = unsafe { owner.to_object().assume_shared() };
         emitter
             .connect(
                 GodotString::from_str("tick"),
-                Some(*object),
+                Some(object),
                 GodotString::from_str("notify"),
                 VariantArray::new_shared(),
                 0,
@@ -89,7 +89,7 @@ impl SignalSubscriber {
         emitter
             .connect(
                 GodotString::from_str("tick_with_data"),
-                Some(*object),
+                Some(object),
                 GodotString::from_str("notify_with_data"),
                 VariantArray::new_shared(),
                 0,

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -3,6 +3,7 @@ extern crate gdnative;
 
 use gdnative::api::MeshInstance;
 use gdnative::init::property::{EnumHint, IntHint, StringHint};
+use gdnative::GodotObject;
 
 #[derive(gdnative::NativeClass)]
 #[inherit(MeshInstance)]
@@ -63,6 +64,7 @@ impl RustTest {
         owner.set_translation(self.start + offset);
 
         if let Some(mat) = owner.get_surface_material(0) {
+            let mat = unsafe { mat.assume_safe() };
             let mat = mat.cast::<SpatialMaterial>().expect("Incorrect material");
             mat.set_albedo(Color::rgba(self.time.cos().abs(), 0.0, 0.0, 1.0));
         }

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -3,7 +3,6 @@ extern crate gdnative;
 
 use gdnative::api::MeshInstance;
 use gdnative::init::property::{EnumHint, IntHint, StringHint};
-use gdnative::GodotObject;
 
 #[derive(gdnative::NativeClass)]
 #[inherit(MeshInstance)]

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -6,7 +6,7 @@
 // Disable non-critical lints for generated code.
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
-use gdnative_core::object::{self, PersistentRef};
+use gdnative_core::object::{self};
 use gdnative_core::private::get_api;
 use gdnative_core::sys;
 use gdnative_core::sys::GodotApi;

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -331,20 +331,18 @@ impl Variant {
 
     /// Creates a `Variant` wrapping a Godot object.
     #[inline]
-    pub fn from_object<T>(val: &T) -> Variant
+    pub fn from_object<R>(val: R) -> Variant
     where
-        T: GodotObject,
+        R: AsArg,
     {
-        Self::from_object_ptr(val.as_ptr())
+        unsafe { R::to_arg_variant(&val) }
     }
 
-    fn from_object_ptr(val: *mut sys::godot_object) -> Variant {
-        unsafe {
-            let api = get_api();
-            let mut dest = sys::godot_variant::default();
-            (api.godot_variant_new_object)(&mut dest, val);
-            Variant(dest)
-        }
+    pub(crate) unsafe fn from_object_ptr(val: *mut sys::godot_object) -> Variant {
+        let api = get_api();
+        let mut dest = sys::godot_variant::default();
+        (api.godot_variant_new_object)(&mut dest, val);
+        Variant(dest)
     }
 
     /// Creates a `Variant` wrapping a signed integer value.
@@ -859,13 +857,13 @@ impl<'l> From<&'l str> for Variant {
     }
 }
 
-impl<T> From<T> for Variant
+impl<R> From<R> for Variant
 where
-    T: GodotObject,
+    R: AsArg,
 {
     #[inline]
-    fn from(val: T) -> Variant {
-        Variant::from_object(&val)
+    fn from(val: R) -> Variant {
+        Variant::from_object(val)
     }
 }
 
@@ -984,6 +982,18 @@ godot_test!(
 /// Convenience attribute that sets `skip_to_variant` and `skip_from_variant`.
 pub trait ToVariant {
     fn to_variant(&self) -> Variant;
+}
+
+/// Types that can only be safely converted to a `Variant` as owned values. Such types cannot
+/// implement `ToVariant` in general, but can still be passed to API methods as arguments, or
+/// used as return values. Notably, this includes `Unique` references to Godot objects and
+/// instances.
+///
+/// This trait should not be implemented by users.
+///
+/// This has a blanket implementation for all types that have `ToVariant`.
+pub trait OwnedToVariant {
+    fn owned_to_variant(self) -> Variant;
 }
 
 /// Trait for types whose `ToVariant` implementations preserve equivalence.
@@ -1205,6 +1215,13 @@ impl fmt::Display for FromVariantError {
     }
 }
 
+impl<T: ToVariant> OwnedToVariant for T {
+    #[inline]
+    fn owned_to_variant(self) -> Variant {
+        self.to_variant()
+    }
+}
+
 impl ToVariant for () {
     #[inline]
     fn to_variant(&self) -> Variant {
@@ -1245,7 +1262,21 @@ impl<'a, T> ToVariantEq for &'a mut T where T: ToVariantEq {}
 impl<T: GodotObject> ToVariant for Ref<T, Shared> {
     #[inline]
     fn to_variant(&self) -> Variant {
-        Variant::from_object_ptr(self.as_ptr())
+        unsafe { Variant::from_object_ptr(self.as_ptr()) }
+    }
+}
+
+impl<T: GodotObject> OwnedToVariant for Ref<T, Unique> {
+    #[inline]
+    fn owned_to_variant(self) -> Variant {
+        unsafe { Variant::from_object_ptr(self.as_ptr()) }
+    }
+}
+
+impl<'a, T: GodotObject> ToVariant for TRef<'a, T, Shared> {
+    #[inline]
+    fn to_variant(&self) -> Variant {
+        unsafe { Variant::from_object_ptr(self.as_ptr()) }
     }
 }
 

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -7,10 +7,12 @@
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 use super::*;
-use crate::object::{self, PersistentRef};
+use crate::object::{self};
 use crate::private::get_api;
+use crate::ref_kind;
 use crate::sys;
 use crate::sys::GodotApi;
+use crate::thread_access;
 
 use libc;
 use std::ops::*;

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 use super::*;
-use crate::object::{self};
+use crate::object::{self, AsArg};
 use crate::private::get_api;
 use crate::ref_kind;
 use crate::sys;

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -47,6 +47,7 @@ mod generated;
 mod new_ref;
 #[doc(hidden)]
 pub mod object;
+pub mod ref_kind;
 pub mod thread_access;
 
 /// Internal low-level API for use by macros and generated bindings. Not a part of the public API.
@@ -55,9 +56,7 @@ pub mod private;
 
 pub use crate::generated::*;
 pub use crate::new_ref::NewRef;
-pub use crate::object::{
-    GodotObject, Instanciable, ManuallyManaged, Ptr, QueueFree, Ref, RefCounted,
-};
+pub use crate::object::{GodotObject, Instanciable, QueueFree, Ref};
 
 pub use sys::GodotApi;
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -56,7 +56,7 @@ pub mod private;
 
 pub use crate::generated::*;
 pub use crate::new_ref::NewRef;
-pub use crate::object::{GodotObject, Instanciable, QueueFree, Ref};
+pub use crate::object::{AsArg, GodotObject, Instanciable, Null, QueueFree, Ref, TRef};
 
 pub use sys::GodotApi;
 

--- a/gdnative-core/src/nativescript/init/property.rs
+++ b/gdnative-core/src/nativescript/init/property.rs
@@ -1,8 +1,9 @@
 //! Property registration.
 
 use crate::nativescript::{Instance, NativeClass};
-use crate::object::{GodotObject, RefCounted};
+use crate::object::GodotObject;
 use crate::private::get_api;
+use crate::thread_access::Shared;
 use crate::*;
 
 use super::ClassBuilder;
@@ -425,9 +426,9 @@ mod impl_export {
         }
     }
 
-    impl<T> Export for Ref<T>
+    impl<T> Export for Ref<T, Shared>
     where
-        T: GodotObject + RefCounted,
+        T: GodotObject,
     {
         type Hint = ();
         #[inline]
@@ -436,21 +437,10 @@ mod impl_export {
         }
     }
 
-    impl<T> Export for Ptr<T>
-    where
-        T: GodotObject + ManuallyManaged,
-    {
-        type Hint = ();
-        #[inline]
-        fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
-            ExportInfo::resource_type::<T>()
-        }
-    }
-
-    impl<T> Export for Instance<T>
+    impl<T> Export for Instance<T, Shared>
     where
         T: NativeClass,
-        Instance<T>: ToVariant,
+        Instance<T, Shared>: ToVariant,
     {
         type Hint = ();
         #[inline]

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -59,16 +59,6 @@ macro_rules! godot_wrap_method_parameter_count {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! godot_wrap_method_inner_strip_ref {
-    (& $lt:lifetime mut $(rest:tt)*) => ($($rest)*);
-    (& $lt:lifetime $(rest:tt)*) => ($($rest)*);
-    (& mut $(rest:tt)*) => ($($rest)*);
-    (& $(rest:tt)*) => ($($rest)*);
-    ($(rest:tt)*) => ($($rest)*);
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -83,7 +83,7 @@ macro_rules! godot_wrap_method_inner {
 
                 use std::panic::{self, AssertUnwindSafe};
                 use $crate::nativescript::{NativeClass, Instance, RefInstance};
-                use $crate::object::{GodotObject, Ref};
+                use $crate::object::{GodotObject, Ref, TRef};
 
                 if user_data.is_null() {
                     $crate::godot_error!(
@@ -105,9 +105,9 @@ macro_rules! godot_wrap_method_inner {
                 };
 
                 let __catch_result = panic::catch_unwind(move || {
-                    let this = <Ref<<$type_name as NativeClass>::Base, $crate::thread_access::Shared>>::from_sys(this);
-                    let this = <<$type_name as NativeClass>::Base as GodotObject>::cast_ref(this.as_raw_unchecked());
-                    let __instance = RefInstance::<$type_name>::from_raw_unchecked(this, user_data);
+                    let this: Ref<<$type_name as NativeClass>::Base, $crate::thread_access::Shared> = Ref::from_sys(this);
+                    let this: TRef<'_, <$type_name as NativeClass>::Base, _> = this.assume_safe_unchecked();
+                    let __instance: RefInstance<'_, $type_name, _> = RefInstance::from_raw_unchecked(this, user_data);
 
                     let num_args = num_args as isize;
 

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -83,7 +83,7 @@ macro_rules! godot_wrap_method_inner {
 
                 use std::panic::{self, AssertUnwindSafe};
                 use $crate::nativescript::{NativeClass, Instance, RefInstance};
-                use $crate::object::{GodotObject, PersistentRef};
+                use $crate::object::{GodotObject, Ref};
 
                 if user_data.is_null() {
                     $crate::godot_error!(
@@ -105,8 +105,8 @@ macro_rules! godot_wrap_method_inner {
                 };
 
                 let __catch_result = panic::catch_unwind(move || {
-                    let this = <<<$type_name as NativeClass>::Base as GodotObject>::PersistentRef>::from_sys(this);
-                    let this = <<$type_name as NativeClass>::Base as GodotObject>::cast_ref(this.as_raw());
+                    let this = <Ref<<$type_name as NativeClass>::Base, $crate::thread_access::Shared>>::from_sys(this);
+                    let this = <<$type_name as NativeClass>::Base as GodotObject>::cast_ref(this.as_raw_unchecked());
                     let __instance = RefInstance::<$type_name>::from_raw_unchecked(this, user_data);
 
                     let num_args = num_args as isize;

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -188,7 +188,7 @@ macro_rules! godot_wrap_method_inner {
                                 $($pname,)*
                                 $($opt_pname,)*
                             );
-                            <$retty as $crate::ToVariant>::to_variant(&ret)
+                            <$retty as $crate::OwnedToVariant>::owned_to_variant(ret)
                         })
                         .unwrap_or_else(|err| {
                             $crate::godot_error!("gdnative-core: method call failed with error: {:?}", err);

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -2,16 +2,21 @@ use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::Deref;
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 
 use crate::private::get_api;
+use crate::ref_kind::{ManuallyManaged, RefCounted, RefKind};
 use crate::sys;
-use crate::GodotString;
-use crate::ObjectMethodTable;
-use crate::ToVariant;
+use crate::thread_access::{
+    LocalThreadAccess, NonUniqueThreadAccess, Shared, ThreadAccess, ThreadLocal, Unique,
+};
 
 #[cfg(feature = "nativescript")]
 use crate::nativescript::{Instance, NativeClass, RefInstance};
+
+mod raw;
+
+pub use self::raw::RawObject;
 
 /// Trait for Godot API objects. This trait is sealed, and implemented for generated wrapper
 /// types.
@@ -20,12 +25,11 @@ use crate::nativescript::{Instance, NativeClass, RefInstance};
 ///
 /// The `cast` method on Godot object types is only for conversion between engine types.
 /// To downcast a `NativeScript` type from its base type, see `Instance::try_from_base`.
-pub unsafe trait GodotObject:
-    Sized + ToVariant + crate::private::godot_object::Sealed
-{
-    /// The "persistent" form of this type. For reference-counted classes, this is `Ref<Self>`.
-    /// For manually-managed classes, this is `Ptr<Self>` instead.
-    type PersistentRef: PersistentRef<Target = Self>;
+pub unsafe trait GodotObject: Sized + crate::private::godot_object::Sealed {
+    /// The memory management kind of this type. This modifies the behavior of the
+    /// [`Ref`](struct.Ref.html) smart pointer. See its type=level documentation for more
+    /// information.
+    type RefKind: RefKind;
 
     fn class_name() -> &'static str;
 
@@ -64,76 +68,55 @@ pub unsafe trait GodotObject:
         self.as_raw().sys().as_ptr()
     }
 
-    /// Creates a wrapper around the same Godot object that has `'static` lifetime.
+    /// Creates a persistent reference to the same Godot object with shared thread access.
     ///
-    /// Most Godot APIs expect object arguments with `'static` lifetime. This method may be used
-    /// to produce a `'static` wrapper given a reference. For reference-counted types, or classes
-    /// that extend `Reference`, this increments the reference count. For manually-managed types,
-    /// including all classes that inherit `Node`, this creates an alias.
+    /// # Safety
+    ///
+    /// There must not be any `Unique` or `ThreadLocal` references of the object when this
+    /// is called. This causes undefined behavior otherwise.
     #[inline]
-    fn claim(&self) -> Self::PersistentRef
+    unsafe fn assume_shared(&self) -> Ref<Self, Shared>
     where
         Self: Sized,
     {
-        unsafe { Self::PersistentRef::from_sys(self.as_raw().sys()) }
+        Ref::from_sys(self.as_raw().sys())
     }
-}
 
-/// Marker trait for reference-counted Godot API objects.
-pub unsafe trait RefCounted: GodotObject {}
-
-/// Marker trait for manually-managed Godot API objects.
-pub unsafe trait ManuallyManaged: GodotObject {}
-
-/// Trait for persistent references to Godot API objects. This trait is sealed and meant to be
-/// an internal interface.
-pub trait PersistentRef: Clone + Debug + ToVariant + private::Sealed {
-    type Target;
-
-    #[doc(hidden)]
-    fn sys(&self) -> *mut sys::godot_object;
-
-    /// Convert to a `RawObject` reference.
+    /// Creates a persistent reference to the same Godot object with thread-local thread access.
     ///
     /// # Safety
     ///
-    /// `self` must point to a valid object of the correct type.
-    #[doc(hidden)]
-    unsafe fn as_raw(&self) -> &RawObject<Self::Target>;
+    /// There must not be any `Unique` or `Shared` references of the object when this
+    /// is called. This causes undefined behavior otherwise.
+    #[inline]
+    unsafe fn assume_thread_local(&self) -> Ref<Self, ThreadLocal>
+    where
+        Self: Sized + GodotObject<RefKind = RefCounted>,
+    {
+        Ref::from_sys(self.as_raw().sys())
+    }
 
-    /// Convert from a raw pointer, incrementing the reference counter if reference-counted.
+    /// Creates a persistent reference to the same Godot object with unique access.
     ///
     /// # Safety
     ///
-    /// `obj` must point to a valid object of the correct type.
-    #[doc(hidden)]
-    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self;
-
-    /// Convert from a pointer returned from a ptrcall. For reference-counted types, this takes
-    /// the ownership of the returned reference, in Rust parlance. For non-reference-counted
-    /// types, its behavior should be exactly the same as `from_sys`. This is needed for
-    /// reference-counted types to be properly freed, since any references returned from
-    /// ptrcalls are leaked in the process of being cast into a pointer.
+    /// **Use with care.** `Unique` is a very strong assumption that can easily be
+    /// violated. Only use this when you are **absolutely** sure you have the only reference.
     ///
-    /// # Safety
-    ///
-    /// `obj` must point to a valid object of the correct type.
-    #[doc(hidden)]
-    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self;
-
-    /// Convert from a pointer returned from a constructor of a reference-counted type. For
-    /// non-reference-counted types, its behavior should be exactly the same as `from_sys`.
-    ///
-    /// # Safety
-    ///
-    /// `obj` must point to a valid object of the correct type, and must be the only reference.
-    #[doc(hidden)]
-    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self;
+    /// There must be no other references of the object when this is called. This causes
+    /// undefined behavior otherwise.
+    #[inline]
+    unsafe fn assume_unique(&self) -> Ref<Self, Unique>
+    where
+        Self: Sized,
+    {
+        Ref::from_sys(self.as_raw().sys())
+    }
 }
 
 /// GodotObjects that have a zero argument constructor.
 pub trait Instanciable: GodotObject {
-    fn construct() -> Self::PersistentRef;
+    fn construct() -> Ref<Self, Unique>;
 }
 
 /// Manually managed Godot classes implementing `queue_free`. This trait has no public
@@ -149,86 +132,209 @@ pub trait QueueFree: GodotObject {
     unsafe fn godot_queue_free(sys: *mut sys::godot_object);
 }
 
-/// A pointer to a manually-managed Godot object. This is semantically equivalent to a non-null
-/// raw pointer, except that it also implements `Send` and `Sync`.
+/// A polymorphic smart pointer for Godot objects whose behavior changes depending on the
+/// memory management method of the underlying type and the thread access status.
 ///
-/// It's impossible to call API methods directly on `Ptr`s. In order to obtain a safe view
-/// to the underlying object, see the `assume_safe` and `assume_safe_during` methods and follow
-/// the safety guidelines there.
-pub struct Ptr<T: GodotObject + ManuallyManaged> {
-    ptr: NonNull<sys::godot_object>,
-    _marker: PhantomData<*const T>,
+/// # Manually-managed types
+///
+/// `Shared` references to manually-managed types, like `Ref<Node, Shared>`, act like raw
+/// pointers. They are safe to alias, can be sent between threads, and can also be taken as
+/// method arguments (converted from `Variant`). They can't be used directly. Instead, it's
+/// required to obtain a safe view first. See the "Obtaining a safe view" section below for
+/// more information.
+///
+/// `ThreadLocal` references to manually-managed types cannot normally be obtained, since
+/// it does not add anything over `Shared` ones.
+///
+/// `Unique` references to manually-managed types, like `Ref<Node, Unique>`, can't be aliased
+/// or sent between threads, but can be used safely. However, they *won't* be automatically
+/// freed on drop, and are *leaked* if not passed to the engine or freed manually with `free`.
+/// `Unique` references can be obtained through constructors safely, or `assume_unique` in
+/// unsafe contexts.
+///
+/// # Reference-counted types
+///
+/// `Shared` references to reference-counted types, like `Ref<Reference, Shared>`, act like
+/// `Arc` smart pointers. New references can be created with `Clone`, and they can be sent
+/// between threads. The pointer is presumed to be always valid. As such, more operations
+/// are available even when thread safety is not assumed. However, API methods still can't be
+/// used directly, and users are required to obtain a safe view first. See the "Obtaining a
+/// safe view" section below for more information.
+///
+/// `ThreadLocal` reference to reference-counted types, like `Ref<Reference, ThreadLocal>`, add
+/// the ability to call API methods safely, but has an internal reference-counting cost to make
+/// it safe to convert to `Shared`.
+///
+/// # Obtaining a safe view
+///
+/// In a lot of cases, references obtained from the engine as return values or arguments aren't
+/// safe to use, due to lack of pointer validity and thread safety guarantees in the API. As
+/// such, it's usually required to use `unsafe` code to obtain safe views of the same object
+/// before API methods can be called. The ways to cast between different reference types are as
+/// follows:
+///
+/// | From | To | Method | Note |
+/// | - | - | - | - |
+/// | `Unique` | `&'a T` | `Deref` (API methods can be called directly) / `as_ref` | - |
+/// | `ThreadLocal` | `&'a T` | `Deref` (API methods can be called directly) / `as_ref` | Only if `T` is a reference-counted type. |
+/// | `Shared` | `&'a T` | `unsafe assume_safe::<'a>` / `unsafe assume_safe_during(&'a _)` | The underlying object must be valid, and exclusive to this thread during `'a`. |
+/// | `Unique` | `ThreadLocal` | `into_thread_local` | - |
+/// | `Unique` | `Shared` | `into_shared` | - |
+/// | `Shared` | `ThreadLocal` | `unsafe assume_thread_local` | The reference must be local to the current thread. |
+/// | `Shared` / `ThreadLocal` | `Unique` | `unsafe assume_unique` | The reference must be unique. |
+/// | `ThreadLocal` | `Shared` | `unsafe assume_unique().into_shared()` | The reference must be unique. |
+///
+pub struct Ref<T: GodotObject, Access: ThreadAccess = Shared> {
+    ptr: <T::RefKind as RefKindSpec>::PtrWrapper,
+    _marker: PhantomData<(*const T, Access)>,
 }
 
-unsafe impl<T: GodotObject + ManuallyManaged> Send for Ptr<T> {}
-unsafe impl<T: GodotObject + ManuallyManaged> Sync for Ptr<T> {}
+unsafe impl<T: GodotObject, Access: ThreadAccess + Send> Send for Ref<T, Access> {}
+unsafe impl<T: GodotObject, Access: ThreadAccess + Sync> Sync for Ref<T, Access> {}
 
-impl<T: GodotObject + ManuallyManaged> Copy for Ptr<T> {}
-impl<T: GodotObject + ManuallyManaged> Clone for Ptr<T> {
+impl<T: GodotObject, Access: ThreadAccess> private::Sealed for Ref<T, Access> {}
+
+impl<T, Access> Copy for Ref<T, Access>
+where
+    T: GodotObject<RefKind = ManuallyManaged>,
+    Access: NonUniqueThreadAccess,
+{
+}
+
+impl<T, Access> Clone for Ref<T, Access>
+where
+    T: GodotObject,
+    Access: NonUniqueThreadAccess,
+{
     #[inline]
     fn clone(&self) -> Self {
-        Ptr {
-            ptr: self.ptr,
-            _marker: PhantomData,
-        }
+        unsafe { Ref::from_sys(self.ptr.as_non_null()) }
     }
 }
 
-impl<T: GodotObject<PersistentRef = Self> + ManuallyManaged + Instanciable> Ptr<T> {
+impl<T: GodotObject + Instanciable> Ref<T, Unique> {
     /// Creates a new instance of `T`.
     ///
-    /// The lifetime of the returned object is *not* automatically managed.
-    ///
-    /// Immediately after creation, the object is owned by the caller, and can be
-    /// passed to the engine (in which case the engine will be responsible for
-    /// destroying the object) or destroyed manually using `Ptr::free`, or preferably
-    /// `Ptr::queue_free` if it is a `Node`.
+    /// The lifetime of the returned object is *not* automatically managed if `T` is a manually-
+    /// managed type.
     #[inline]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         T::construct()
     }
 }
-
-impl<T: GodotObject + ManuallyManaged> Ptr<T> {
-    unsafe fn as_raw<'a>(self) -> &'a RawObject<T> {
-        RawObject::from_sys_ref_unchecked(self.ptr)
+/// Methods for references that can be dereferenced safely.
+impl<T: GodotObject, Access: ThreadAccess> AsRef<T> for Ref<T, Access>
+where
+    RefImplBound: SafeDeref<T::RefKind, Access>,
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        RefImplBound::impl_as_ref(self)
     }
+}
 
-    /// Returns the underlying raw pointer. This is an internal interface.
+/// Methods for references that can be dereferences safely.
+impl<T: GodotObject, Access: ThreadAccess> Deref for Ref<T, Access>
+where
+    RefImplBound: SafeDeref<T::RefKind, Access>,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+/// Methods for references that point to valid objects.
+impl<T: GodotObject, Access: ThreadAccess> Ref<T, Access>
+where
+    RefImplBound: SafeAsRaw<T::RefKind, Access>,
+{
+    /// Cast to a `RawObject` reference safely.
+    #[inline]
     #[doc(hidden)]
-    #[inline]
-    pub fn as_ptr(self) -> *mut sys::godot_object {
-        self.ptr.as_ptr()
+    pub fn as_raw(&self) -> &RawObject<T> {
+        unsafe { self.as_raw_unchecked() }
     }
 
-    /// Returns `true` if the pointer currently points to a valid object of the correct type.
-    /// **This does NOT guarantee that it's safe to use this pointer.**
+    /// Performs a dynamic reference cast to target type, keeping the reference count.
+    /// Shorthand for `try_cast().ok()`.
     ///
-    /// # Safety
-    ///
-    /// This thread must have exclusive access to the object during the call.
+    /// This is only possible between types with the same `RefKind`s, since otherwise the
+    /// reference can get leaked.
     #[inline]
-    pub unsafe fn is_instance_sane(self) -> bool {
-        let api = get_api();
-        if !(api.godot_is_instance_valid)(self.as_ptr()) {
-            return false;
+    pub fn cast<U>(self) -> Option<Ref<U, Access>>
+    where
+        U: GodotObject<RefKind = T::RefKind>,
+    {
+        self.try_cast().ok()
+    }
+
+    /// Performs a dynamic reference cast to target type, keeping the reference count.
+    ///
+    /// This is only possible between types with the same `RefKind`s, since otherwise the
+    /// reference can get leaked.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)` if the cast failed.
+    #[inline]
+    pub fn try_cast<U>(self) -> Result<Ref<U, Access>, Self>
+    where
+        U: GodotObject<RefKind = T::RefKind>,
+    {
+        unsafe {
+            if self.as_raw().is_class::<U>() {
+                let ret = Ref::move_from_sys(self.ptr.as_non_null());
+                std::mem::forget(self);
+                Ok(ret)
+            } else {
+                Err(self)
+            }
         }
-
-        self.as_raw().is_class::<T>()
     }
 
-    /// Assume that `self` is safe to use during the `'a` lifetime. This lifetime is unbounded
-    /// and inferred by the compiler unless given explicitly.
+    /// Performs a downcast to a `NativeClass` instance, keeping the reference count.
+    /// Shorthand for `try_cast_instance().ok()`.
+    #[inline]
+    pub fn cast_instance<C>(self) -> Option<Instance<C, Access>>
+    where
+        C: NativeClass<Base = T>,
+    {
+        self.try_cast_instance().ok()
+    }
+
+    /// Performs a downcast to a `NativeClass` instance, keeping the reference count.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)` if the cast failed.
+    #[inline]
+    pub fn try_cast_instance<C>(self) -> Result<Instance<C, Access>, Self>
+    where
+        C: NativeClass<Base = T>,
+    {
+        Instance::try_from_base(self)
+    }
+}
+
+impl<T: GodotObject> Ref<T, Shared> {
+    /// Assume that `self` is safe to use, returning a reference that can be used to call API
+    /// methods.
     ///
     /// This is guaranteed to be a no-op at runtime if `debug_assertions` is disabled. Runtime
     /// sanity checks may be added in debug builds to help catch bugs.
     ///
     /// # Safety
     ///
-    /// It's safe to call `assume_safe` only if:
+    /// Suppose that the lifetime of the returned reference is `'a`. It's safe to call
+    /// `assume_safe` only if:
     ///
     /// 1. During the entirety of `'a`, the underlying object will always be valid.
+    ///
+    ///     *This is always true for reference-counted types.*
     ///
     ///     This means that any methods called on the resulting reference will not free it,
     ///     unless it's the last operation within the lifetime.
@@ -248,24 +354,52 @@ impl<T: GodotObject + ManuallyManaged> Ptr<T> {
     ///
     /// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
     #[inline(always)]
-    pub unsafe fn assume_safe<'a>(self) -> &'a T {
-        debug_assert!(
-            self.is_instance_sane(),
-            "assume_safe called on an invalid pointer"
-        );
-        self.assume_safe_unchecked::<'a>()
+    pub unsafe fn assume_safe<'a>(&self) -> &'a T {
+        T::RefKind::impl_assume_safe(self)
     }
 
-    /// Assume that `self` is safe to use during the `'a` lifetime, if a sanity check using
-    /// `is_instance_sane` passed. This lifetime is unbounded and inferred by the compiler
-    /// unless given explicitly.
+    /// Assume that `self` is the unique reference to the underlying object.
+    ///
+    /// This is guaranteed to be a no-op at runtime if `debug_assertions` is disabled. Runtime
+    /// sanity checks may be added in debug builds to help catch bugs.
+    ///
+    /// # Safety
+    ///
+    /// Calling `assume_unique` when `self` isn't the unique reference is instant undefined
+    /// behavior. This is a much stronger assumption than `assume_safe` and should be used with
+    /// care.
+    #[inline(always)]
+    pub unsafe fn assume_unique(self) -> Ref<T, Unique> {
+        T::RefKind::impl_assume_unique(self)
+    }
+}
+
+impl<T: GodotObject<RefKind = ManuallyManaged>> Ref<T, Shared> {
+    /// Returns `true` if the pointer currently points to a valid object of the correct type.
+    /// **This does NOT guarantee that it's safe to use this pointer.**
+    ///
+    /// # Safety
+    ///
+    /// This thread must have exclusive access to the object during the call.
+    #[inline]
+    pub unsafe fn is_instance_sane(self) -> bool {
+        let api = get_api();
+        if !(api.godot_is_instance_valid)(self.as_ptr()) {
+            return false;
+        }
+
+        self.as_raw_unchecked().is_class::<T>()
+    }
+
+    /// Assume that `self` is safe to use, if a sanity check using `is_instance_sane` passed.
     ///
     /// # Safety
     ///
     /// The same safety constraints as `assume_safe` applies. **The sanity check does NOT
     /// guarantee that the operation is safe.**
     #[inline]
-    pub unsafe fn assume_safe_if_sane<'a>(self) -> Option<&'a T> {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub unsafe fn assume_safe_if_sane<'a>(&self) -> Option<&'a T> {
         if self.is_instance_sane() {
             Some(self.assume_safe_unchecked())
         } else {
@@ -273,505 +407,390 @@ impl<T: GodotObject + ManuallyManaged> Ptr<T> {
         }
     }
 
-    #[inline(always)]
-    unsafe fn assume_safe_unchecked<'a>(self) -> &'a T {
-        T::cast_ref(self.as_raw())
-    }
-
-    /// Assume that `self` is safe to use during the lifetime of the input reference. The
-    /// input reference is unused and may be anything. This is a convenience wrapper around
-    /// `assume_safe`.
-    ///
-    /// This is guaranteed to be a no-op at runtime if `debug_assertions` is disabled. Runtime
-    /// sanity checks may be added in debug builds to help catch bugs.
+    /// Assume that `self` is the unique reference to the underlying object, if a sanity check
+    /// using `is_instance_sane` passed.
     ///
     /// # Safety
     ///
-    /// The same safety constraints as `assume_safe` applies.
-    #[inline(always)]
-    pub unsafe fn assume_safe_during<'a, L: 'a>(self, _lifetime: &'a L) -> &'a T {
-        self.assume_safe::<'a>()
-    }
-
-    /// Assume that `self` is safe to use during the lifetime of the input reference, if a
-    /// sanity check using `is_instance_sane` passed. The input reference is unused and may
-    /// be anything. This is a convenience wrapper around `assume_safe_if_sane`.
-    ///
-    /// # Safety
-    ///
-    /// The same safety constraints as `assume_safe` applies. **The sanity check does NOT
-    /// guarantee that the operation is safe.**
-    #[inline(always)]
-    pub unsafe fn assume_safe_during_if_sane<'a, L: 'a>(self, _lifetime: &'a L) -> Option<&'a T> {
-        self.assume_safe_if_sane::<'a>()
-    }
-
-    /// Manually frees the object.
-    ///
-    /// # Safety
-    ///
-    /// During the call, the underlying object must be valid, and this thread must have
-    /// exclusive access to the object. This pointer must never be used again.
+    /// Calling `assume_unique_if_sane` when `self` isn't the unique reference is instant
+    /// undefined behavior. This is a much stronger assumption than `assume_safe` and should be
+    /// used with care.
     #[inline]
-    pub unsafe fn free(self) {
-        self.as_raw().free();
-    }
-}
-
-impl<T: GodotObject + ManuallyManaged + QueueFree> Ptr<T> {
-    /// Queues the object for deallocation in the near future. This is preferable for `Node`s
-    /// compared to `Ptr::free`.
-    ///
-    /// # Safety
-    ///
-    /// During the call, the underlying object must be valid, and this thread must have
-    /// exclusive access to the object. This pointer must never be used again.
-    #[inline]
-    pub unsafe fn queue_free(self) {
-        T::godot_queue_free(self.as_ptr())
-    }
-}
-
-impl<T: GodotObject + ManuallyManaged> private::Sealed for Ptr<T> {}
-impl<T: GodotObject + ManuallyManaged> PersistentRef for Ptr<T> {
-    type Target = T;
-
-    #[inline]
-    fn sys(&self) -> *mut sys::godot_object {
-        self.ptr.as_ptr()
-    }
-
-    #[inline]
-    unsafe fn as_raw(&self) -> &RawObject<Self::Target> {
-        RawObject::from_sys_ref_unchecked(self.ptr)
-    }
-
-    #[inline]
-    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self {
-        Ptr {
-            ptr: obj,
-            _marker: PhantomData,
+    pub unsafe fn assume_unique_if_sane(self) -> Option<Ref<T, Unique>> {
+        if self.is_instance_sane() {
+            Some(self.cast_access())
+        } else {
+            None
         }
     }
+}
 
-    #[inline]
-    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self {
-        Self::from_sys(obj)
-    }
-
-    #[inline]
-    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self {
-        Self::from_sys(obj)
+impl<T: GodotObject<RefKind = RefCounted>> Ref<T, Shared> {
+    /// Assume that all references to the underlying object is local to the current thread.
+    ///
+    /// This is guaranteed to be a no-op at runtime.
+    ///
+    /// # Safety
+    ///
+    /// Calling `assume_thread_local` when there are references on other threads is instant
+    /// undefined behavior. This is a much stronger assumption than `assume_safe` and should
+    /// be used with care.
+    #[inline(always)]
+    pub unsafe fn assume_thread_local(self) -> Ref<T, ThreadLocal> {
+        self.cast_access()
     }
 }
 
-impl<T: GodotObject + ManuallyManaged> Eq for Ptr<T> {}
-impl<T: GodotObject + ManuallyManaged> PartialEq for Ptr<T> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.ptr == other.ptr
+impl<T: GodotObject<RefKind = RefCounted>> Ref<T, Unique> {
+    /// Convert to a thread-local reference.
+    ///
+    /// This is guaranteed to be a no-op at runtime.
+    #[inline(always)]
+    pub fn into_thread_local(self) -> Ref<T, ThreadLocal> {
+        unsafe { self.cast_access() }
     }
 }
 
-impl<T: GodotObject + ManuallyManaged> Ord for Ptr<T> {
+impl<T: GodotObject> Ref<T, Unique> {
+    /// Convert to a shared reference.
+    ///
+    /// This is guaranteed to be a no-op at runtime.
+    #[inline(always)]
+    pub fn into_shared(self) -> Ref<T, Shared> {
+        unsafe { self.cast_access() }
+    }
+}
+
+impl<T: GodotObject<RefKind = ManuallyManaged>> Ref<T, Unique> {
+    /// Manually frees the object.
+    ///
+    /// Manually-managed objects are not free-on-drop *even when the access is unique*, because
+    /// it's impossible to know whether methods take "ownership" of them or not. It's up to the
+    /// user to decide when they should be freed.
+    #[inline]
+    pub fn free(self) {
+        unsafe {
+            self.as_raw().free();
+        }
+    }
+}
+
+impl<T: GodotObject<RefKind = ManuallyManaged> + QueueFree> Ref<T, Unique> {
+    /// Queues the object for deallocation in the near future. This is preferable for `Node`s
+    /// compared to `Ref::free`.
+    #[inline]
+    pub fn queue_free(self) {
+        unsafe { T::godot_queue_free(self.as_ptr()) }
+    }
+}
+
+impl<T: GodotObject, Access: ThreadAccess> Eq for Ref<T, Access> {}
+impl<T, Access, RhsAccess> PartialEq<Ref<T, RhsAccess>> for Ref<T, Access>
+where
+    T: GodotObject,
+    Access: ThreadAccess,
+    RhsAccess: ThreadAccess,
+{
+    #[inline]
+    fn eq(&self, other: &Ref<T, RhsAccess>) -> bool {
+        self.ptr.as_non_null() == other.ptr.as_non_null()
+    }
+}
+
+impl<T: GodotObject, Access: ThreadAccess> Ord for Ref<T, Access> {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.ptr.cmp(&other.ptr)
+        self.ptr.as_non_null().cmp(&other.ptr.as_non_null())
     }
 }
 
-impl<T: GodotObject + ManuallyManaged> PartialOrd for Ptr<T> {
+impl<T: GodotObject, Access: ThreadAccess> PartialOrd for Ref<T, Access> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.ptr.partial_cmp(&other.ptr)
+        self.ptr.as_non_null().partial_cmp(&other.ptr.as_non_null())
     }
 }
 
-impl<T: GodotObject + ManuallyManaged> Hash for Ptr<T> {
+impl<T: GodotObject, Access: ThreadAccess> Hash for Ref<T, Access> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_usize(self.ptr.as_ptr() as usize)
     }
 }
 
-impl<T: GodotObject + ManuallyManaged> Debug for Ptr<T> {
+impl<T: GodotObject, Access: ThreadAccess> Debug for Ref<T, Access> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({:p})", T::class_name(), self.ptr)
+        write!(f, "{}({:p})", T::class_name(), self.ptr.as_ptr())
     }
 }
 
-/// A reference to a reference-counted Godot object. This is semantically analogous to a `Rc`
-/// wrapper.
-///
-/// It's possible to call API methods in safe contexts directly on `Ref`.
-pub struct Ref<T: GodotObject + RefCounted> {
-    ptr: NonNull<sys::godot_object>,
-    _marker: PhantomData<*const T>,
-}
-
-impl<T: GodotObject + RefCounted> Deref for Ref<T> {
-    type Target = T;
-
+impl<T: GodotObject, Access: ThreadAccess> Ref<T, Access> {
+    /// Convert to a nullable raw pointer.
+    #[doc(hidden)]
     #[inline]
-    fn deref(&self) -> &Self::Target {
-        unsafe { T::cast_ref(self.as_raw()) }
-    }
-}
-
-impl<T: GodotObject + RefCounted> AsRef<T> for Ref<T> {
-    #[inline]
-    fn as_ref(&self) -> &T {
-        unsafe { T::cast_ref(self.as_raw()) }
-    }
-}
-
-impl<T: GodotObject + RefCounted> Clone for Ref<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        unsafe { Self::from_sys(self.ptr) }
-    }
-}
-
-impl<T: GodotObject + RefCounted> Drop for Ref<T> {
-    #[inline]
-    fn drop(&mut self) {
-        unsafe {
-            self.as_raw().unref_and_free_if_last();
-        }
-    }
-}
-
-impl<T: GodotObject<PersistentRef = Self> + RefCounted + Instanciable> Ref<T> {
-    /// Creates a new instance of `T`.
-    ///
-    /// The returned object is automatically managed for reference-counted types.
-    #[inline]
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        T::construct()
-    }
-}
-
-impl<T: GodotObject<PersistentRef = Self> + RefCounted> Ref<T> {
-    /// Performs a dynamic reference cast to target type, keeping the reference count.
-    #[inline]
-    pub fn cast<U: GodotObject>(self) -> Option<Ref<U>>
-    where
-        U: GodotObject + RefCounted,
-    {
-        unsafe {
-            if self.as_raw().is_class::<U>() {
-                let ret = Some(Ref::move_from_sys(self.ptr));
-                std::mem::forget(self);
-                ret
-            } else {
-                None
-            }
-        }
-    }
-
-    /// Performs a downcast to a `NativeClass` instance, keeping the reference count.
-    #[inline]
-    pub fn cast_instance<C>(self) -> Option<Instance<C>>
-    where
-        C: NativeClass<Base = T>,
-    {
-        Instance::try_from_ref_base(self)
-    }
-}
-
-impl<T: GodotObject + RefCounted> private::Sealed for Ref<T> {}
-impl<T: GodotObject + RefCounted> PersistentRef for Ref<T> {
-    type Target = T;
-
-    #[inline]
-    fn sys(&self) -> *mut sys::godot_object {
+    pub fn sys(&self) -> *mut sys::godot_object {
         self.ptr.as_ptr()
     }
 
+    /// Convert to a nullable raw pointer.
+    #[doc(hidden)]
     #[inline]
-    unsafe fn as_raw(&self) -> &RawObject<Self::Target> {
-        RawObject::from_sys_ref_unchecked(self.ptr)
+    pub fn as_ptr(&self) -> *mut sys::godot_object {
+        self.ptr.as_ptr()
     }
 
+    /// Convert to a `RawObject` reference.
+    ///
+    /// # Safety
+    ///
+    /// `self` must point to a valid object of the correct type.
+    #[doc(hidden)]
     #[inline]
-    unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self {
-        let ret = Self::move_from_sys(obj);
-        ret.as_raw().add_ref();
-        ret
+    pub unsafe fn as_raw_unchecked<'a>(&self) -> &'a RawObject<T> {
+        RawObject::from_sys_ref_unchecked(self.ptr.as_non_null())
     }
 
+    /// Convert from a pointer returned from a ptrcall. For reference-counted types, this takes
+    /// the ownership of the returned reference, in Rust parlance. For non-reference-counted
+    /// types, its behavior should be exactly the same as `from_sys`. This is needed for
+    /// reference-counted types to be properly freed, since any references returned from
+    /// ptrcalls are leaked in the process of being cast into a pointer.
+    ///
+    /// # Safety
+    ///
+    /// `obj` must point to a valid object of the correct type.
+    #[doc(hidden)]
     #[inline]
-    unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+    pub unsafe fn move_from_sys(obj: NonNull<sys::godot_object>) -> Self {
         Ref {
-            ptr: obj,
+            ptr: <T::RefKind as RefKindSpec>::PtrWrapper::new(obj),
             _marker: PhantomData,
         }
     }
 
+    /// Convert from a raw pointer, incrementing the reference counter if reference-counted.
+    ///
+    /// # Safety
+    ///
+    /// `obj` must point to a valid object of the correct type.
+    #[doc(hidden)]
     #[inline]
-    unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+    pub unsafe fn from_sys(obj: NonNull<sys::godot_object>) -> Self {
         let ret = Self::move_from_sys(obj);
-        ret.as_raw().init_ref_count();
+        <T::RefKind as RefKindSpec>::maybe_add_ref(ret.as_raw_unchecked());
         ret
     }
-}
 
-impl<T: GodotObject + RefCounted> Debug for Ref<T> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({:p})", T::class_name(), self.ptr)
-    }
-}
-
-/// An opaque struct representing Godot objects. This should never be created on the stack.
-///
-/// This is an internal interface. Users are expected to use references to named generated types
-/// instead.
-#[repr(C)]
-pub struct RawObject<T> {
-    _opaque: [u8; 0],
-    _marker: PhantomData<T>,
-}
-
-impl<T: GodotObject> RawObject<T> {
-    /// Creates a typed reference from a pointer, without checking the type of the pointer.
+    /// Convert from a pointer returned from a constructor of a reference-counted type. For
+    /// non-reference-counted types, its behavior should be exactly the same as `from_sys`.
     ///
     /// # Safety
     ///
-    /// The `obj` pointer must be pointing to a valid Godot object of type `T` during the
-    /// entirety of `'a`.
+    /// `obj` must point to a valid object of the correct type, and must be the only reference.
+    #[doc(hidden)]
     #[inline]
-    pub unsafe fn from_sys_ref_unchecked<'a>(obj: NonNull<sys::godot_object>) -> &'a Self {
-        &*(obj.as_ptr() as *mut Self)
+    pub unsafe fn init_from_sys(obj: NonNull<sys::godot_object>) -> Self {
+        let ret = Self::move_from_sys(obj);
+        <T::RefKind as RefKindSpec>::maybe_init_ref(ret.as_raw_unchecked());
+        ret
     }
 
-    /// Creates a typed reference from a pointer if the pointer is pointing to an object of
-    /// the correct type. Returns `None` otherwise.
+    /// Casts the access type of `self` to `TargetAccess`, moving the reference.
     ///
     /// # Safety
     ///
-    /// The `obj` pointer must be pointing to a valid Godot object during the entirety of `'a`.
-    #[inline]
-    pub unsafe fn try_from_sys_ref<'a>(obj: NonNull<sys::godot_object>) -> Option<&'a Self> {
-        if ptr_is_class(obj.as_ptr(), T::class_name()) {
-            Some(Self::from_sys_ref_unchecked(obj))
-        } else {
-            None
-        }
+    /// The cast must be valid.
+    unsafe fn cast_access<TargetAccess: ThreadAccess>(self) -> Ref<T, TargetAccess> {
+        let ret = Ref::move_from_sys(self.ptr.as_non_null());
+        std::mem::forget(self);
+        ret
     }
 
-    /// Casts a reference to this opaque object to `*const sys::godot_object`.
-    #[inline]
-    pub fn sys(&self) -> NonNull<sys::godot_object> {
-        // SAFETY: references should never be null
-        unsafe { NonNull::new_unchecked(self as *const _ as *mut _) }
+    unsafe fn assume_safe_unchecked<'a>(&self) -> &'a T {
+        T::cast_ref(self.as_raw_unchecked())
     }
+}
 
-    /// Checks whether the object is of a certain Godot class.
+/// Trait for combinations of `RefKind` and `ThreadAccess` that can be dereferenced safely.
+/// This is an internal interface.
+pub unsafe trait SafeDeref<Kind: RefKind, Access: ThreadAccess> {
+    /// Returns a safe reference to the underlying object.
+    #[doc(hidden)]
+    fn impl_as_ref<T: GodotObject<RefKind = Kind>>(this: &Ref<T, Access>) -> &T;
+}
+
+/// Trait for persistent `Ref`s that point to valid objects. This is an internal interface.
+pub unsafe trait SafeAsRaw<Kind: RefKind, Access: ThreadAccess> {
+    /// Returns a raw reference to the underlying object.
+    #[doc(hidden)]
+    fn impl_as_raw<T: GodotObject<RefKind = Kind>>(this: &Ref<T, Access>) -> &RawObject<T>;
+}
+
+/// Struct to be used for various `Ref` trait bounds.
+pub struct RefImplBound {
+    _private: (),
+}
+
+unsafe impl SafeDeref<ManuallyManaged, Unique> for RefImplBound {
     #[inline]
-    pub fn is_class<U: GodotObject>(&self) -> bool {
-        self.is_class_by_name(U::class_name())
+    fn impl_as_ref<T: GodotObject<RefKind = ManuallyManaged>>(this: &Ref<T, Unique>) -> &T {
+        unsafe { this.assume_safe_unchecked() }
     }
+}
 
-    /// Checks whether the object is of a certain Godot class by name.
+unsafe impl<Access: LocalThreadAccess> SafeDeref<RefCounted, Access> for RefImplBound {
     #[inline]
-    pub fn is_class_by_name(&self, class_name: &str) -> bool {
-        unsafe { ptr_is_class(self.sys().as_ptr(), class_name) }
+    fn impl_as_ref<T: GodotObject<RefKind = RefCounted>>(this: &Ref<T, Access>) -> &T {
+        unsafe { this.assume_safe_unchecked() }
     }
+}
 
-    /// Returns the class name of this object dynamically using `Object::get_class`.
+unsafe impl SafeAsRaw<ManuallyManaged, Unique> for RefImplBound {
     #[inline]
-    pub fn class_name(&self) -> String {
-        let api = crate::private::get_api();
-        let get_class_method = ObjectMethodTable::get(api).get_class;
-        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-        let mut class_name = sys::godot_string::default();
-        let ret_ptr = &mut class_name as *mut sys::godot_string;
-
-        unsafe {
-            (api.godot_method_bind_ptrcall)(
-                get_class_method,
-                self.sys().as_ptr(),
-                argument_buffer.as_mut_ptr() as *mut _,
-                ret_ptr as *mut _,
-            );
-        }
-
-        let string = GodotString::from_sys(class_name);
-        string.to_string()
+    fn impl_as_raw<T: GodotObject<RefKind = ManuallyManaged>>(
+        this: &Ref<T, Unique>,
+    ) -> &RawObject<T> {
+        unsafe { this.as_raw_unchecked() }
     }
+}
 
-    /// Attempt to cast a Godot object to a different class type.
+unsafe impl<Access: ThreadAccess> SafeAsRaw<RefCounted, Access> for RefImplBound {
     #[inline]
-    pub fn cast<U>(&self) -> Option<&RawObject<U>>
+    fn impl_as_raw<T: GodotObject<RefKind = RefCounted>>(this: &Ref<T, Access>) -> &RawObject<T> {
+        unsafe { this.as_raw_unchecked() }
+    }
+}
+
+/// Specialization trait depending on `RefKind`. This is an internal interface.
+pub trait RefKindSpec: Sized {
+    /// Pointer wrapper that may be `Drop` or not.
+    #[doc(hidden)]
+    type PtrWrapper: PtrWrapper;
+
+    #[doc(hidden)]
+    unsafe fn impl_assume_safe<'a, T: GodotObject<RefKind = Self>>(this: &Ref<T, Shared>) -> &'a T
     where
-        U: GodotObject,
-    {
-        unsafe { RawObject::try_from_sys_ref(self.sys()) }
-    }
+        Self: RefKind;
 
-    /// Attempt to cast a Godot object to a different class type without checking the type at
-    /// runtime.
-    ///
-    /// # Safety
-    ///
-    /// The types must be compatible.
-    #[inline]
-    pub unsafe fn cast_unchecked<U>(&self) -> &RawObject<U>
+    #[doc(hidden)]
+    unsafe fn impl_assume_unique<T: GodotObject<RefKind = Self>>(
+        this: Ref<T, Shared>,
+    ) -> Ref<T, Unique>
     where
-        U: GodotObject,
-    {
-        RawObject::from_sys_ref_unchecked(self.sys())
+        Self: RefKind;
+
+    #[doc(hidden)]
+    unsafe fn maybe_add_ref<T: GodotObject<RefKind = Self>>(raw: &RawObject<T>)
+    where
+        Self: RefKind;
+
+    #[doc(hidden)]
+    unsafe fn maybe_init_ref<T: GodotObject<RefKind = Self>>(raw: &RawObject<T>)
+    where
+        Self: RefKind;
+}
+
+impl RefKindSpec for ManuallyManaged {
+    type PtrWrapper = Forget;
+
+    #[inline(always)]
+    unsafe fn impl_assume_safe<'a, T: GodotObject<RefKind = Self>>(this: &Ref<T, Shared>) -> &'a T {
+        debug_assert!(
+            this.is_instance_sane(),
+            "assume_safe called on an invalid pointer"
+        );
+        this.assume_safe_unchecked()
     }
 
-    /// Free the underlying object.
-    ///
-    /// # Safety
-    ///
-    /// Further operations must not be performed on the same reference.
+    #[inline(always)]
+    unsafe fn impl_assume_unique<T: GodotObject<RefKind = Self>>(
+        this: Ref<T, Shared>,
+    ) -> Ref<T, Unique> {
+        debug_assert!(
+            this.is_instance_sane(),
+            "assume_unique called on an invalid pointer"
+        );
+        this.cast_access()
+    }
+
     #[inline]
-    pub unsafe fn free(&self) {
-        (get_api().godot_object_destroy)(self.sys().as_ptr());
+    unsafe fn maybe_add_ref<T: GodotObject<RefKind = Self>>(_raw: &RawObject<T>) {}
+    #[inline]
+    unsafe fn maybe_init_ref<T: GodotObject<RefKind = Self>>(_raw: &RawObject<T>) {}
+}
+
+impl RefKindSpec for RefCounted {
+    type PtrWrapper = UnRef;
+
+    #[inline(always)]
+    unsafe fn impl_assume_safe<'a, T: GodotObject<RefKind = Self>>(this: &Ref<T, Shared>) -> &'a T {
+        this.assume_safe_unchecked()
+    }
+
+    #[inline(always)]
+    unsafe fn impl_assume_unique<T: GodotObject<RefKind = Self>>(
+        this: Ref<T, Shared>,
+    ) -> Ref<T, Unique> {
+        this.cast_access()
+    }
+
+    #[inline]
+    unsafe fn maybe_add_ref<T: GodotObject<RefKind = Self>>(raw: &RawObject<T>) {
+        raw.add_ref();
+    }
+
+    #[inline]
+    unsafe fn maybe_init_ref<T: GodotObject<RefKind = Self>>(raw: &RawObject<T>) {
+        raw.init_ref_count();
     }
 }
 
-impl<T: GodotObject + RefCounted> RawObject<T> {
-    /// Increase the reference count of the object.
+/// Specialization trait for `Drop` behavior.
+pub trait PtrWrapper {
+    fn new(ptr: NonNull<sys::godot_object>) -> Self;
+    fn as_non_null(&self) -> NonNull<sys::godot_object>;
+
     #[inline]
-    pub fn add_ref(&self) {
-        use crate::ReferenceMethodTable;
+    fn as_ptr(&self) -> *mut sys::godot_object {
+        self.as_non_null().as_ptr()
+    }
+}
 
-        let api = crate::private::get_api();
-        let addref_method = ReferenceMethodTable::get(api).reference;
-        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-        let mut ok = false;
-        let ok_ptr = &mut ok as *mut bool;
+#[derive(Copy, Clone)]
+pub struct Forget(NonNull<sys::godot_object>);
+impl PtrWrapper for Forget {
+    #[inline]
+    fn new(ptr: NonNull<sys::godot_object>) -> Self {
+        Forget(ptr)
+    }
 
+    #[inline]
+    fn as_non_null(&self) -> NonNull<sys::godot_object> {
+        self.0
+    }
+}
+
+pub struct UnRef(NonNull<sys::godot_object>);
+impl PtrWrapper for UnRef {
+    #[inline]
+    fn new(ptr: NonNull<sys::godot_object>) -> Self {
+        UnRef(ptr)
+    }
+
+    #[inline]
+    fn as_non_null(&self) -> NonNull<sys::godot_object> {
+        self.0
+    }
+}
+impl Drop for UnRef {
+    #[inline]
+    fn drop(&mut self) {
         unsafe {
-            (api.godot_method_bind_ptrcall)(
-                addref_method,
-                self.sys().as_ptr(),
-                argument_buffer.as_mut_ptr() as *mut _,
-                ok_ptr as *mut _,
-            );
+            let raw = RawObject::<crate::Reference>::from_sys_ref_unchecked(self.0);
+            raw.unref_and_free_if_last();
         }
-
-        // If this assertion blows up it means there is a reference counting bug
-        // and we tried to increment the ref count of a dead object (who's ref
-        // count is equal to zero).
-        debug_assert!(ok);
     }
-
-    /// Decrease the reference count of the object. Returns `true` if this is the last
-    /// reference.
-    ///
-    /// # Safety
-    ///
-    /// Further operations must not be performed on the same reference if this is the last
-    /// reference.
-    #[inline]
-    pub unsafe fn unref(&self) -> bool {
-        use crate::ReferenceMethodTable;
-
-        let api = crate::private::get_api();
-        let unref_method = ReferenceMethodTable::get(api).unreference;
-        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-        let mut last_reference = false;
-        let ret_ptr = &mut last_reference as *mut bool;
-        (api.godot_method_bind_ptrcall)(
-            unref_method,
-            self.sys().as_ptr(),
-            argument_buffer.as_mut_ptr() as *mut _,
-            ret_ptr as *mut _,
-        );
-
-        last_reference
-    }
-
-    /// Decrease the reference count of the object. Frees the object and returns `true` if this
-    /// is the last reference.
-    ///
-    /// # Safety
-    ///
-    /// Further operations must not be performed on the same reference if this is the last
-    /// reference.
-    #[inline]
-    pub unsafe fn unref_and_free_if_last(&self) -> bool {
-        let last_reference = self.unref();
-
-        if last_reference {
-            self.free();
-        }
-
-        last_reference
-    }
-
-    /// Initialize the reference count of the object.
-    ///
-    /// # Safety
-    ///
-    /// This function assumes that no other references are held at the time.
-    #[inline]
-    pub unsafe fn init_ref_count(&self) {
-        use crate::ReferenceMethodTable;
-
-        let obj = self.sys().as_ptr();
-
-        let api = crate::private::get_api();
-        let init_method = ReferenceMethodTable::get(api).init_ref;
-        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
-        let mut ok = false;
-        let ret_ptr = &mut ok as *mut bool;
-        (api.godot_method_bind_ptrcall)(
-            init_method,
-            obj,
-            argument_buffer.as_mut_ptr() as *mut _,
-            ret_ptr as *mut _,
-        );
-
-        debug_assert!(ok);
-    }
-}
-
-impl<T: GodotObject> Debug for RawObject<T> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({:p})", T::class_name(), self.sys())
-    }
-}
-
-/// Checks whether the raw object pointer is of a certain Godot class.
-///
-/// # Safety
-///
-/// The `obj` pointer must be pointing to a valid Godot object.
-#[inline]
-unsafe fn ptr_is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
-    let api = crate::private::get_api();
-    let method_bind = ObjectMethodTable::get(api).is_class;
-
-    let mut class_name = (api.godot_string_chars_to_utf8_with_len)(
-        class_name.as_ptr() as *const _,
-        class_name.len() as _,
-    );
-
-    let mut argument_buffer = [ptr::null() as *const libc::c_void; 1];
-    argument_buffer[0] = (&class_name) as *const _ as *const _;
-
-    let mut ret = false;
-    let ret_ptr = &mut ret as *mut _;
-    (api.godot_method_bind_ptrcall)(
-        method_bind,
-        obj,
-        argument_buffer.as_mut_ptr() as *mut _,
-        ret_ptr as *mut _,
-    );
-
-    (api.godot_string_destroy)(&mut class_name);
-
-    ret
 }
 
 mod private {

--- a/gdnative-core/src/object/raw.rs
+++ b/gdnative-core/src/object/raw.rs
@@ -1,0 +1,260 @@
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::ptr::{self, NonNull};
+
+use crate::private::get_api;
+use crate::ref_kind::RefCounted;
+use crate::sys;
+use crate::GodotString;
+use crate::ObjectMethodTable;
+
+use super::GodotObject;
+
+/// An opaque struct representing Godot objects. This should never be created on the stack.
+///
+/// This is an internal interface. Users are expected to use references to named generated types
+/// instead.
+#[repr(C)]
+pub struct RawObject<T> {
+    _opaque: [u8; 0],
+    _marker: PhantomData<T>,
+}
+
+impl<T: GodotObject> RawObject<T> {
+    /// Creates a typed reference from a pointer, without checking the type of the pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `obj` pointer must be pointing to a valid Godot object of type `T` during the
+    /// entirety of `'a`.
+    #[inline]
+    pub unsafe fn from_sys_ref_unchecked<'a>(obj: NonNull<sys::godot_object>) -> &'a Self {
+        &*(obj.as_ptr() as *mut Self)
+    }
+
+    /// Creates a typed reference from a pointer if the pointer is pointing to an object of
+    /// the correct type. Returns `None` otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The `obj` pointer must be pointing to a valid Godot object during the entirety of `'a`.
+    #[inline]
+    pub unsafe fn try_from_sys_ref<'a>(obj: NonNull<sys::godot_object>) -> Option<&'a Self> {
+        if ptr_is_class(obj.as_ptr(), T::class_name()) {
+            Some(Self::from_sys_ref_unchecked(obj))
+        } else {
+            None
+        }
+    }
+
+    /// Casts a reference to this opaque object to `*const sys::godot_object`.
+    #[inline]
+    pub fn sys(&self) -> NonNull<sys::godot_object> {
+        // SAFETY: references should never be null
+        unsafe { NonNull::new_unchecked(self as *const _ as *mut _) }
+    }
+
+    /// Checks whether the object is of a certain Godot class.
+    #[inline]
+    pub fn is_class<U: GodotObject>(&self) -> bool {
+        self.is_class_by_name(U::class_name())
+    }
+
+    /// Checks whether the object is of a certain Godot class by name.
+    #[inline]
+    pub fn is_class_by_name(&self, class_name: &str) -> bool {
+        unsafe { ptr_is_class(self.sys().as_ptr(), class_name) }
+    }
+
+    /// Returns the class name of this object dynamically using `Object::get_class`.
+    #[inline]
+    pub fn class_name(&self) -> String {
+        let api = crate::private::get_api();
+        let get_class_method = ObjectMethodTable::get(api).get_class;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut class_name = sys::godot_string::default();
+        let ret_ptr = &mut class_name as *mut sys::godot_string;
+
+        unsafe {
+            (api.godot_method_bind_ptrcall)(
+                get_class_method,
+                self.sys().as_ptr(),
+                argument_buffer.as_mut_ptr() as *mut _,
+                ret_ptr as *mut _,
+            );
+        }
+
+        let string = GodotString::from_sys(class_name);
+        string.to_string()
+    }
+
+    /// Attempt to cast a Godot object to a different class type.
+    #[inline]
+    pub fn cast<U>(&self) -> Option<&RawObject<U>>
+    where
+        U: GodotObject,
+    {
+        unsafe { RawObject::try_from_sys_ref(self.sys()) }
+    }
+
+    /// Attempt to cast a Godot object to a different class type without checking the type at
+    /// runtime.
+    ///
+    /// # Safety
+    ///
+    /// The types must be compatible.
+    #[inline]
+    pub unsafe fn cast_unchecked<U>(&self) -> &RawObject<U>
+    where
+        U: GodotObject,
+    {
+        RawObject::from_sys_ref_unchecked(self.sys())
+    }
+
+    /// Free the underlying object.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference.
+    #[inline]
+    pub unsafe fn free(&self) {
+        (get_api().godot_object_destroy)(self.sys().as_ptr());
+    }
+}
+
+impl<T: GodotObject<RefKind = RefCounted>> RawObject<T> {
+    /// Increase the reference count of the object.
+    #[inline]
+    pub fn add_ref(&self) {
+        use crate::ReferenceMethodTable;
+
+        let api = crate::private::get_api();
+        let addref_method = ReferenceMethodTable::get(api).reference;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut ok = false;
+        let ok_ptr = &mut ok as *mut bool;
+
+        unsafe {
+            (api.godot_method_bind_ptrcall)(
+                addref_method,
+                self.sys().as_ptr(),
+                argument_buffer.as_mut_ptr() as *mut _,
+                ok_ptr as *mut _,
+            );
+        }
+
+        // If this assertion blows up it means there is a reference counting bug
+        // and we tried to increment the ref count of a dead object (who's ref
+        // count is equal to zero).
+        debug_assert!(ok);
+    }
+
+    /// Decrease the reference count of the object. Returns `true` if this is the last
+    /// reference.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference if this is the last
+    /// reference.
+    #[inline]
+    pub unsafe fn unref(&self) -> bool {
+        use crate::ReferenceMethodTable;
+
+        let api = crate::private::get_api();
+        let unref_method = ReferenceMethodTable::get(api).unreference;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut last_reference = false;
+        let ret_ptr = &mut last_reference as *mut bool;
+        (api.godot_method_bind_ptrcall)(
+            unref_method,
+            self.sys().as_ptr(),
+            argument_buffer.as_mut_ptr() as *mut _,
+            ret_ptr as *mut _,
+        );
+
+        last_reference
+    }
+
+    /// Decrease the reference count of the object. Frees the object and returns `true` if this
+    /// is the last reference.
+    ///
+    /// # Safety
+    ///
+    /// Further operations must not be performed on the same reference if this is the last
+    /// reference.
+    #[inline]
+    pub unsafe fn unref_and_free_if_last(&self) -> bool {
+        let last_reference = self.unref();
+
+        if last_reference {
+            self.free();
+        }
+
+        last_reference
+    }
+
+    /// Initialize the reference count of the object.
+    ///
+    /// # Safety
+    ///
+    /// This function assumes that no other references are held at the time.
+    #[inline]
+    pub unsafe fn init_ref_count(&self) {
+        use crate::ReferenceMethodTable;
+
+        let obj = self.sys().as_ptr();
+
+        let api = crate::private::get_api();
+        let init_method = ReferenceMethodTable::get(api).init_ref;
+        let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
+        let mut ok = false;
+        let ret_ptr = &mut ok as *mut bool;
+        (api.godot_method_bind_ptrcall)(
+            init_method,
+            obj,
+            argument_buffer.as_mut_ptr() as *mut _,
+            ret_ptr as *mut _,
+        );
+
+        debug_assert!(ok);
+    }
+}
+
+impl<T: GodotObject> Debug for RawObject<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({:p})", T::class_name(), self.sys())
+    }
+}
+
+/// Checks whether the raw object pointer is of a certain Godot class.
+///
+/// # Safety
+///
+/// The `obj` pointer must be pointing to a valid Godot object.
+#[inline]
+unsafe fn ptr_is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
+    let api = crate::private::get_api();
+    let method_bind = ObjectMethodTable::get(api).is_class;
+
+    let mut class_name = (api.godot_string_chars_to_utf8_with_len)(
+        class_name.as_ptr() as *const _,
+        class_name.len() as _,
+    );
+
+    let mut argument_buffer = [ptr::null() as *const libc::c_void; 1];
+    argument_buffer[0] = (&class_name) as *const _ as *const _;
+
+    let mut ret = false;
+    let ret_ptr = &mut ret as *mut _;
+    (api.godot_method_bind_ptrcall)(
+        method_bind,
+        obj,
+        argument_buffer.as_mut_ptr() as *mut _,
+        ret_ptr as *mut _,
+    );
+
+    (api.godot_string_destroy)(&mut class_name);
+
+    ret
+}

--- a/gdnative-core/src/ref_kind.rs
+++ b/gdnative-core/src/ref_kind.rs
@@ -1,0 +1,25 @@
+//! Marker types to express the memory management method of Godot types.
+
+use crate::object::RefKindSpec;
+
+/// Marker that indicates that a type is manually managed.
+pub struct ManuallyManaged;
+
+/// Marker that indicates that a type is reference-counted.
+pub struct RefCounted;
+
+/// Trait to parameterize over the memory management markers
+/// [`ManuallyManaged`](struct.ManuallyManaged.html) and [`RefCounted`](struct.RefCounted.html).
+///
+/// This trait is sealed and has no public members.
+pub trait RefKind: RefKindSpec + private::Sealed {}
+
+impl RefKind for ManuallyManaged {}
+impl private::Sealed for ManuallyManaged {}
+
+impl RefKind for RefCounted {}
+impl private::Sealed for RefCounted {}
+
+mod private {
+    pub trait Sealed {}
+}

--- a/gdnative-core/src/thread_access.rs
+++ b/gdnative-core/src/thread_access.rs
@@ -1,4 +1,4 @@
-//! Marker types to express thread safety of Godot types.
+//! Typestates to express thread safety of Godot types.
 
 /// Marker that indicates that a value currently only has a
 /// single unique reference.
@@ -6,19 +6,39 @@ pub struct Unique;
 
 /// Marker that indicates that a value currently might be shared in the same or
 /// over multiple threads.
+pub struct Shared;
+
+/// Marker that indicates that a value can currently only be shared in the same thread.
 ///
 /// Using this marker causes the type to be `!Send + !Sync`.
-pub struct Shared(std::marker::PhantomData<*const ()>);
+pub struct ThreadLocal(std::marker::PhantomData<*const ()>);
 
-/// Trait to parametrise over the access markers [`Unique`](struct.Unique.html)
-/// and [`Shared`](struct.Shared.html).
+/// Trait to parametrise over the access markers [`Unique`](struct.Unique.html),
+/// [`Shared`](struct.Shared.html), and [`ThreadLocal`](struct.ThreadLocal.html).
+///
+/// This trait is sealed and has no public members.
 pub trait ThreadAccess: private::Sealed {}
 
+/// Trait to parametrise over the access markers that are local to the current thread:
+/// [`Unique`](struct.Unique.html) and [`ThreadLocal`](struct.ThreadLocal.html).
+pub trait LocalThreadAccess: ThreadAccess {}
+
+/// Trait to parametrise over the access markers that are not unique:
+/// [`Shared`](struct.Shared.html) and [`ThreadLocal`](struct.ThreadLocal.html).
+pub trait NonUniqueThreadAccess: ThreadAccess {}
+
 impl ThreadAccess for Unique {}
+impl LocalThreadAccess for Unique {}
 impl private::Sealed for Unique {}
 
 impl ThreadAccess for Shared {}
+impl NonUniqueThreadAccess for Shared {}
 impl private::Sealed for Shared {}
+
+impl ThreadAccess for ThreadLocal {}
+impl LocalThreadAccess for ThreadLocal {}
+impl NonUniqueThreadAccess for ThreadLocal {}
+impl private::Sealed for ThreadLocal {}
 
 mod private {
     pub trait Sealed {}

--- a/gdnative-core/src/thread_access.rs
+++ b/gdnative-core/src/thread_access.rs
@@ -2,7 +2,10 @@
 
 /// Marker that indicates that a value currently only has a
 /// single unique reference.
-pub struct Unique;
+///
+/// Using this marker causes the type to be `!Sync`.
+pub struct Unique(std::marker::PhantomData<*const ()>);
+unsafe impl Send for Unique {}
 
 /// Marker that indicates that a value currently might be shared in the same or
 /// over multiple threads.

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -31,12 +31,13 @@
 //! API types may be reference-counted or manually-managed. This is indicated by the
 //! `RefCounted` and `ManuallyManaged` marker traits.
 //!
-//! The API types may exist in two reference forms: bare and "persistent". Bare references
+//! The API types can exist in three reference forms: bare, `TRef` and `Ref`. Bare references
 //! to API types, like `&'a Node`, represent valid and safe references to Godot objects.
-//! As such, API methods may be called safely on them. Persistent references, like `Ptr<Node>`
-//! or `Ref<Reference>`, have `'static` lifetime and can be persisted, but are not always safe
-//! to use. For more information on how to use persistent references to manually-managed objects
-//! safely, see the documentation on `Ptr::assume_safe`.
+//! As such, API methods may be called safely on them. `TRef` adds typestate tracking, which
+//! enable additional abilities like being able to be passed to the engine. `Ref`, or
+//! "persistent" references, have `'static` lifetime, but are not always safe to use. For more
+//! information on how to use persistent references safely, see the type-level documentation
+//! on `Ref`.
 //!
 //! ## Feature flags
 //!

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -166,13 +166,13 @@ fn test_rust_class_construction() -> bool {
     let ok = std::panic::catch_unwind(|| {
         let foo = Foo::new_instance();
 
-        assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
+        assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));
 
         let base = foo.into_base();
         assert_eq!(Some(42), base.call("answer".into(), &[]).try_to_i64());
 
         let foo = Instance::<Foo, _>::try_from_base(base).expect("should be able to downcast");
-        assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
+        assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));
 
         let base = foo.into_base();
         assert!(Instance::<NotFoo, _>::try_from_base(base).is_err());

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -76,15 +76,8 @@ fn test_constructor() -> bool {
     let _ = lib.is_singleton();
 
     let path = Path2D::new();
-
-    {
-        let path = unsafe { path.assume_safe() };
-        let _ = path.z_index();
-    }
-
-    unsafe {
-        path.free();
-    }
+    let _ = path.z_index();
+    path.free();
 
     true
 }
@@ -171,18 +164,18 @@ fn test_rust_class_construction() -> bool {
     println!(" -- test_rust_class_construction");
 
     let ok = std::panic::catch_unwind(|| {
-        let foo = Instance::<Foo>::new();
+        let foo = Foo::new_instance();
 
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
 
         let base = foo.into_base();
         assert_eq!(Some(42), base.call("answer".into(), &[]).try_to_i64());
 
-        let foo = Instance::<Foo>::try_from_base(&*base).expect("should be able to downcast");
+        let foo = Instance::<Foo, _>::try_from_base(base).expect("should be able to downcast");
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
 
         let base = foo.into_base();
-        assert!(Instance::<NotFoo>::try_from_base(&*base).is_none());
+        assert!(Instance::<NotFoo, _>::try_from_base(base).is_err());
     })
     .is_ok();
 

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -40,7 +40,7 @@ impl Bar {
     #[export]
     fn free_is_not_ub(&mut self, owner: &Node) -> bool {
         unsafe {
-            owner.claim().free();
+            owner.assume_unique().free();
         }
         assert_eq!(42, self.0, "self should not point to garbage");
         true
@@ -69,8 +69,7 @@ fn test_owner_free_ub() -> bool {
         let drop_counter = Arc::new(AtomicUsize::new(0));
 
         {
-            let bar = Instance::<Bar>::new();
-            let bar = unsafe { bar.assume_safe() };
+            let bar = Bar::new_instance();
 
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
@@ -82,14 +81,11 @@ fn test_owner_free_ub() -> bool {
                     .try_to_bool()
             );
 
-            unsafe {
-                bar.claim().free();
-            }
+            bar.into_base().free();
         }
 
         {
-            let bar = Instance::<Bar>::new();
-            let bar = unsafe { bar.assume_safe() };
+            let bar = Bar::new_instance();
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
 

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -48,7 +48,7 @@ impl Bar {
 
     #[export]
     fn set_script_is_not_ub(&mut self, owner: &Node) -> bool {
-        owner.set_script(None);
+        owner.set_script(Null::null());
         assert_eq!(42, self.0, "self should not point to garbage");
         true
     }

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -81,7 +81,7 @@ fn test_register_property() -> bool {
     println!(" -- test_register_property");
 
     let ok = std::panic::catch_unwind(|| {
-        let obj = Instance::<RegisterProperty>::new();
+        let obj = RegisterProperty::new_instance();
 
         let base = obj.into_base();
 

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -72,7 +72,7 @@ fn test_return_leak() -> bool {
                 .expect("lock should not fail");
 
             let base = probe.into_base().into_shared();
-            animation_tree.set_tree_root(Some(base.cast().unwrap()));
+            animation_tree.set_tree_root(base.cast().unwrap());
         }
 
         assert_eq!(0, drop_counter.load(AtomicOrdering::Acquire));

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -53,9 +53,9 @@ fn test_variant_call_args() -> bool {
     println!(" -- test_variant_call_args");
 
     let ok = std::panic::catch_unwind(|| {
-        let obj = Instance::<VariantCallArgs>::new();
+        let obj = Instance::<VariantCallArgs, _>::new();
 
-        let mut base = obj.into_base().to_variant();
+        let mut base = obj.into_base().into_shared().to_variant();
 
         assert_eq!(
             Some(42),


### PR DESCRIPTION
This (should) make it sound to convert `Shared` references to `Variant`, which has `Send`.

This is a draft. There are known issues and some more changes are planned to address them.

## Known issues

- ~~I find it inconvenient that references can't be used as parameters safely now. I'm thinking about adding a new type for temporary references that tracks typestate (`TRef<'a, T, Access>`?), so we are able to prevent unique references from being passed into methods.~~ Added `TRef` and a new `AsArg` trait for arguments. This however made `None` impossible to infer the for compiler. A new `Null<T>` type is added for this purpose.
- ~~Would it make sense to allow passing `ThreadLocal` references into methods? I guess with the thread-safety guideline assumption this is *probably* sound but I'm not really sure. Need to think about it a bit more.~~ This is not good because it's not possible to tell whether the methods "borrow" the argument or takes it elsewhere where it might be accessed on other threads.
- ~~Dodge the creeps compiles, but the enemies aren't moving. This needs to be fixed.~~
- Currently the bindings won't complain when non-unique `Unique` references are dropped. I added a runtime check originally, but that caused the compiler to complain about specialized `Drop`s. Not sure if there is a good way to do this currently without ATCs or `Drop` specialization.
- We can't have safe conversions to `Ref<T, Unique>` because the reference count isn't exposed in the Godot API. Too bad!
- The `Ref` type exposed a nice interface that removed the need for the ugly `<T as GodotObject>::PersistentRef` qualified type syntax, but inside it's a pile of unspeakable horror due to lack of proper specialization...

---

Close #447