### PR TITLE
add a curated prelude module to gdnative and gdnative-core

### DIFF
--- a/examples/dodge_the_creeps/src/extensions.rs
+++ b/examples/dodge_the_creeps/src/extensions.rs
@@ -1,5 +1,4 @@
-use gdnative::api::Node;
-use gdnative::*;
+use gdnative::prelude::*;
 
 pub trait NodeExt {
     /// Gets a node at `path`, assumes that it's safe to use, and casts it to `T`.
@@ -10,14 +9,14 @@ pub trait NodeExt {
     unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
         &self,
         path: P,
-    ) -> TRef<'_, T, thread_access::Shared>;
+    ) -> TRef<'_, T, Shared>;
 }
 
 impl NodeExt for Node {
     unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
         &self,
         path: P,
-    ) -> TRef<'_, T, thread_access::Shared> {
+    ) -> TRef<'_, T, Shared> {
         self.get_node(path.into())
             .expect("node should exist")
             .assume_safe()

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -1,6 +1,5 @@
 use crate::extensions::NodeExt as _;
-use gdnative::api::*;
-use gdnative::*;
+use gdnative::prelude::*;
 
 #[derive(NativeClass)]
 #[inherit(CanvasLayer)]
@@ -10,8 +9,8 @@ pub struct HUD;
 
 #[methods]
 impl HUD {
-    fn register_hud(builder: &init::ClassBuilder<Self>) {
-        builder.add_signal(init::Signal {
+    fn register_hud(builder: &ClassBuilder<Self>) {
+        builder.add_signal(Signal {
             name: "start_game",
             args: &[],
         });

--- a/examples/dodge_the_creeps/src/lib.rs
+++ b/examples/dodge_the_creeps/src/lib.rs
@@ -7,7 +7,7 @@ mod main_scene;
 mod mob;
 mod player;
 
-fn init(handle: gdnative::init::InitHandle) {
+fn init(handle: gdnative::prelude::InitHandle) {
     handle.add_class::<player::Player>();
     handle.add_class::<mob::Mob>();
     handle.add_class::<main_scene::Main>();

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -2,10 +2,8 @@ use crate::extensions::NodeExt as _;
 use crate::hud;
 use crate::mob;
 use crate::player;
-use gdnative::api::*;
-use gdnative::ref_kind::ManuallyManaged;
-use gdnative::thread_access::{Shared, Unique};
-use gdnative::*;
+use gdnative::api::{Area2D, PathFollow2D, Position2D, RigidBody2D};
+use gdnative::prelude::*;
 use rand::*;
 use std::f64::consts::PI;
 

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -1,6 +1,6 @@
 use crate::extensions::NodeExt;
-use gdnative::api::*;
-use gdnative::*;
+use gdnative::api::{AnimatedSprite, RigidBody2D};
+use gdnative::prelude::*;
 use rand::seq::SliceRandom;
 
 #[derive(NativeClass)]

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -1,6 +1,6 @@
 use crate::extensions::NodeExt as _;
-use gdnative::api::*;
-use gdnative::*;
+use gdnative::api::{AnimatedSprite, Area2D, CollisionShape2D, PhysicsBody2D};
+use gdnative::prelude::*;
 
 /// The player "class"
 #[derive(NativeClass)]
@@ -16,8 +16,8 @@ pub struct Player {
 
 #[methods]
 impl Player {
-    fn register_player(builder: &init::ClassBuilder<Self>) {
-        builder.add_signal(init::Signal {
+    fn register_player(builder: &ClassBuilder<Self>) {
+        builder.add_signal(Signal {
             name: "hit",
             args: &[],
         });

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -1,23 +1,25 @@
 #[macro_use]
 extern crate gdnative;
 
-#[derive(gdnative::NativeClass)]
-#[inherit(gdnative::api::Node)]
+use gdnative::prelude::*;
+
+#[derive(NativeClass)]
+#[inherit(Node)]
 struct HelloWorld;
 
 #[gdnative::methods]
 impl HelloWorld {
-    fn _init(_owner: &gdnative::api::Node) -> Self {
+    fn _init(_owner: &Node) -> Self {
         HelloWorld
     }
 
     #[export]
-    fn _ready(&self, _owner: &gdnative::api::Node) {
+    fn _ready(&self, _owner: &Node) {
         godot_print!("hello, world.")
     }
 }
 
-fn init(handle: gdnative::init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<HelloWorld>();
 }
 

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -3,10 +3,7 @@ extern crate gdnative;
 extern crate euclid;
 
 use euclid::vec3;
-use gdnative::api::{Node, PackedScene, ResourceLoader, Spatial};
-use gdnative::ref_kind::ManuallyManaged;
-use gdnative::thread_access::{ThreadLocal, Unique};
-use gdnative::{GodotString, Ref, Variant};
+use gdnative::prelude::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ManageErrs {
@@ -109,7 +106,7 @@ impl SceneCreate {
     }
 }
 
-fn init(handle: gdnative::init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<SceneCreate>();
 }
 

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -1,5 +1,4 @@
-use gdnative::api::{Label, Node};
-use gdnative::*;
+use gdnative::prelude::*;
 
 #[derive(NativeClass)]
 #[inherit(Node)]
@@ -12,20 +11,20 @@ struct SignalEmitter {
 
 #[methods]
 impl SignalEmitter {
-    fn register_signals(builder: &init::ClassBuilder<Self>) {
-        builder.add_signal(init::Signal {
+    fn register_signals(builder: &ClassBuilder<Self>) {
+        builder.add_signal(Signal {
             name: "tick",
             args: &[],
         });
 
-        builder.add_signal(init::Signal {
+        builder.add_signal(Signal {
             name: "tick_with_data",
             // Argument list used by the editor for GUI and generation of GDScript handlers. It can be omitted if the signal is only used from code.
-            args: &[init::SignalArgument {
+            args: &[SignalArgument {
                 name: "data",
                 default: Variant::from_i64(100),
-                export_info: init::ExportInfo::new(VariantType::I64),
-                usage: init::PropertyUsage::DEFAULT,
+                export_info: ExportInfo::new(VariantType::I64),
+                usage: PropertyUsage::DEFAULT,
             }],
         });
     }
@@ -116,11 +115,11 @@ impl SignalSubscriber {
     }
 }
 
-fn init(handle: init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<SignalEmitter>();
     handle.add_class::<SignalSubscriber>();
 }
 
-godot_gdnative_init!();
-godot_nativescript_init!(init);
-godot_gdnative_terminate!();
+gdnative::godot_gdnative_init!();
+gdnative::godot_nativescript_init!(init);
+gdnative::godot_gdnative_terminate!();

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -2,19 +2,21 @@
 extern crate gdnative;
 
 use gdnative::api::MeshInstance;
-use gdnative::init::property::{EnumHint, IntHint, StringHint};
+use gdnative::prelude::*;
+
+use gdnative::nativescript::init::property::{EnumHint, IntHint, StringHint};
 
 #[derive(gdnative::NativeClass)]
 #[inherit(MeshInstance)]
 #[register_with(register_properties)]
 struct RustTest {
-    start: gdnative::Vector3,
+    start: Vector3,
     time: f32,
     #[property(path = "base/rotate_speed")]
     rotate_speed: f64,
 }
 
-fn register_properties(builder: &gdnative::init::ClassBuilder<RustTest>) {
+fn register_properties(builder: &ClassBuilder<RustTest>) {
     builder
         .add_property::<String>("test/test_enum")
         .with_hint(StringHint::Enum(EnumHint::new(vec![
@@ -41,7 +43,7 @@ fn register_properties(builder: &gdnative::init::ClassBuilder<RustTest>) {
 impl RustTest {
     fn _init(_owner: &MeshInstance) -> Self {
         RustTest {
-            start: gdnative::Vector3::new(0.0, 0.0, 0.0),
+            start: Vector3::new(0.0, 0.0, 0.0),
             time: 0.0,
             rotate_speed: 0.05,
         }
@@ -54,7 +56,7 @@ impl RustTest {
 
     #[export]
     fn _physics_process(&mut self, owner: &MeshInstance, delta: f64) {
-        use gdnative::{api::SpatialMaterial, Color, Vector3};
+        use gdnative::api::SpatialMaterial;
 
         self.time += delta as f32;
         owner.rotate_y(self.rotate_speed * delta);
@@ -70,7 +72,7 @@ impl RustTest {
     }
 }
 
-fn init(handle: gdnative::init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<RustTest>();
 }
 

--- a/gdnative-bindings/src/generated.rs
+++ b/gdnative-bindings/src/generated.rs
@@ -1,14 +1,13 @@
 use libc;
 use std::sync::Once;
 
+use gdnative_core::core_types::*;
 use gdnative_core::object::*;
-use gdnative_core::thread_access;
-use gdnative_core::*;
-
 use gdnative_core::private::get_api;
 use gdnative_core::sys;
 use gdnative_core::sys::GodotApi;
-use gdnative_core::vector3;
+use gdnative_core::thread_access;
+use gdnative_core::*;
 
 use crate::generated::reference::*;
 

--- a/gdnative-core/src/core_types/byte_array.rs
+++ b/gdnative-core/src/core_types/byte_array.rs
@@ -1,4 +1,4 @@
-use crate::typed_array::TypedArray;
+use crate::core_types::typed_array::TypedArray;
 
 /// A reference-counted vector of `u8` that uses Godot's pool allocator.
 pub type ByteArray = TypedArray<u8>;

--- a/gdnative-core/src/core_types/color_array.rs
+++ b/gdnative-core/src/core_types/color_array.rs
@@ -1,5 +1,5 @@
-use crate::typed_array::TypedArray;
-use crate::Color;
+use crate::core_types::typed_array::TypedArray;
+use crate::core_types::Color;
 
 /// A reference-counted vector of `Color` that uses Godot's pool allocator.
 pub type ColorArray = TypedArray<Color>;

--- a/gdnative-core/src/core_types/dictionary.rs
+++ b/gdnative-core/src/core_types/dictionary.rs
@@ -1,15 +1,15 @@
 use std::iter::{Extend, FromIterator};
 use std::marker::PhantomData;
 
+use crate::core_types::GodotString;
 use crate::private::get_api;
 use crate::sys;
-use crate::GodotString;
 
+use crate::core_types::ToVariant;
+use crate::core_types::ToVariantEq;
+use crate::core_types::Variant;
+use crate::core_types::VariantArray;
 use crate::NewRef;
-use crate::ToVariant;
-use crate::ToVariantEq;
-use crate::Variant;
-use crate::VariantArray;
 use std::fmt;
 
 use crate::thread_access::*;
@@ -518,7 +518,7 @@ impl Extend<(Variant, Variant)> for Dictionary<Unique> {
 godot_test!(test_dictionary {
     use std::collections::HashSet;
 
-    use crate::VariantType;
+    use crate::core_types::VariantType;
     let foo = Variant::from_str("foo");
     let bar = Variant::from_str("bar");
     let nope = Variant::from_str("nope");

--- a/gdnative-core/src/core_types/float32_array.rs
+++ b/gdnative-core/src/core_types/float32_array.rs
@@ -1,4 +1,4 @@
-use crate::typed_array::TypedArray;
+use crate::core_types::typed_array::TypedArray;
 
 /// A reference-counted vector of `f32` that uses Godot's pool allocator.
 pub type Float32Array = TypedArray<f32>;

--- a/gdnative-core/src/core_types/geom/aabb.rs
+++ b/gdnative-core/src/core_types/geom/aabb.rs
@@ -1,4 +1,4 @@
-use crate::Vector3;
+use crate::core_types::Vector3;
 
 /// Axis-aligned bounding box.
 #[repr(C)]

--- a/gdnative-core/src/core_types/geom/basis.rs
+++ b/gdnative-core/src/core_types/geom/basis.rs
@@ -1,4 +1,4 @@
-use crate::{Quat, Vector3};
+use crate::core_types::{Quat, Vector3};
 use euclid::{approxeq::ApproxEq, default, Transform3D, UnknownUnit, Vector3D};
 
 /// A 3x3 matrix.

--- a/gdnative-core/src/core_types/geom/plane.rs
+++ b/gdnative-core/src/core_types/geom/plane.rs
@@ -1,4 +1,4 @@
-use crate::Vector3;
+use crate::core_types::Vector3;
 
 /// Plane in hessian form.
 #[repr(C)]

--- a/gdnative-core/src/core_types/geom/transform.rs
+++ b/gdnative-core/src/core_types/geom/transform.rs
@@ -1,4 +1,4 @@
-use crate::{Basis, Vector3};
+use crate::core_types::{Basis, Vector3};
 use euclid::{default, Point3D, Transform3D, UnknownUnit};
 
 /// 3D Transformation (3x4 matrix) Using basis + origin representation.

--- a/gdnative-core/src/core_types/int32_array.rs
+++ b/gdnative-core/src/core_types/int32_array.rs
@@ -1,4 +1,4 @@
-use crate::typed_array::TypedArray;
+use crate::core_types::typed_array::TypedArray;
 
 /// A reference-counted vector of `i32` that uses Godot's pool allocator.
 pub type Int32Array = TypedArray<i32>;

--- a/gdnative-core/src/core_types/node_path.rs
+++ b/gdnative-core/src/core_types/node_path.rs
@@ -1,6 +1,6 @@
+use crate::core_types::GodotString;
 use crate::private::get_api;
 use crate::sys;
-use crate::GodotString;
 use crate::NewRef;
 use std::fmt;
 

--- a/gdnative-core/src/core_types/point2.rs
+++ b/gdnative-core/src/core_types/point2.rs
@@ -1,4 +1,4 @@
-use crate::{Angle, Point2, Vector2};
+use crate::core_types::{Angle, Point2, Vector2};
 use euclid::Trig;
 
 /// Helper methods for `Point2`.

--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -419,7 +419,7 @@ where
 }
 
 godot_test!(test_string {
-    use crate::{GodotString, Variant, VariantType};
+    use crate::core_types::{GodotString, Variant, VariantType};
 
     let foo: GodotString = "foo".into();
     assert_eq!(foo.len(), 3);

--- a/gdnative-core/src/core_types/string_array.rs
+++ b/gdnative-core/src/core_types/string_array.rs
@@ -1,5 +1,5 @@
-use crate::typed_array::TypedArray;
-use crate::GodotString;
+use crate::core_types::typed_array::TypedArray;
+use crate::core_types::GodotString;
 
 /// A reference-counted vector of `GodotString` that uses Godot's pool allocator.
 pub type StringArray = TypedArray<GodotString>;

--- a/gdnative-core/src/core_types/typed_array.rs
+++ b/gdnative-core/src/core_types/typed_array.rs
@@ -4,10 +4,12 @@ use std::iter::{Extend, FromIterator};
 
 use gdnative_impl_proc_macros as macros;
 
-use crate::access::{Aligned, MaybeUnaligned};
+use crate::core_types::access::{Aligned, MaybeUnaligned};
+use crate::core_types::{
+    Color, GodotString, VariantArray, Vector2, Vector2Godot, Vector3, Vector3Godot,
+};
 use crate::private::get_api;
 use crate::NewRef;
-use crate::{Color, GodotString, VariantArray, Vector2, Vector2Godot, Vector3, Vector3Godot};
 
 /// A reference-counted CoW typed vector using Godot's pool allocator, generic over possible
 /// element types.
@@ -342,7 +344,7 @@ impl<'a, T: Element> ReadGuard<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Element> crate::access::Guard for ReadGuard<'a, T> {
+unsafe impl<'a, T: Element> crate::core_types::access::Guard for ReadGuard<'a, T> {
     type Target = T;
 
     #[inline]
@@ -402,7 +404,7 @@ impl<'a, T: Element> WriteGuard<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Element> crate::access::Guard for WriteGuard<'a, T> {
+unsafe impl<'a, T: Element> crate::core_types::access::Guard for WriteGuard<'a, T> {
     type Target = T;
 
     #[inline]
@@ -418,7 +420,7 @@ unsafe impl<'a, T: Element> crate::access::Guard for WriteGuard<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Element> crate::access::WritePtr for WriteGuard<'a, T> {}
+unsafe impl<'a, T: Element> crate::core_types::access::WritePtr for WriteGuard<'a, T> {}
 
 impl<'a, T: Element> Drop for WriteGuard<'a, T> {
     #[inline]

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::mem::{forget, transmute};
 use std::ptr;
 
+use crate::core_types::*;
+use crate::object::*;
 use crate::private::{get_api, ManuallyManagedClassPlaceholder};
 use crate::thread_access::*;
 
@@ -1508,7 +1510,7 @@ from_variant_from_sys!(
     impl FromVariant for Dictionary<Shared> as Dictionary : godot_variant_as_dictionary;
 );
 
-impl<T: crate::typed_array::Element> ToVariant for TypedArray<T> {
+impl<T: crate::core_types::typed_array::Element> ToVariant for TypedArray<T> {
     #[inline]
     fn to_variant(&self) -> Variant {
         unsafe {
@@ -1519,9 +1521,9 @@ impl<T: crate::typed_array::Element> ToVariant for TypedArray<T> {
         }
     }
 }
-impl<T: crate::typed_array::Element + Eq> ToVariantEq for TypedArray<T> {}
+impl<T: crate::core_types::typed_array::Element + Eq> ToVariantEq for TypedArray<T> {}
 
-impl<T: crate::typed_array::Element> FromVariant for TypedArray<T> {
+impl<T: crate::core_types::typed_array::Element> FromVariant for TypedArray<T> {
     #[inline]
     fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
         unsafe {

--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -4,9 +4,9 @@ use std::marker::PhantomData;
 use crate::private::get_api;
 use crate::sys;
 
+use crate::core_types::ToVariant;
+use crate::core_types::Variant;
 use crate::NewRef;
-use crate::ToVariant;
-use crate::Variant;
 
 use crate::thread_access::*;
 

--- a/gdnative-core/src/core_types/vector2.rs
+++ b/gdnative-core/src/core_types/vector2.rs
@@ -1,4 +1,4 @@
-use crate::{Angle, Rotation2D, Vector2};
+use crate::core_types::{Angle, Rotation2D, Vector2};
 
 /// Helper methods for `Vector2`.
 ///
@@ -107,10 +107,10 @@ impl Vector2Godot for Vector2 {
 
 godot_test!(
     test_vector2_variants {
-        use crate::ToVariant;
+        use crate::core_types::ToVariant;
 
         fn test(vector: Vector2, set_to: Vector2) {
-            use crate::FromVariant;
+            use crate::core_types::FromVariant;
             let api = crate::private::get_api();
 
             let copied = vector;
@@ -145,8 +145,8 @@ godot_test!(
 
 #[cfg(test)]
 mod tests {
-    use crate::vector2::Vector2Godot;
-    use crate::Vector2;
+    use crate::core_types::vector2::Vector2Godot;
+    use crate::core_types::Vector2;
 
     #[test]
     fn it_is_copy() {

--- a/gdnative-core/src/core_types/vector2_array.rs
+++ b/gdnative-core/src/core_types/vector2_array.rs
@@ -1,5 +1,5 @@
-use crate::typed_array::TypedArray;
-use crate::Vector2;
+use crate::core_types::typed_array::TypedArray;
+use crate::core_types::Vector2;
 
 /// A reference-counted vector of `Vector2` that uses Godot's pool allocator.
 pub type Vector2Array = TypedArray<Vector2>;

--- a/gdnative-core/src/core_types/vector3.rs
+++ b/gdnative-core/src/core_types/vector3.rs
@@ -1,4 +1,4 @@
-use crate::Vector3;
+use crate::core_types::Vector3;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u32)]
@@ -46,7 +46,7 @@ impl Vector3Godot for Vector3 {
 
 godot_test!(
     test_vector3_variants {
-        use crate::{FromVariant, ToVariant, Vector3};
+        use crate::core_types::{FromVariant, ToVariant, Vector3};
 
         fn test(vector: Vector3, set_to: Vector3) {
             let api = crate::private::get_api();
@@ -100,7 +100,7 @@ godot_test!(
 
 #[cfg(test)]
 mod tests {
-    use crate::Vector3;
+    use crate::core_types::Vector3;
 
     #[test]
     fn it_is_copy() {

--- a/gdnative-core/src/core_types/vector3_array.rs
+++ b/gdnative-core/src/core_types/vector3_array.rs
@@ -1,5 +1,5 @@
-use crate::typed_array::TypedArray;
-use crate::Vector3;
+use crate::core_types::typed_array::TypedArray;
+use crate::core_types::Vector3;
 
 /// A reference-counted vector of `Vector3` that uses Godot's pool allocator.
 pub type Vector3Array = TypedArray<Vector3>;

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -36,15 +36,11 @@ extern crate approx;
 mod macros;
 
 pub mod core_types;
-pub use core_types::*;
 
 #[cfg(feature = "nativescript")]
 pub mod nativescript;
-#[cfg(feature = "nativescript")]
-pub use nativescript::*;
 
 mod new_ref;
-#[doc(hidden)]
 pub mod object;
 pub mod ref_kind;
 pub mod thread_access;
@@ -53,12 +49,11 @@ pub mod thread_access;
 #[doc(hidden)]
 pub mod private;
 
-pub use crate::new_ref::NewRef;
-pub use crate::object::{AsArg, GodotObject, Instanciable, Null, QueueFree, Ref, TRef};
+//
+// Re-exports
+//
 
-pub use sys::GodotApi;
+pub use new_ref::NewRef;
+pub use object::{GodotObject, Null, Ref, TRef};
 
-#[doc(inline)]
-pub use error::GodotError;
-
-pub type GodotResult = Result<(), GodotError>;
+pub type GodotResult = Result<(), core_types::error::GodotError>;

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -106,7 +106,7 @@ macro_rules! godot_print {
 
         #[allow(unused_unsafe)]
         unsafe {
-            let msg = $crate::GodotString::from_str(msg);
+            let msg = $crate::core_types::GodotString::from_str(msg);
             ($crate::private::get_api().godot_print)(&msg.to_sys() as *const _);
         }
     });

--- a/gdnative-core/src/nativescript/class.rs
+++ b/gdnative-core/src/nativescript/class.rs
@@ -1,5 +1,8 @@
 use std::ptr::NonNull;
 
+use crate::core_types::{
+    FromVariant, FromVariantError, GodotString, OwnedToVariant, ToVariant, Variant,
+};
 use crate::nativescript::init::ClassBuilder;
 use crate::nativescript::Map;
 use crate::nativescript::MapMut;
@@ -8,17 +11,10 @@ use crate::object::{
     AssumeSafeLifetime, LifetimeConstraint, QueueFree, RawObject, Ref, RefImplBound, SafeAsRaw,
     SafeDeref, TRef,
 };
+use crate::object::{GodotObject, Instanciable};
 use crate::private::{get_api, ReferenceCountedClassPlaceholder};
 use crate::ref_kind::{ManuallyManaged, RefCounted};
 use crate::thread_access::{Shared, ThreadAccess, ThreadLocal, Unique};
-use crate::FromVariant;
-use crate::FromVariantError;
-use crate::GodotObject;
-use crate::GodotString;
-use crate::Instanciable;
-use crate::OwnedToVariant;
-use crate::ToVariant;
-use crate::Variant;
 
 /// Trait used for describing and initializing a Godot script class.
 ///

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -36,11 +36,11 @@ use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ptr;
 
+use crate::core_types::{GodotString, Variant};
 use crate::nativescript::NativeClass;
 use crate::nativescript::NativeClassMethods;
 use crate::nativescript::UserData;
 use crate::private::get_api;
-use crate::Variant;
 
 pub mod property;
 

--- a/gdnative-core/src/nativescript/init/property.rs
+++ b/gdnative-core/src/nativescript/init/property.rs
@@ -1,10 +1,11 @@
 //! Property registration.
 
+use crate::core_types::*;
 use crate::nativescript::{Instance, NativeClass};
 use crate::object::GodotObject;
+use crate::object::Ref;
 use crate::private::get_api;
 use crate::thread_access::Shared;
-use crate::*;
 
 use super::ClassBuilder;
 

--- a/gdnative-core/src/nativescript/init/property/accessor.rs
+++ b/gdnative-core/src/nativescript/init/property/accessor.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
+use crate::core_types::{FromVariant, ToVariant, Variant};
 use crate::nativescript::user_data::UserData;
 use crate::nativescript::Map;
 use crate::nativescript::MapMut;

--- a/gdnative-core/src/nativescript/init/property/accessor/invalid.rs
+++ b/gdnative-core/src/nativescript/init/property/accessor/invalid.rs
@@ -2,6 +2,7 @@
 
 use std::mem;
 
+use crate::core_types::{FromVariant, ToVariant, Variant};
 use crate::nativescript::NativeClass;
 use crate::*;
 

--- a/gdnative-core/src/nativescript/init/property/hint.rs
+++ b/gdnative-core/src/nativescript/init/property/hint.rs
@@ -3,9 +3,9 @@
 use std::fmt::{self, Write};
 use std::ops::RangeInclusive;
 
+use crate::core_types::GodotString;
+use crate::core_types::VariantType;
 use crate::sys;
-use crate::GodotString;
-use crate::VariantType;
 
 use super::ExportInfo;
 
@@ -16,7 +16,7 @@ use super::ExportInfo;
 /// Basic usage:
 ///
 /// ```rust
-/// use gdnative_core::init::property::hint::RangeHint;
+/// use gdnative_core::nativescript::init::property::hint::RangeHint;
 ///
 /// let hint: RangeHint<f64> = RangeHint::new(0.0, 20.0).or_greater();
 /// ```
@@ -110,7 +110,7 @@ where
 /// Basic usage:
 ///
 /// ```rust
-/// use gdnative_core::init::property::hint::EnumHint;
+/// use gdnative_core::nativescript::init::property::hint::EnumHint;
 ///
 /// let hint = EnumHint::new(vec!["Foo".into(), "Bar".into(), "Baz".into()]);
 /// ```

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -90,7 +90,7 @@ macro_rules! godot_wrap_method_inner {
                         "gdnative-core: user data pointer for {} is null (did the constructor fail?)",
                         stringify!($type_name),
                     );
-                    return $crate::Variant::new().forget();
+                    return $crate::core_types::Variant::new().forget();
                 }
 
                 let this = match std::ptr::NonNull::new(this) {
@@ -100,7 +100,7 @@ macro_rules! godot_wrap_method_inner {
                             "gdnative-core: base object pointer for {} is null (probably a bug in Godot)",
                             stringify!($type_name),
                         );
-                        return $crate::Variant::new().forget();
+                        return $crate::core_types::Variant::new().forget();
                     },
                 };
 
@@ -114,20 +114,20 @@ macro_rules! godot_wrap_method_inner {
                     let num_required_params = $crate::godot_wrap_method_parameter_count!($($pname,)*);
                     if num_args < num_required_params {
                         $crate::godot_error!("Incorrect number of parameters: required {} but got {}", num_required_params, num_args);
-                        return $crate::Variant::new();
+                        return $crate::core_types::Variant::new();
                     }
 
                     let num_optional_params = $crate::godot_wrap_method_parameter_count!($($opt_pname,)*);
                     let num_max_params = num_required_params + num_optional_params;
                     if num_args > num_max_params {
                         $crate::godot_error!("Incorrect number of parameters: expected at most {} but got {}", num_max_params, num_args);
-                        return $crate::Variant::new();
+                        return $crate::core_types::Variant::new();
                     }
 
                     let mut offset = 0;
                     $(
-                        let _variant: &$crate::Variant = ::std::mem::transmute(&mut **(args.offset(offset)));
-                        let $pname = match <$pty as $crate::FromVariant>::from_variant(_variant) {
+                        let _variant: &$crate::core_types::Variant = ::std::mem::transmute(&mut **(args.offset(offset)));
+                        let $pname = match <$pty as $crate::core_types::FromVariant>::from_variant(_variant) {
                             Ok(val) => val,
                             Err(err) => {
                                 $crate::godot_error!(
@@ -137,7 +137,7 @@ macro_rules! godot_wrap_method_inner {
                                     ty = stringify!($pty),
                                     err = err,
                                 );
-                                return $crate::Variant::new();
+                                return $crate::core_types::Variant::new();
                             },
                         };
 
@@ -146,9 +146,9 @@ macro_rules! godot_wrap_method_inner {
 
                     $(
                         let $opt_pname = if offset < num_args {
-                            let _variant: &$crate::Variant = ::std::mem::transmute(&mut **(args.offset(offset)));
+                            let _variant: &$crate::core_types::Variant = ::std::mem::transmute(&mut **(args.offset(offset)));
 
-                            let $opt_pname = match <$opt_pty as $crate::FromVariant>::from_variant(_variant) {
+                            let $opt_pname = match <$opt_pty as $crate::core_types::FromVariant>::from_variant(_variant) {
                                 Ok(val) => val,
                                 Err(err) => {
                                     $crate::godot_error!(
@@ -158,7 +158,7 @@ macro_rules! godot_wrap_method_inner {
                                         ty = stringify!($opt_pty),
                                         err = err,
                                     );
-                                    return $crate::Variant::new();
+                                    return $crate::core_types::Variant::new();
                                 },
                             };
 
@@ -178,12 +178,12 @@ macro_rules! godot_wrap_method_inner {
                                 $($pname,)*
                                 $($opt_pname,)*
                             );
-                            <$retty as $crate::OwnedToVariant>::owned_to_variant(ret)
+                            <$retty as $crate::core_types::OwnedToVariant>::owned_to_variant(ret)
                         })
                         .unwrap_or_else(|err| {
                             $crate::godot_error!("gdnative-core: method call failed with error: {:?}", err);
                             $crate::godot_error!("gdnative-core: check module level documentation on gdnative::user_data for more information");
-                            $crate::Variant::new()
+                            $crate::core_types::Variant::new()
                         });
 
                     std::mem::drop(__instance);
@@ -194,7 +194,7 @@ macro_rules! godot_wrap_method_inner {
                 __catch_result
                     .unwrap_or_else(|_err| {
                         $crate::godot_error!("gdnative-core: method panicked (check stderr for output)");
-                        $crate::Variant::new()
+                        $crate::core_types::Variant::new()
                     })
                     .forget()
             }

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -850,8 +850,8 @@ pub trait AsArg: private::Sealed {
 
     #[doc(hidden)]
     #[inline]
-    unsafe fn to_arg_variant(&self) -> crate::Variant {
-        crate::Variant::from_object_ptr(self.as_arg_ptr())
+    unsafe fn to_arg_variant(&self) -> crate::core_types::Variant {
+        crate::core_types::Variant::from_object_ptr(self.as_arg_ptr())
     }
 }
 

--- a/gdnative-core/src/object/raw.rs
+++ b/gdnative-core/src/object/raw.rs
@@ -2,10 +2,10 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::ptr::{self, NonNull};
 
+use crate::core_types::GodotString;
 use crate::private::get_api;
 use crate::ref_kind::RefCounted;
 use crate::sys;
-use crate::GodotString;
 
 use super::GodotObject;
 

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -78,7 +78,7 @@ pub(crate) fn derive_methods(meta: TokenStream, input: TokenStream) -> TokenStre
 
                 quote_spanned!( sig_span=>
                     {
-                        let method = gdnative::godot_wrap_method!(
+                        let method = ::gdnative::godot_wrap_method!(
                             #class_name,
                             fn #name ( #( #args )* ) -> #ret_ty
                         );
@@ -93,10 +93,10 @@ pub(crate) fn derive_methods(meta: TokenStream, input: TokenStream) -> TokenStre
 
             #impl_block
 
-            impl gdnative::NativeClassMethods for #class_name {
+            impl gdnative::nativescript::NativeClassMethods for #class_name {
 
-                fn register(builder: &gdnative::init::ClassBuilder<Self>) {
-                    use gdnative::init::*;
+                fn register(builder: &::gdnative::nativescript::init::ClassBuilder<Self>) {
+                    use gdnative::nativescript::init::*;
 
                     #(#methods)*
                 }

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -50,7 +50,7 @@ pub(crate) fn derive_native_class(input: TokenStream) -> TokenStream {
         let name_str = quote!(#name).to_string();
 
         quote!(
-            impl gdnative::NativeClass for #name {
+            impl ::gdnative::nativescript::NativeClass for #name {
                 type Base = #base;
                 type UserData = #user_data;
 
@@ -62,7 +62,7 @@ pub(crate) fn derive_native_class(input: TokenStream) -> TokenStream {
                     Self::_init(owner)
                 }
 
-                fn register_properties(builder: &gdnative::init::ClassBuilder<Self>) {
+                fn register_properties(builder: &::gdnative::nativescript::init::ClassBuilder<Self>) {
                     #(#properties)*;
                     #register_callback
                 }
@@ -106,21 +106,20 @@ fn parse_derive_input(input: TokenStream) -> Result<DeriveData, TokenStream> {
         .map(|attr| attr.parse_args::<Path>().map_err(|e| e.to_compile_error()))
         .transpose()?;
 
-    let user_data =
-        input
-            .attrs
-            .iter()
-            .find(|a| a.path.is_ident("user_data"))
-            .map(|attr| {
-                attr.parse_args::<Type>()
-                    .map_err(|err| err.to_compile_error())
-            })
-            .unwrap_or_else(|| {
-                Ok(syn::parse::<Type>(
-                    quote! { ::gdnative::user_data::DefaultUserData<#ident> }.into(),
-                )
-                .expect("quoted tokens for default userdata should be a valid type"))
-            })?;
+    let user_data = input
+        .attrs
+        .iter()
+        .find(|a| a.path.is_ident("user_data"))
+        .map(|attr| {
+            attr.parse_args::<Type>()
+                .map_err(|err| err.to_compile_error())
+        })
+        .unwrap_or_else(|| {
+            Ok(syn::parse::<Type>(
+                quote! { ::gdnative::nativescript::user_data::DefaultUserData<#ident> }.into(),
+            )
+            .expect("quoted tokens for default userdata should be a valid type"))
+        })?;
 
     // make sure it's a struct
     let struct_data = if let Data::Struct(data) = input.data {

--- a/gdnative-derive/src/variant.rs
+++ b/gdnative-derive/src/variant.rs
@@ -61,11 +61,11 @@ pub(crate) fn parse_derive_input(
 }
 
 pub(crate) fn derive_to_variant(input: TokenStream) -> TokenStream {
-    let bound: syn::Path = syn::parse2(quote! { ::gdnative::ToVariant }).unwrap();
+    let bound: syn::Path = syn::parse2(quote! { ::gdnative::core_types::ToVariant }).unwrap();
     to::expand_to_variant(parse_derive_input(input, &bound, Direction::To))
 }
 
 pub(crate) fn derive_from_variant(input: TokenStream) -> TokenStream {
-    let bound: syn::Path = syn::parse2(quote! { ::gdnative::FromVariant }).unwrap();
+    let bound: syn::Path = syn::parse2(quote! { ::gdnative::core_types::FromVariant }).unwrap();
     from::expand_from_variant(parse_derive_input(input, &bound, Direction::From))
 }

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -55,7 +55,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
 
             quote! {
                 {
-                    let __dict = ::gdnative::Dictionary::from_variant(#input_ident)
+                    let __dict = ::gdnative::core_types::Dictionary::from_variant(#input_ident)
                         .map_err(|__err| FVE::InvalidEnumRepr {
                             expected: VariantEnumRepr::ExternallyTagged,
                             error: Box::new(__err),
@@ -102,15 +102,15 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
 
     let result = quote! {
         #[allow(unused_variables)]
-        impl #generics ::gdnative::FromVariant for #ident #generics #where_clause {
+        impl #generics ::gdnative::core_types::FromVariant for #ident #generics #where_clause {
             fn from_variant(
-                #input_ident: &::gdnative::Variant
-            ) -> ::std::result::Result<Self, ::gdnative::FromVariantError> {
-                use ::gdnative::ToVariant;
-                use ::gdnative::FromVariant;
-                use ::gdnative::FromVariantError as FVE;
-                use ::gdnative::VariantEnumRepr;
-                use ::gdnative::VariantStructRepr;
+                #input_ident: &::gdnative::core_types::Variant
+            ) -> ::std::result::Result<Self, ::gdnative::core_types::FromVariantError> {
+                use ::gdnative::core_types::ToVariant;
+                use ::gdnative::core_types::FromVariant;
+                use ::gdnative::core_types::FromVariantError as FVE;
+                use ::gdnative::core_types::VariantEnumRepr;
+                use ::gdnative::core_types::VariantStructRepr;
 
                 #return_expr
             }

--- a/gdnative-derive/src/variant/repr.rs
+++ b/gdnative-derive/src/variant/repr.rs
@@ -91,7 +91,7 @@ impl VariantRepr {
     pub(crate) fn to_variant(&self) -> TokenStream2 {
         match self {
             VariantRepr::Unit => {
-                quote! { ::gdnative::Dictionary::new().into_shared().to_variant() }
+                quote! { ::gdnative::core_types::Dictionary::new().into_shared().to_variant() }
             }
             VariantRepr::Tuple(fields) => {
                 if fields.len() == 1 {
@@ -112,7 +112,7 @@ impl VariantRepr {
 
                     quote! {
                         {
-                            let __array = ::gdnative::VariantArray::new();
+                            let __array = ::gdnative::core_types::VariantArray::new();
                             #(
                                 __array.push(&#exprs);
                             )*
@@ -135,10 +135,10 @@ impl VariantRepr {
 
                 quote! {
                     {
-                        let __dict = ::gdnative::Dictionary::new();
+                        let __dict = ::gdnative::core_types::Dictionary::new();
                         #(
                             {
-                                let __key = ::gdnative::GodotString::from(#name_string_literals).to_variant();
+                                let __key = ::gdnative::core_types::GodotString::from(#name_string_literals).to_variant();
                                 __dict.insert(&__key, &#exprs);
                             }
                         )*
@@ -200,7 +200,7 @@ impl VariantRepr {
 
                     quote! {
                         {
-                            ::gdnative::VariantArray::from_variant(#variant)
+                            ::gdnative::core_types::VariantArray::from_variant(#variant)
                                 .map_err(|__err| FVE::InvalidStructRepr {
                                     expected: VariantStructRepr::Tuple,
                                     error: Box::new(__err),
@@ -215,7 +215,7 @@ impl VariantRepr {
                                         #(
                                             let __index = #indices;
                                             let #non_skipped_idents = #non_skipped_exprs
-                                                .map_err(|err| FromVariantError::InvalidItem {
+                                                .map_err(|err| FVE::InvalidItem {
                                                     index: __index as usize,
                                                     error: Box::new(err),
                                                 })?;
@@ -259,7 +259,7 @@ impl VariantRepr {
 
                 quote! {
                     {
-                        ::gdnative::Dictionary::from_variant(#variant)
+                        ::gdnative::core_types::Dictionary::from_variant(#variant)
                             .map_err(|__err| FVE::InvalidStructRepr {
                                 expected: VariantStructRepr::Struct,
                                 error: Box::new(__err),
@@ -267,7 +267,7 @@ impl VariantRepr {
                             .and_then(|__dict| {
                                 #(
                                     let __field_name = #name_string_literals;
-                                    let __key = ::gdnative::GodotString::from(__field_name).to_variant();
+                                    let __key = ::gdnative::core_types::GodotString::from(__field_name).to_variant();
                                     let #non_skipped_idents = #exprs
                                         .map_err(|err| FVE::InvalidField {
                                             field_name: __field_name,
@@ -300,7 +300,7 @@ impl Field {
         if let Some(from_variant_with) = &self.attr.from_variant_with {
             quote!(#from_variant_with(#variant))
         } else {
-            quote!(FromVariant::from_variant(#variant))
+            quote!(::gdnative::core_types::FromVariant::from_variant(#variant))
         }
     }
 }

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -41,8 +41,8 @@ pub(crate) fn expand_to_variant(derive_data: DeriveData) -> TokenStream {
                         let var_ident_string_literal = Literal::string(&var_ident_string);
                         quote! {
                             #ident::#var_ident #destructure_pattern => {
-                                let __dict = ::gdnative::Dictionary::new();
-                                let __key = ::gdnative::GodotString::from(#var_ident_string_literal).to_variant();
+                                let __dict = ::gdnative::core_types::Dictionary::new();
+                                let __key = ::gdnative::core_types::GodotString::from(#var_ident_string_literal).to_variant();
                                 let __value = #to_variant;
                                 __dict.insert(&__key, &__value);
                                 __dict.into_shared().to_variant()
@@ -63,10 +63,10 @@ pub(crate) fn expand_to_variant(derive_data: DeriveData) -> TokenStream {
 
     let result = quote! {
         #[allow(unused_variables)]
-        impl #generics ::gdnative::ToVariant for #ident #generics #where_clause {
-            fn to_variant(&self) -> ::gdnative::Variant {
-                use ::gdnative::ToVariant;
-                use ::gdnative::FromVariant;
+        impl #generics ::gdnative::core_types::ToVariant for #ident #generics #where_clause {
+            fn to_variant(&self) -> ::gdnative::core_types::Variant {
+                use ::gdnative::core_types::ToVariant;
+                use ::gdnative::core_types::FromVariant;
 
                 #return_expr
             }

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -56,6 +56,8 @@ pub use gdnative_core::*;
 #[doc(inline)]
 pub use gdnative_derive::*;
 
+pub mod prelude;
+
 #[doc(inline)]
 #[cfg(feature = "bindings")]
 /// Bindings for the Godot Class API.

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -1,0 +1,30 @@
+pub use gdnative_core::core_types::{
+    self, error::GodotError, Aabb, Angle, Basis, ByteArray, Color, ColorArray, Dictionary,
+    Float32Array, GodotString, Int32Array, NodePath, Plane, Point2, Point3, Quat, Rect2, Rid,
+    Rotation2D, Rotation3D, StringArray, StringName, Transform, Transform2D, Variant, VariantArray,
+    VariantOperator, VariantType, Vector2, Vector2Array, Vector3, Vector3Array,
+};
+pub use gdnative_core::core_types::{
+    FromVariant, OwnedToVariant, ToVariant, Vector2Godot, Vector3Godot,
+};
+
+pub use gdnative_core::object::{AsArg, GodotObject, Instanciable, Null, QueueFree, Ref, TRef};
+pub use gdnative_core::ref_kind::{ManuallyManaged, RefCounted};
+pub use gdnative_core::thread_access::{Shared, ThreadLocal, Unique};
+
+pub use gdnative_core::nativescript::{
+    self,
+    class::{Instance, RefInstance},
+    init::{ClassBuilder, InitHandle, Signal, SignalArgument},
+    user_data::{self, Aether, ArcData, LocalCellData, MutexData, RwLockData},
+    ExportInfo, NativeClass, NativeClassMethods, PropertyUsage,
+};
+
+pub use gdnative_derive::*;
+
+#[cfg(feature = "bindings")]
+pub use gdnative_bindings::{
+    Button, CanvasItem, CanvasLayer, ColorRect, Control, Image, Input, InputEvent, InputEventKey,
+    KinematicBody, KinematicBody2D, Label, Node, Node2D, Object, PackedScene, Reference,
+    ResourceLoader, SceneTree, Shader, Spatial, Sprite, Texture, Timer, Tween, Viewport,
+};

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::blacklisted_name)]
 
 use gdnative::api::*;
-use gdnative::*;
+use gdnative::prelude::*;
 
 mod test_derive;
 mod test_free_ub;
@@ -16,42 +16,42 @@ pub extern "C" fn run_tests(
     _args: *mut gdnative::sys::godot_array,
 ) -> gdnative::sys::godot_variant {
     let mut status = true;
-    status &= gdnative::test_string();
+    status &= gdnative::core_types::test_string();
 
-    status &= gdnative::dictionary::test_dictionary();
+    status &= gdnative::core_types::dictionary::test_dictionary();
     // status &= gdnative::test_dictionary_clone_clear();
 
-    status &= gdnative::test_array();
-    status &= gdnative::test_array_debug();
+    status &= gdnative::core_types::test_array();
+    status &= gdnative::core_types::test_array_debug();
     // status &= gdnative::test_array_clone_clear();
 
-    status &= gdnative::test_variant_nil();
-    status &= gdnative::test_variant_i64();
-    status &= gdnative::test_variant_bool();
+    status &= gdnative::core_types::test_variant_nil();
+    status &= gdnative::core_types::test_variant_i64();
+    status &= gdnative::core_types::test_variant_bool();
 
-    status &= gdnative::test_vector2_variants();
+    status &= gdnative::core_types::test_vector2_variants();
 
-    status &= gdnative::test_vector3_variants();
+    status &= gdnative::core_types::test_vector3_variants();
 
-    status &= gdnative::test_variant_option();
-    status &= gdnative::test_variant_result();
-    status &= gdnative::test_to_variant_iter();
-    status &= gdnative::test_variant_tuple();
+    status &= gdnative::core_types::test_variant_option();
+    status &= gdnative::core_types::test_variant_result();
+    status &= gdnative::core_types::test_to_variant_iter();
+    status &= gdnative::core_types::test_variant_tuple();
 
-    status &= gdnative::test_byte_array_access();
-    status &= gdnative::test_byte_array_debug();
-    status &= gdnative::test_int32_array_access();
-    status &= gdnative::test_int32_array_debug();
-    status &= gdnative::test_float32_array_access();
-    status &= gdnative::test_float32_array_debug();
-    status &= gdnative::test_color_array_access();
-    status &= gdnative::test_color_array_debug();
-    status &= gdnative::test_string_array_access();
-    status &= gdnative::test_string_array_debug();
-    status &= gdnative::test_vector2_array_access();
-    status &= gdnative::test_vector2_array_debug();
-    status &= gdnative::test_vector3_array_access();
-    status &= gdnative::test_vector3_array_debug();
+    status &= gdnative::core_types::test_byte_array_access();
+    status &= gdnative::core_types::test_byte_array_debug();
+    status &= gdnative::core_types::test_int32_array_access();
+    status &= gdnative::core_types::test_int32_array_debug();
+    status &= gdnative::core_types::test_float32_array_access();
+    status &= gdnative::core_types::test_float32_array_debug();
+    status &= gdnative::core_types::test_color_array_access();
+    status &= gdnative::core_types::test_color_array_debug();
+    status &= gdnative::core_types::test_string_array_access();
+    status &= gdnative::core_types::test_string_array_debug();
+    status &= gdnative::core_types::test_vector2_array_access();
+    status &= gdnative::core_types::test_vector2_array_debug();
+    status &= gdnative::core_types::test_vector3_array_access();
+    status &= gdnative::core_types::test_vector3_array_debug();
 
     status &= test_constructor();
     status &= test_underscore_method_binding();
@@ -64,7 +64,7 @@ pub extern "C" fn run_tests(
     status &= test_variant_call_args::run_tests();
     status &= test_variant_ops::run_tests();
 
-    gdnative::Variant::from_bool(status).forget()
+    gdnative::core_types::Variant::from_bool(status).forget()
 }
 
 fn test_constructor() -> bool {
@@ -93,7 +93,7 @@ fn test_underscore_method_binding() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_underscore_method_binding failed");
+        gdnative::godot_error!("   !! Test test_underscore_method_binding failed");
     }
 
     ok
@@ -110,7 +110,7 @@ impl NativeClass for Foo {
     fn init(_owner: &Reference) -> Foo {
         Foo(42)
     }
-    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 struct NotFoo;
@@ -124,7 +124,7 @@ impl NativeClass for NotFoo {
     fn init(_owner: &Reference) -> NotFoo {
         NotFoo
     }
-    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 #[methods]
@@ -182,7 +182,7 @@ fn test_rust_class_construction() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_rust_class_construction failed");
+        gdnative::godot_error!("   !! Test test_rust_class_construction failed");
     }
 
     ok
@@ -215,7 +215,7 @@ impl OptionalArgs {
     }
 }
 
-fn init(handle: init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<Foo>();
     handle.add_class::<OptionalArgs>();
 
@@ -227,6 +227,6 @@ fn init(handle: init::InitHandle) {
     test_variant_ops::register(handle);
 }
 
-godot_gdnative_init!();
-godot_nativescript_init!(init);
-godot_gdnative_terminate!();
+gdnative::godot_gdnative_init!();
+gdnative::godot_nativescript_init!(init);
+gdnative::godot_gdnative_terminate!();

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -1,4 +1,5 @@
-use gdnative::*;
+// use gdnative::*;
+use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
@@ -8,7 +9,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(_handle: init::InitHandle) {}
+pub(crate) fn register(_handle: InitHandle) {}
 
 fn test_derive_to_variant() -> bool {
     println!(" -- test_derive_to_variant");
@@ -52,7 +53,7 @@ fn test_derive_to_variant() -> bool {
     }
 
     mod variant_with {
-        use gdnative::{FromVariantError, GodotString, ToVariant, Variant};
+        use gdnative::core_types::{FromVariantError, GodotString, ToVariant, Variant};
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
         pub fn to_variant(_ptr: &*mut ()) -> Variant {
@@ -115,7 +116,7 @@ fn test_derive_to_variant() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_derive_to_variant failed");
+        gdnative::godot_error!("   !! Test test_derive_to_variant failed");
     }
 
     ok

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -1,5 +1,4 @@
-use gdnative::api::*;
-use gdnative::*;
+use gdnative::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
@@ -11,7 +10,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: init::InitHandle) {
+pub(crate) fn register(handle: InitHandle) {
     handle.add_class::<Bar>();
 }
 
@@ -26,7 +25,7 @@ impl NativeClass for Bar {
     fn init(_owner: &Node) -> Bar {
         Bar(42, None)
     }
-    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 impl Bar {
@@ -99,7 +98,7 @@ fn test_owner_free_ub() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_owner_free_ub failed");
+        gdnative::godot_error!("   !! Test test_owner_free_ub failed");
     }
 
     ok

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -1,5 +1,4 @@
-use gdnative::api::Reference;
-use gdnative::*;
+use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
@@ -9,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: init::InitHandle) {
+pub(crate) fn register(handle: InitHandle) {
     handle.add_class::<RegisterSignal>();
     handle.add_class::<RegisterProperty>();
 }
@@ -26,14 +25,14 @@ impl NativeClass for RegisterSignal {
     fn init(_owner: &Reference) -> RegisterSignal {
         RegisterSignal
     }
-    fn register_properties(builder: &init::ClassBuilder<Self>) {
-        builder.add_signal(gdnative::init::Signal {
+    fn register_properties(builder: &ClassBuilder<Self>) {
+        builder.add_signal(Signal {
             name: "progress",
-            args: &[gdnative::init::SignalArgument {
+            args: &[SignalArgument {
                 name: "amount",
-                default: gdnative::Variant::new(),
-                export_info: init::ExportInfo::new(VariantType::I64),
-                usage: gdnative::init::PropertyUsage::DEFAULT,
+                default: Variant::new(),
+                export_info: ExportInfo::new(VariantType::I64),
+                usage: PropertyUsage::DEFAULT,
             }],
         });
     }
@@ -55,7 +54,7 @@ impl NativeClass for RegisterProperty {
     fn init(_owner: &Reference) -> RegisterProperty {
         RegisterProperty { value: 42 }
     }
-    fn register_properties(builder: &init::ClassBuilder<Self>) {
+    fn register_properties(builder: &ClassBuilder<Self>) {
         builder
             .add_property("value")
             .with_default(42)
@@ -105,7 +104,7 @@ fn test_register_property() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_register_property failed");
+        gdnative::godot_error!("   !! Test test_register_property failed");
     }
 
     ok

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -1,5 +1,5 @@
 use gdnative::api::*;
-use gdnative::*;
+use gdnative::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: init::InitHandle) {
+pub(crate) fn register(handle: InitHandle) {
     handle.add_class::<Probe>();
 }
 
@@ -35,7 +35,7 @@ impl NativeClass for Probe {
         Probe { drop_count: None }
     }
 
-    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 impl Probe {
@@ -96,7 +96,7 @@ fn test_return_leak() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_return_leak failed");
+        gdnative::godot_error!("   !! Test test_return_leak failed");
     }
 
     ok

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -1,5 +1,4 @@
-use gdnative::api::Reference;
-use gdnative::*;
+use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
@@ -9,7 +8,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(handle: init::InitHandle) {
+pub(crate) fn register(handle: InitHandle) {
     handle.add_class::<VariantCallArgs>();
 }
 
@@ -24,7 +23,7 @@ impl NativeClass for VariantCallArgs {
     fn init(_owner: &Reference) -> VariantCallArgs {
         VariantCallArgs
     }
-    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 #[methods]
@@ -97,7 +96,7 @@ fn test_variant_call_args() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_variant_call_args failed");
+        gdnative::godot_error!("   !! Test test_variant_call_args failed");
     }
 
     ok

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -1,4 +1,5 @@
-use gdnative::*;
+use gdnative::core_types::InvalidOp;
+use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
@@ -8,7 +9,7 @@ pub(crate) fn run_tests() -> bool {
     status
 }
 
-pub(crate) fn register(_handle: init::InitHandle) {}
+pub(crate) fn register(_handle: InitHandle) {}
 
 fn test_variant_ops() -> bool {
     println!(" -- test_variant_ops");
@@ -40,7 +41,7 @@ fn test_variant_ops() -> bool {
     .is_ok();
 
     if !ok {
-        godot_error!("   !! Test test_variant_ops failed");
+        gdnative::godot_error!("   !! Test test_variant_ops failed");
     }
 
     ok


### PR DESCRIPTION
closes #389

This cleans up the re-exported items from those crates. This caused a
lot of paths to be changed to be more explicit.

The preludes include all core types and many common Godot classes too.