### PR TITLE
[441] unsafe call, callv, call_deferred

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -169,7 +169,9 @@ fn test_rust_class_construction() -> bool {
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));
 
         let base = foo.into_base();
-        assert_eq!(Some(42), base.call("answer".into(), &[]).try_to_i64());
+        assert_eq!(Some(42), unsafe {
+            base.call("answer".into(), &[]).try_to_i64()
+        });
 
         let foo = Instance::<Foo, _>::try_from_base(base).expect("should be able to downcast");
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -74,12 +74,11 @@ fn test_owner_free_ub() -> bool {
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
 
-            assert_eq!(
-                Some(true),
+            assert_eq!(Some(true), unsafe {
                 bar.base()
                     .call("set_script_is_not_ub".into(), &[])
                     .try_to_bool()
-            );
+            });
 
             bar.into_base().free();
         }
@@ -89,10 +88,9 @@ fn test_owner_free_ub() -> bool {
             bar.map_mut(|bar, _| bar.set_drop_counter(drop_counter.clone()))
                 .expect("lock should not fail");
 
-            assert_eq!(
-                Some(true),
+            assert_eq!(Some(true), unsafe {
                 bar.base().call("free_is_not_ub".into(), &[]).try_to_bool()
-            );
+            });
         }
 
         // the values are eventually dropped

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -85,15 +85,21 @@ fn test_register_property() -> bool {
 
         let base = obj.into_base();
 
-        assert_eq!(Some(42), base.call("get_value".into(), &[]).try_to_i64());
+        assert_eq!(Some(42), unsafe {
+            base.call("get_value".into(), &[]).try_to_i64()
+        });
 
         base.set("value".into(), 54.to_variant());
 
-        assert_eq!(Some(54), base.call("get_value".into(), &[]).try_to_i64());
+        assert_eq!(Some(54), unsafe {
+            base.call("get_value".into(), &[]).try_to_i64()
+        });
 
-        base.call("set_value".into(), &[4242.to_variant()]);
+        unsafe { base.call("set_value".into(), &[4242.to_variant()]) };
 
-        assert_eq!(Some(4242), base.call("get_value".into(), &[]).try_to_i64());
+        assert_eq!(Some(4242), unsafe {
+            base.call("get_value".into(), &[]).try_to_i64()
+        });
     })
     .is_ok();
 


### PR DESCRIPTION
Per #441 This makes those functions unsafe. Using slice of tuples for simplicity.

Closes #441 