### PR TITLE
[424] Enums as Associated Constants

### DIFF
--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -16,6 +16,8 @@ use crate::documentation::*;
 use crate::methods::*;
 use crate::special_methods::*;
 
+use heck::SnakeCase;
+
 use std::io;
 
 pub type GeneratorResult<T = ()> = Result<T, io::Error>;
@@ -122,10 +124,16 @@ fn generate_class_bindings(api: &Api, class: &GodotClass) -> TokenStream {
         Default::default()
     };
 
+    let module = format_ident!("{}", class.name.to_snake_case());
+    let class = format_ident!("{}", class.name);
     quote! {
-        #types_and_methods
-        #traits
-        #methods_and_table
+        pub mod #module {
+            use super::*;
+            #types_and_methods
+            #traits
+            #methods_and_table
+        }
+        pub use crate::generated::#module::#class;
     }
 }
 

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -459,7 +459,7 @@ fn generate_return_pre(ty: &Ty) -> TokenStream {
             let sys_ty = ty.to_sys().unwrap();
             quote !{
                 let mut ret = #sys_ty::default();
-                let ret_ptr = &mut ret as *mut _;
+                let ret_ptr = (&mut ret) as *mut _;
             }
         }
         &Ty::Object(_) // TODO: double check
@@ -489,10 +489,15 @@ fn generate_return_pre(ty: &Ty) -> TokenStream {
                 let ret_ptr = (&mut ret) as *mut _;
             }
         }
-        &Ty::Enum(ref name) => {
-            let name = format_ident!("{}", name);
+        &Ty::Vector3Axis => {
             quote! {
-                let mut ret: #name = mem::transmute(0);
+                let mut ret = crate::generated::vector3::Axis::X;
+                let ret_ptr = (&mut ret) as *mut _;
+            }
+        }
+        &Ty::Enum(ref path) => {
+            quote! {
+                let mut ret = <#path>::from(0i64);
                 let ret_ptr = (&mut ret) as *mut _;
             }
         }

--- a/gdnative-bindings/src/generated.rs
+++ b/gdnative-bindings/src/generated.rs
@@ -1,0 +1,15 @@
+use libc;
+use std::sync::Once;
+
+use gdnative_core::object::*;
+use gdnative_core::thread_access;
+use gdnative_core::*;
+
+use gdnative_core::private::get_api;
+use gdnative_core::sys;
+use gdnative_core::sys::GodotApi;
+use gdnative_core::vector3;
+
+use crate::generated::reference::*;
+
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -1,19 +1,9 @@
 #![allow(non_snake_case)] // because of the generated bindings.
-#![allow(unused_imports)]
 #![allow(unused_unsafe)]
 // False positives on generated drops that enforce lifetime
 #![allow(clippy::drop_copy)]
 // Disable non-critical lints for generated code.
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
-use gdnative_core::object::{self};
-use gdnative_core::private::get_api;
-use gdnative_core::sys;
-use gdnative_core::sys::GodotApi;
-use gdnative_core::*;
-
-use libc;
-use std::ops::*;
-use std::sync::Once;
-
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+mod generated;
+pub use generated::*;

--- a/gdnative-core/src/core_types/vector3.rs
+++ b/gdnative-core/src/core_types/vector3.rs
@@ -1,5 +1,13 @@
 use crate::Vector3;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Axis {
+    X = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_X as u32,
+    Y = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_Y as u32,
+    Z = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_Z as u32,
+}
+
 /// Helper methods for `Vector3`.
 ///
 /// Trait used to provide additional methods that are equivalent to Godot's methods.
@@ -47,15 +55,15 @@ godot_test!(
             unsafe {
                 assert_relative_eq!(vector.x, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
-                    crate::Vector3Axis::X as u32 as sys::godot_vector3_axis
+                    Axis::X as u32 as sys::godot_vector3_axis
                 ));
                 assert_relative_eq!(vector.y, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
-                    crate::Vector3Axis::Y as u32 as sys::godot_vector3_axis
+                    Axis::Y as u32 as sys::godot_vector3_axis
                 ));
                 assert_relative_eq!(vector.z, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
-                    crate::Vector3Axis::Z as u32 as sys::godot_vector3_axis
+                    Axis::Z as u32 as sys::godot_vector3_axis
                 ));
             }
             assert_eq!(vector, copied);
@@ -64,17 +72,17 @@ godot_test!(
             unsafe {
                 (api.godot_vector3_set_axis)(
                     &mut copied as *mut _ as *mut sys::godot_vector3,
-                    crate::Vector3Axis::X as u32 as sys::godot_vector3_axis,
+                    Axis::X as u32 as sys::godot_vector3_axis,
                     set_to.x
                 );
                 (api.godot_vector3_set_axis)(
                     &mut copied as *mut _ as *mut sys::godot_vector3,
-                    crate::Vector3Axis::Y as u32 as sys::godot_vector3_axis,
+                    Axis::Y as u32 as sys::godot_vector3_axis,
                     set_to.y
                 );
                 (api.godot_vector3_set_axis)(
                     &mut copied as *mut _ as *mut sys::godot_vector3,
-                    crate::Vector3Axis::Z as u32 as sys::godot_vector3_axis,
+                    Axis::Z as u32 as sys::godot_vector3_axis,
                     set_to.z
                 );
             }

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -61,12 +61,4 @@ pub use sys::GodotApi;
 #[doc(inline)]
 pub use error::GodotError;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
-pub enum Vector3Axis {
-    X = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_X as u32,
-    Y = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_Y as u32,
-    Z = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_Z as u32,
-}
-
 pub type GodotResult = Result<(), GodotError>;


### PR DESCRIPTION
For every Enum there is a newtype created with Name(i64) as the format.
Renaming rules are simpler:

1. Removes common prefix for Enum variants, only if all variants have the same prefix:
2. If the variant would then start with a number, prefix with an underscore.

Examples:
```
    pub struct Eyes(pub i64);
    impl Eyes {
        pub const MONO: Eyes = Eyes(0i64);
        pub const LEFT: Eyes = Eyes(1i64);
        pub const RIGHT: Eyes = Eyes(2i64);
    }

    pub struct FilterDb(pub i64);
    impl FilterDb {
        pub const _6DB: FilterDb = FilterDb(0i64);
        pub const _12DB: FilterDb = FilterDb(1i64);
        pub const _18DB: FilterDb = FilterDb(2i64);
        pub const _24DB: FilterDb = FilterDb(3i64);
    }
```

A big grep of the enum variants:
https://paste.sr.ht/~halzy/2331aa3fbc37f29b5f08c8421e0080aab6f5e4ae