### PR TITLE
Removing duplicated Api::new() calls.

### DIFF
--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -26,10 +26,8 @@ use std::io;
 pub type GeneratorResult<T = ()> = Result<T, io::Error>;
 
 #[allow(clippy::implicit_hasher)]
-pub fn generate_bindings(ignore: Option<HashSet<String>>) -> TokenStream {
+pub fn generate_bindings(api: &Api, ignore: Option<HashSet<String>>) -> TokenStream {
     let to_ignore = ignore.unwrap_or_default();
-
-    let api = Api::new();
 
     let imports = generate_imports();
 
@@ -56,9 +54,7 @@ pub fn generate_imports() -> TokenStream {
     }
 }
 
-pub fn generate_class(class_name: &str) -> TokenStream {
-    let api = Api::new();
-
+pub fn generate_class(api: &Api, class_name: &str) -> TokenStream {
     let class = api.find_class(class_name);
 
     if let Some(class) = class {

--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -14,10 +14,11 @@ fn main() {
     {
         let mut output = BufWriter::new(File::create(&output_rs).unwrap());
 
+        let api = Api::new();
         // gdnative-core already implements all dependencies of Object
-        let to_ignore = strongly_connected_components(&Api::new(), "Object", None);
+        let to_ignore = strongly_connected_components(&api, "Object", None);
 
-        let code = generate_bindings(Some(to_ignore));
+        let code = generate_bindings(&api, Some(to_ignore));
         write!(&mut output, "{}", code).unwrap();
     }
 

--- a/gdnative-core/build.rs
+++ b/gdnative-core/build.rs
@@ -16,9 +16,10 @@ fn main() {
     {
         let mut output = File::create(&generated_rs).unwrap();
 
-        let classes = strongly_connected_components(&Api::new(), "Object", None);
+        let api = Api::new();
+        let classes = strongly_connected_components(&api, "Object", None);
 
-        let code = classes.iter().map(|class| generate_class(&class));
+        let code = classes.iter().map(|class| generate_class(&api, &class));
         let code = quote! {
             #(#code)*
         };


### PR DESCRIPTION
The api.json file was being deserialized more than once. Changed to reuse the first instance.