### PR TITLE
Removing serde_derive in favor of serde feature derive.

### DIFF
--- a/bindings_generator/Cargo.toml
+++ b/bindings_generator/Cargo.toml
@@ -16,7 +16,6 @@ debug = []
 heck = "0.3.0"
 proc-macro2 = "1.0.6"
 quote = "1.0.2"
-serde = "1.0.15"
-serde_derive = "1.0.15"
+serde = { version = "1.0.15", features = ["derive"] }
 serde_json = "1.0.3"
 syn = { version = "1.0", features = ["full", "extra-traits", "visit"] }

--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::{HashMap, HashSet};

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate serde_derive;
-
 use proc_macro2::TokenStream;
 
 use quote::{format_ident, quote};


### PR DESCRIPTION
Removes the need for `extern crate`