### PR TITLE
Constrain `assume_safe` lifetime if ref-counted

### DIFF
--- a/gdnative-core/src/nativescript/class.rs
+++ b/gdnative-core/src/nativescript/class.rs
@@ -4,7 +4,10 @@ use crate::nativescript::init::ClassBuilder;
 use crate::nativescript::Map;
 use crate::nativescript::MapMut;
 use crate::nativescript::UserData;
-use crate::object::{QueueFree, RawObject, Ref, RefImplBound, SafeAsRaw, SafeDeref, TRef};
+use crate::object::{
+    AssumeSafeLifetime, LifetimeConstraint, QueueFree, RawObject, Ref, RefImplBound, SafeAsRaw,
+    SafeDeref, TRef,
+};
 use crate::private::get_api;
 use crate::ref_kind::{ManuallyManaged, RefCounted};
 use crate::thread_access::{Shared, ThreadAccess, ThreadLocal, Unique};
@@ -349,7 +352,10 @@ impl<T: NativeClass> Instance<T, Shared> {
     /// It's safe to call `assume_safe` only if the constraints of `Ref::assume_safe`
     /// are satisfied for the base object.
     #[inline]
-    pub unsafe fn assume_safe<'a>(&self) -> RefInstance<'a, T, Shared> {
+    pub unsafe fn assume_safe<'a, 'r>(&'r self) -> RefInstance<'a, T, Shared>
+    where
+        AssumeSafeLifetime<'a, 'r>: LifetimeConstraint<<T::Base as GodotObject>::RefKind>,
+    {
         RefInstance {
             owner: self.owner.assume_safe(),
             script: self.script.clone(),


### PR DESCRIPTION
This makes `assume_safe` slightly safer for reference-counted types at compile time by rejecting code that assume safety for longer than the lifetime of the underlying reference.

Consider this function:

```rust
fn foo(r: Ref<Reference>) {
    let tref = unsafe { r.assume_safe() };
    drop(r);
    tref.claim();
}
```

On current `master`, this will build with no problem, which is *still sound* due to the semantics of `assume_safe`, but not as nice as we want it to be. With this PR, the compiler will now complain that:

```
error[E0505]: cannot move out of `r` because it is borrowed
   |
   |     let tref = unsafe { r.assume_safe() };
   |                         - borrow of `r` occurs here
   |     drop(r);
   |          ^ move out of `r` occurs here
   |     tref.claim();
   |     ---- borrow later used here
```

...which makes it harder to accidentally `assume_safe` for longer than the underlying reference.

This PR adds no inconvenience when dealing with manually-managed objects. The same code with `Node` still compiles normally:

```rust
fn bar(r: Ref<Node>) {
    let tref = unsafe { r.assume_safe() };
    drop(r);
    tref.claim();
}
```

Close #455