### PR TITLE
remove inlining of Object methods in Reference

### DIFF
--- a/bindings_generator/src/classes.rs
+++ b/bindings_generator/src/classes.rs
@@ -41,13 +41,8 @@ pub fn generate_class_impl(api: &Api, class: &GodotClass) -> TokenStream {
 
     let mut method_set = HashSet::default();
 
-    let class_methods = methods::generate_methods(
-        &api,
-        &mut method_set,
-        &class.name,
-        class.is_pointer_safe(),
-        true,
-    );
+    let class_methods =
+        methods::generate_methods(&api, &mut method_set, &class.name, class.is_pointer_safe());
 
     let class_upcast =
         special_methods::generate_upcast(&api, &class.base_class, class.is_pointer_safe());

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -271,7 +271,6 @@ pub fn generate_methods(
     api: &Api,
     method_set: &mut HashSet<String>,
     class_name: &str,
-    is_safe: bool,
     is_leaf: bool,
 ) -> TokenStream {
     let mut result = TokenStream::new();
@@ -345,17 +344,6 @@ pub fn generate_methods(
                 }
             };
             result.extend(output);
-        }
-
-        // Reference includes all of Object's methods so they are safe.
-        if class.base_class == "Reference" {
-            result.extend(generate_methods(
-                api,
-                method_set,
-                &class.base_class,
-                is_safe,
-                false,
-            ));
         }
     }
     result

--- a/gdnative-bindings/src/generated.rs
+++ b/gdnative-bindings/src/generated.rs
@@ -10,6 +10,4 @@ use gdnative_core::sys;
 use gdnative_core::sys::GodotApi;
 use gdnative_core::vector3;
 
-use crate::generated::reference::*;
-
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));


### PR DESCRIPTION
Since #390 this is no longer needed since Object methods are also safe.

closes #442