### PR TITLE
Improving incremental builds

### DIFF
--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT"
 workspace = ".."
 edition = "2018"
 
+[features]
+formatted = []
+
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.8.1" }
 gdnative-core = { path = "../gdnative-core", version = "0.8.1" }

--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -20,9 +20,20 @@ fn main() {
         write!(&mut output, "{}", code).unwrap();
     }
 
+    if cfg!(feature = "formatted") {
+        format_file(&output_rs);
+    }
+
+    // build.rs will automatically be recompiled and run if it's dependencies are updated.
+    // Ignoring all but build.rs will keep from needless rebuilds.
+    // Manually rebuilding the crate will ignore this.
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn format_file(output_rs: &PathBuf) {
     print!(
         "Formatting generated file: {}... ",
-        output_rs.file_name().map(|s| s.to_str()).flatten().unwrap()
+        output_rs.file_name().and_then(|s| s.to_str()).unwrap()
     );
     match Command::new("rustup")
         .arg("run")

--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -8,6 +8,10 @@ fn main() {
     header_binding::generate(&manifest_dir, &out_dir);
 
     api_wrapper::generate(&api_json_file, &out_dir, "api_wrapper.rs");
+
+    // Only re-run build.rs if the gdnative_api.json file has been updated.
+    // Manually rebuilding the crate will ignore this.
+    println!("cargo:rerun-if-changed={}", api_json_file);
 }
 
 mod header_binding {


### PR DESCRIPTION
Using `cargo:rerun-if-changed` to signal when build.rs should run.