### PR TITLE
reworked method implementation generation

### DIFF
--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -1,11 +1,138 @@
 use crate::api::*;
-use crate::documentation::class_doc_link;
 use crate::rust_safe_name;
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+
+/// Types of icalls.
+pub(crate) enum IcallType {
+    Ptr,
+    Varargs,
+    Var,
+}
+
+pub(crate) struct MethodSig {
+    pub(crate) return_type: Ty,
+    pub(crate) arguments: Vec<Ty>,
+    pub(crate) has_varargs: bool,
+}
+
+impl MethodSig {
+    pub(crate) fn from_method(method: &GodotMethod) -> Self {
+        // reduce the amoun of types so that more icalls can be shared.
+        fn ty_erase(ty: Ty) -> Ty {
+            match ty {
+                Ty::Vector3Axis
+                | Ty::Result
+                | Ty::VariantType
+                | Ty::VariantOperator
+                | Ty::Enum(_) => Ty::I64,
+
+                // Objects are erased too, but their path is never inspected.
+                Ty::Object(path) => Ty::Object(path),
+
+                other => other,
+            }
+        }
+
+        let has_varargs = method.has_varargs;
+
+        let return_type = if has_varargs {
+            Ty::Variant
+        } else {
+            Ty::from_src(&method.return_type)
+        };
+
+        let mut args = Vec::new();
+        for arg in &method.arguments {
+            args.push(ty_erase(arg.get_type()));
+        }
+
+        Self {
+            return_type: ty_erase(return_type),
+            arguments: args,
+            has_varargs: method.has_varargs,
+        }
+    }
+
+    pub(crate) fn function_name(&self) -> String {
+        // the name for a type used in the name of the icall
+        fn ty_arg_name(ty: &Ty) -> &'static str {
+            match ty {
+                Ty::Void => "void",
+                Ty::String => "str",
+                Ty::F64 => "f64",
+                Ty::I64 => "i64",
+                Ty::Bool => "bool",
+                Ty::Vector2 => "vec2",
+                Ty::Vector3 => "vec3",
+
+                Ty::Quat => "quat",
+                Ty::Transform => "trans",
+                Ty::Transform2D => "trans2D",
+                Ty::Rect2 => "rect2",
+                Ty::Plane => "plane",
+                Ty::Basis => "basis",
+                Ty::Color => "color",
+                Ty::NodePath => "nodepath",
+                Ty::Variant => "var",
+                Ty::Aabb => "aabb",
+                Ty::Rid => "rid",
+                Ty::VariantArray => "arr",
+                Ty::Dictionary => "dict",
+                Ty::ByteArray => "bytearr",
+                Ty::StringArray => "strarr",
+                Ty::Vector2Array => "vec2arr",
+                Ty::Vector3Array => "vec3arr",
+                Ty::ColorArray => "colorarr",
+                Ty::Int32Array => "i32arr",
+                Ty::Float32Array => "f32arr",
+
+                Ty::Result
+                | Ty::Vector3Axis
+                | Ty::VariantType
+                | Ty::VariantOperator
+                | Ty::Enum(_) => "i64",
+
+                Ty::Object(_) => "obj",
+            }
+        }
+
+        let icall_ty = self.icall_type();
+
+        // Only ptrcalls have "static" typing on their return types.
+        // The other calling types always return `Variant`.
+        let mut name = match icall_ty {
+            IcallType::Ptr => format!("icallptr_{}", ty_arg_name(&self.return_type)),
+            IcallType::Varargs => String::from("icallvarargs_"),
+            IcallType::Var => String::from("icallvar_"),
+        };
+
+        for arg in &self.arguments {
+            name.push('_');
+            name.push_str(ty_arg_name(arg));
+        }
+
+        name
+    }
+
+    #[allow(clippy::single_match)]
+    pub(crate) fn icall_type(&self) -> IcallType {
+        if self.has_varargs {
+            return IcallType::Varargs;
+        }
+
+        match self.return_type {
+            Ty::VariantArray => return IcallType::Var,
+            _ => {}
+        }
+
+        IcallType::Ptr
+    }
+}
 
 fn skip_method(name: &str) -> bool {
     const METHODS: &[&str] = &["free", "reference", "unreference"];
@@ -113,145 +240,6 @@ pub fn generate_method_table(api: &Api, class: &GodotClass) -> TokenStream {
     }
 }
 
-pub fn generate_method_impl(class: &GodotClass, method: &GodotMethod) -> TokenStream {
-    let MethodName {
-        rust_name: method_name,
-        ..
-    } = method.get_name();
-
-    if skip_method(&method_name) {
-        return Default::default();
-    }
-
-    let rust_ret_type = if method.has_varargs {
-        Ty::Variant.to_rust()
-    } else {
-        method.get_return_type().to_rust()
-    };
-
-    let args = method.arguments.iter().map(|argument| {
-        let name = format_ident!("{}", rust_safe_name(&argument.name));
-        let typ = argument.get_type().to_rust_arg();
-        quote! {
-            #name: #typ
-        }
-    });
-
-    let varargs = if method.has_varargs {
-        quote! {
-            varargs: &[Variant]
-        }
-    } else {
-        Default::default()
-    };
-
-    let arg_count = method.arguments.len();
-    let method_body = if method.has_varargs {
-        let args_buffer = quote! {
-            let mut argument_buffer: Vec<*const sys::godot_variant> = Vec::with_capacity(#arg_count + varargs.len());
-        };
-
-        let arguments = method.arguments.iter().map(|arg| {
-            let name = rust_safe_name(&arg.name);
-
-            let new_var = match arg.get_type() {
-                Ty::Object(_) => {
-                    quote! {
-                        let #name: Variant = #name.to_arg_variant();
-                    }
-                }
-                Ty::String => {
-                    quote! {
-                        let #name: Variant = Variant::from_godot_string(&#name);
-                    }
-                }
-                _ => {
-                    quote! {
-                       let #name: Variant = (&#name).to_variant();
-                    }
-                }
-            };
-
-            quote! {
-                #new_var
-                argument_buffer.push(#name.sys());
-            }
-        });
-
-        let varargs_body = quote! {
-            for arg in varargs {
-                argument_buffer.push(arg.sys() as *const _);
-            }
-            let ret = Variant::from_sys((gd_api.godot_method_bind_call)(method_bind, obj_ptr, argument_buffer.as_mut_ptr(), argument_buffer.len() as _, ptr::null_mut()));
-        };
-
-        let drop_args = method.arguments.iter().map(|arg| {
-            let arg_name = rust_safe_name(&arg.name);
-            quote! { drop(#arg_name); }
-        });
-
-        let ret = match method.get_return_type() {
-            Ty::Object(_) => quote! { ret.try_to_object() },
-            _ => quote! { ret.into() },
-        };
-
-        quote! {
-            #args_buffer
-            #(#arguments)*
-            #varargs_body
-            #(#drop_args)*
-            #ret
-        }
-    } else {
-        let args = method
-            .arguments
-            .iter()
-            .map(|arg| generate_argument_pre(&arg.get_type(), rust_safe_name(&arg.name)));
-        let return_pre = generate_return_pre(&method.get_return_type());
-
-        let arg_drops = method.arguments.iter().map(|arg| {
-            let name = rust_safe_name(&arg.name);
-            quote! { drop(#name); }
-        });
-
-        let ret = method.get_return_type().to_return_post();
-
-        quote! {
-            let mut argument_buffer : [*const libc::c_void; #arg_count] = [
-                #(#args),*
-            ];
-
-            #return_pre
-
-            (gd_api.godot_method_bind_ptrcall)(method_bind, obj_ptr, argument_buffer.as_mut_ptr() as *mut _, ret_ptr as *mut _);
-
-            #(#arg_drops)*
-
-            #ret
-        }
-    };
-
-    let class_method_name = format_ident!("{}_{}", class.name, method_name);
-    let method_table = format_ident!("{}MethodTable", class.name);
-    let rust_method_name = format_ident!("{}", method_name);
-    let visibility = if class.name == "Reference" && method_name == "init_ref" {
-        quote! { pub }
-    } else {
-        quote! { pub(crate) }
-    };
-
-    quote! {
-        #[doc(hidden)]
-        #[inline]
-        #visibility unsafe fn #class_method_name(obj_ptr: *mut sys::godot_object, #(#args,)* #varargs) -> #rust_ret_type {
-            let gd_api = get_api();
-
-            let method_bind: *mut sys::godot_method_bind = #method_table::get(gd_api).#rust_method_name;
-            #method_body
-        }
-    }
-}
-
 /// Removes 'get_' from the beginning of `name` if `name` is a property getter on `class`.
 fn rename_property_getter<'a>(name: &'a str, class: &GodotClass) -> &'a str {
     if name.starts_with("get_") && class.is_getter(name) {
@@ -267,226 +255,483 @@ const UNSAFE_OBJECT_METHODS: &[(&str, &str)] = &[
     ("Object", "call_deferred"),
 ];
 
-pub fn generate_methods(
-    api: &Api,
-    method_set: &mut HashSet<String>,
-    class_name: &str,
-    is_leaf: bool,
+pub(crate) fn generate_methods(
+    class: &GodotClass,
+    icalls: &mut HashMap<String, MethodSig>,
 ) -> TokenStream {
-    let mut result = TokenStream::new();
-    if let Some(class) = api.find_class(class_name) {
-        for method in &class.methods {
-            let MethodName {
-                rust_name: method_name,
-                ..
-            } = method.get_name();
-
-            if skip_method(&method_name) {
-                continue;
+    // Brings values of some types to a type with less information.
+    fn arg_erase(ty: &Ty, name: &proc_macro2::Ident) -> TokenStream {
+        match ty {
+            Ty::VariantType | Ty::VariantOperator | Ty::Vector3Axis | Ty::Result => {
+                quote! { (#name as u32) as i64 }
             }
 
-            let mut rust_ret_type = method.get_return_type().to_rust();
+            Ty::Enum(_) => quote! { #name.0 },
 
-            // Ensure that methods are not injected several times.
-            let method_name_string = method_name.to_string();
-            if method_set.contains(&method_name_string) {
-                continue;
-            }
-            method_set.insert(method_name_string);
+            Ty::Object(_) => quote! { #name.as_arg_ptr() },
 
-            let mut params_decl = TokenStream::new();
-            let mut params_use = TokenStream::new();
-            for argument in &method.arguments {
-                let ty = argument.get_type().to_rust_arg();
-                let name = rust_safe_name(&argument.name);
-                params_decl.extend(quote! {
-                    , #name: #ty
-                });
-                params_use.extend(quote! {
-                    , #name
-                });
-            }
-
-            if method.has_varargs {
-                params_decl.extend(quote! {
-                    , varargs: &[Variant]
-                });
-                params_use.extend(quote! {
-                    , varargs
-                });
-                rust_ret_type = syn::parse_quote! { Variant };
-            }
-
-            if !is_leaf {
-                let documentation = format!("    /// Inherited from {}.", class_doc_link(class));
-                result.extend(quote! {
-                    #[doc=#documentation]
-                });
-            }
-
-            // Adjust getters to match guideline conventions:
-            // https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter
-            let rusty_method_name = rename_property_getter(&method_name, &class);
-
-            let rusty_name = format_ident!("{}", rusty_method_name);
-            let function_name = format_ident!("{}_{}", class.name, method_name);
-
-            let maybe_unsafe = if UNSAFE_OBJECT_METHODS.contains(&(&class.name, method_name)) {
-                quote! { unsafe }
-            } else {
-                Default::default()
-            };
-
-            let output = quote! {
-                #[inline]
-                pub #maybe_unsafe fn #rusty_name(&self #params_decl) -> #rust_ret_type {
-                    unsafe { #function_name(self.this.sys().as_ptr() #params_use) }
-                }
-            };
-            result.extend(output);
+            _ => quote! { #name },
         }
     }
+
+    let mut method_set = HashSet::new();
+    let mut result = TokenStream::new();
+
+    for method in &class.methods {
+        let MethodName {
+            rust_name: method_name,
+            ..
+        } = method.get_name();
+
+        if skip_method(&method_name) {
+            continue;
+        }
+
+        let mut ret_type = method.get_return_type();
+        let mut rust_ret_type = ret_type.to_rust();
+
+        // Ensure that methods are not injected several times.
+        let method_name_string = method_name.to_string();
+        if method_set.contains(&method_name_string) {
+            continue;
+        }
+        method_set.insert(method_name_string);
+
+        let mut params_decl = TokenStream::new();
+        let mut params_use = TokenStream::new();
+        for argument in &method.arguments {
+            let ty = argument.get_type();
+            let rust_ty = ty.to_rust_arg();
+            let name = rust_safe_name(&argument.name);
+
+            let arg_erased = arg_erase(&ty, &name);
+
+            params_decl.extend(quote! {
+                , #name: #rust_ty
+            });
+            params_use.extend(quote! {
+                , #arg_erased
+            });
+        }
+
+        if method.has_varargs {
+            params_decl.extend(quote! {
+                , varargs: &[Variant]
+            });
+            params_use.extend(quote! {
+                , varargs
+            });
+            ret_type = Ty::Variant;
+            rust_ret_type = syn::parse_quote! { Variant };
+        }
+
+        // Adjust getters to match guideline conventions:
+        // https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter
+        let rusty_method_name = rename_property_getter(&method_name, &class);
+
+        let method_sig = MethodSig::from_method(method);
+        let icall_ty = method_sig.icall_type();
+        let icall_name = method_sig.function_name();
+        let icall = format_ident!("{}", icall_name);
+
+        icalls.insert(icall_name.clone(), method_sig);
+
+        let rusty_name = format_ident!("{}", rusty_method_name);
+
+        let maybe_unsafe = if UNSAFE_OBJECT_METHODS.contains(&(&class.name, method_name)) {
+            quote! { unsafe }
+        } else {
+            Default::default()
+        };
+
+        let method_bind_fetch = {
+            let method_table = format_ident!("{}MethodTable", class.name);
+            let rust_method_name = format_ident!("{}", method_name);
+
+            quote! {
+                let method_bind: *mut sys::godot_method_bind = #method_table::get(get_api()).#rust_method_name;
+            }
+        };
+
+        let recover = ret_recover(&ret_type, icall_ty);
+
+        let output = quote! {
+            #[inline]
+            pub #maybe_unsafe fn #rusty_name(&self #params_decl) -> #rust_ret_type {
+                unsafe {
+                    #method_bind_fetch
+
+                    let ret = crate::icalls::#icall(method_bind, self.this.sys().as_ptr() #params_use);
+
+                    #recover
+                }
+            }
+        };
+        result.extend(output);
+    }
+
     result
 }
 
-fn generate_argument_pre(ty: &Ty, name: proc_macro2::Ident) -> TokenStream {
-    match ty {
-        &Ty::Bool
-        | &Ty::F64
-        | &Ty::I64
-        | &Ty::Vector2
-        | &Ty::Vector3
-        | &Ty::Transform
-        | &Ty::Transform2D
-        | &Ty::Quat
-        | &Ty::Plane
-        | &Ty::Aabb
-        | &Ty::Basis
-        | &Ty::Rect2
-        | &Ty::Color => {
+fn ret_recover(ty: &Ty, icall_ty: IcallType) -> TokenStream {
+    match icall_ty {
+        IcallType::Ptr => ty.to_return_post(),
+        IcallType::Varargs => {
+            // only variant possible
+            quote! { ret }
+        }
+        IcallType::Var => {
+            let rust_type = ty.to_rust();
+            // always a variant returned, use FromVariant
             quote! {
-                (&#name) as *const _ as *const _
+                <#rust_type>::from_variant(&ret).expect("Unexpected variant type")
             }
         }
-        &Ty::Variant
-        | &Ty::String
-        | &Ty::Rid
-        | &Ty::NodePath
-        | &Ty::VariantArray
-        | &Ty::Dictionary
-        | &Ty::ByteArray
-        | &Ty::StringArray
-        | &Ty::Vector2Array
-        | &Ty::Vector3Array
-        | &Ty::ColorArray
-        | &Ty::Int32Array
-        | &Ty::Float32Array => {
-            quote! {
-                #name.sys() as *const _ as *const _
-            }
-        }
-        &Ty::Object(_) => {
-            quote! {
-                #name.as_arg_ptr() as *const _ as *const _
-            }
-        }
-        _ => Default::default(),
     }
 }
 
-fn generate_return_pre(ty: &Ty) -> TokenStream {
-    match ty {
-        &Ty::Void => {
+pub(crate) fn generate_icall(name: String, sig: MethodSig) -> TokenStream {
+    match sig.icall_type() {
+        IcallType::Ptr => ptrcall::generate_icall(name, sig),
+        IcallType::Varargs => varargs_call::generate_icall(name, sig),
+        IcallType::Var => varcall::generate_icall(name, sig),
+    }
+}
+
+mod ptrcall {
+    use super::*;
+    use quote::{format_ident, quote};
+
+    pub(super) fn generate_icall(name: String, sig: super::MethodSig) -> proc_macro2::TokenStream {
+        let name_ident = format_ident!("{}", name);
+
+        let rust_ret_type = sig.return_type.to_icall_return();
+
+        let arguments = sig
+            .arguments
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| (format_ident!("arg{}", i), ty));
+
+        let args = arguments.clone().map(|(name, ty)| {
+            let typ = ty.to_icall_arg();
             quote! {
-                let ret_ptr = ptr::null_mut();
+                #name: #typ
             }
-        },
-        &Ty::F64 => {
-            quote !{
-                let mut ret = 0.0f64;
-                let ret_ptr = &mut ret as *mut _;
+        });
+
+        let arg_count = sig.arguments.len();
+        let method_body = {
+            let args = arguments
+                .clone()
+                .map(|(name, ty)| generate_argument_pre(ty, name));
+            let return_pre = generate_return_pre(&sig.return_type);
+
+            let arg_drops = arguments.clone().map(|(name, _)| {
+                quote! { drop(#name); }
+            });
+
+            quote! {
+                let gd_api = get_api();
+
+                let mut argument_buffer : [*const libc::c_void; #arg_count] = [
+                    #(#args),*
+                ];
+
+                #return_pre
+
+                (gd_api.godot_method_bind_ptrcall)(method_bind, obj_ptr, argument_buffer.as_mut_ptr() as *mut _, ret_ptr as *mut _);
+
+                #(#arg_drops)*
+
+                ret
             }
-        },
-        &Ty::I64 => {
-            quote !{
-                let mut ret = 0i64;
-                let ret_ptr = &mut ret as *mut _;
-            }
-        },
-        &Ty::Bool => {
-            quote !{
-                let mut ret = false;
-                let ret_ptr = &mut ret as *mut _;
-            }
-        },
-        &Ty::String
-        | &Ty::Vector2
-        | &Ty::Vector3
-        | &Ty::Transform
-        | &Ty::Transform2D
-        | &Ty::Quat
-        | &Ty::Plane
-        | &Ty::Rect2
-        | &Ty::Basis
-        | &Ty::Color
-        | &Ty::NodePath
-        | &Ty::Variant
-        | &Ty::Aabb
-        | &Ty::VariantArray
-        | &Ty::Dictionary
-        | &Ty::ByteArray
-        | &Ty::StringArray
-        | &Ty::Vector2Array
-        | &Ty::Vector3Array
-        | &Ty::ColorArray
-        | &Ty::Int32Array
-        | &Ty::Float32Array
-        | &Ty::Rid
-        => {
-            // Enum || Void is not handled here, can .unwrap()
-            let sys_ty = ty.to_sys().unwrap();
-            quote !{
-                let mut ret = #sys_ty::default();
-                let ret_ptr = (&mut ret) as *mut _;
+        };
+
+        quote! {
+            #[doc(hidden)]
+            #[inline(never)]
+            pub(crate) unsafe fn #name_ident(method_bind: *mut sys::godot_method_bind, obj_ptr: *mut sys::godot_object, #(#args,)*) -> #rust_ret_type {
+                #method_body
             }
         }
-        &Ty::Object(_) // TODO: double check
-        => {
-            quote!{
-                let mut ret: *mut sys::godot_object = ptr::null_mut();
-                let ret_ptr = (&mut ret) as *mut _;
+    }
+
+    fn generate_argument_pre(ty: &Ty, name: proc_macro2::Ident) -> TokenStream {
+        match ty {
+            Ty::Bool
+            | Ty::F64
+            | Ty::I64
+            | Ty::Vector2
+            | Ty::Vector3
+            | Ty::Transform
+            | Ty::Transform2D
+            | Ty::Quat
+            | Ty::Plane
+            | Ty::Aabb
+            | Ty::Basis
+            | Ty::Rect2
+            | Ty::Color => {
+                quote! {
+                    (&#name) as *const _ as *const _
+                }
+            }
+            Ty::Variant
+            | Ty::String
+            | Ty::Rid
+            | Ty::NodePath
+            | Ty::VariantArray
+            | Ty::Dictionary
+            | Ty::ByteArray
+            | Ty::StringArray
+            | Ty::Vector2Array
+            | Ty::Vector3Array
+            | Ty::ColorArray
+            | Ty::Int32Array
+            | Ty::Float32Array => {
+                quote! {
+                    #name.sys() as *const _ as *const _
+                }
+            }
+            Ty::Object(_) => {
+                quote! {
+                    #name as *const _ as *const _
+                }
+            }
+            _ => Default::default(),
+        }
+    }
+
+    fn generate_return_pre(ty: &Ty) -> TokenStream {
+        match ty {
+            Ty::Void => {
+                quote! {
+                    let ret = ();
+                    let ret_ptr = ptr::null_mut();
+                }
+            }
+            Ty::F64 => {
+                quote! {
+                    let mut ret = 0.0f64;
+                    let ret_ptr = &mut ret as *mut _;
+                }
+            }
+            Ty::I64 => {
+                quote! {
+                    let mut ret = 0i64;
+                    let ret_ptr = &mut ret as *mut _;
+                }
+            }
+            Ty::Bool => {
+                quote! {
+                    let mut ret = false;
+                    let ret_ptr = &mut ret as *mut _;
+                }
+            }
+            Ty::String
+            | Ty::Vector2
+            | Ty::Vector3
+            | Ty::Transform
+            | Ty::Transform2D
+            | Ty::Quat
+            | Ty::Plane
+            | Ty::Rect2
+            | Ty::Basis
+            | Ty::Color
+            | Ty::NodePath
+            | Ty::Variant
+            | Ty::Aabb
+            | Ty::VariantArray
+            | Ty::Dictionary
+            | Ty::ByteArray
+            | Ty::StringArray
+            | Ty::Vector2Array
+            | Ty::Vector3Array
+            | Ty::ColorArray
+            | Ty::Int32Array
+            | Ty::Float32Array
+            | Ty::Rid => {
+                // Enum || Void is not handled here, can .unwrap()
+                let sys_ty = ty.to_sys().unwrap();
+                quote! {
+                    let mut ret = #sys_ty::default();
+                    let ret_ptr = (&mut ret) as *mut _;
+                }
+            }
+            Ty::Object(_) => {
+                quote! {
+                    let mut ret: *mut sys::godot_object = ptr::null_mut();
+                    let ret_ptr = (&mut ret) as *mut _;
+                }
+            }
+            Ty::Result | Ty::VariantType | Ty::VariantOperator | Ty::Vector3Axis | Ty::Enum(_) => {
+                quote! {
+                    let mut ret = 0i64;
+                    let ret_ptr = (&mut ret) as *mut _;
+                }
             }
         }
-        &Ty::Result => {
+    }
+}
+
+mod varargs_call {
+    use crate::api::*;
+    use quote::{format_ident, quote};
+
+    pub(super) fn generate_icall(name: String, sig: super::MethodSig) -> proc_macro2::TokenStream {
+        let name_ident = format_ident!("{}", name);
+
+        let arguments = sig
+            .arguments
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| (format_ident!("arg{}", i), ty));
+
+        let args = arguments.clone().map(|(name, ty)| {
+            let rust_ty = ty.to_icall_arg();
             quote! {
-                let mut ret: sys::godot_error = sys::godot_error_GODOT_OK;
-                let ret_ptr = (&mut ret) as *mut _;
+                #name: #rust_ty
+            }
+        });
+
+        let arg_count = sig.arguments.len();
+        let method_body = {
+            let args_buffer = quote! {
+                let mut argument_buffer: Vec<*const sys::godot_variant> = Vec::with_capacity(#arg_count + varargs.len());
+            };
+
+            let args = arguments.clone().map(|(name, ty)| {
+                let new_var = match ty {
+                    Ty::Object(_) => {
+                        quote! {
+                            let #name: Variant = Variant::from_object_ptr(#name);
+                        }
+                    }
+                    Ty::String => {
+                        quote! {
+                            let #name: Variant = Variant::from_godot_string(&#name);
+                        }
+                    }
+                    _ => {
+                        quote! {
+                           let #name: Variant = (&#name).to_variant();
+                        }
+                    }
+                };
+
+                quote! {
+                    #new_var
+                    argument_buffer.push(#name.sys());
+                }
+            });
+
+            let varargs_body = quote! {
+                for arg in varargs {
+                    argument_buffer.push(arg.sys() as *const _);
+                }
+                let ret = (gd_api.godot_method_bind_call)(method_bind, obj_ptr, argument_buffer.as_mut_ptr(), argument_buffer.len() as _, ptr::null_mut());
+            };
+
+            let drop_args = arguments.clone().map(|(name, _)| {
+                quote! { drop(#name); }
+            });
+
+            quote! {
+                let gd_api = get_api();
+
+                #args_buffer
+                #(#args)*
+                #varargs_body
+                #(#drop_args)*
+                Variant::from_sys(ret)
+            }
+        };
+
+        quote! {
+            #[doc(hidden)]
+            #[inline(never)]
+            pub(crate) unsafe fn #name_ident(method_bind: *mut sys::godot_method_bind, obj_ptr: *mut sys::godot_object, #(#args,)* varargs: &[Variant]) -> Variant {
+                #method_body
             }
         }
-        &Ty::VariantType => {
+    }
+}
+
+mod varcall {
+    use crate::api::*;
+    use quote::{format_ident, quote};
+
+    pub(super) fn generate_icall(name: String, sig: super::MethodSig) -> proc_macro2::TokenStream {
+        let name_ident = format_ident!("{}", name);
+
+        let arguments = sig
+            .arguments
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| (format_ident!("arg{}", i), ty));
+
+        let args = arguments.clone().map(|(name, ty)| {
+            let rust_ty = ty.to_icall_arg();
             quote! {
-                let mut ret: sys::godot_variant_type = sys::godot_variant_type_GODOT_VARIANT_TYPE_NIL;
-                let ret_ptr = (&mut ret) as *mut _;
+                #name: #rust_ty
             }
-        }
-        &Ty::VariantOperator => {
-            // An invalid value is used here, so that `try_from_sys` can detect the error in case
-            // the pointer is not written to.
+        });
+
+        let arg_count = sig.arguments.len();
+        let method_body = {
+            let arg_bindings = arguments.clone().map(|(name, ty)| match ty {
+                Ty::Object(_) => {
+                    quote! {
+                        let #name: Variant = Variant::from_object_ptr(#name);
+                    }
+                }
+                Ty::String => {
+                    quote! {
+                        let #name: Variant = Variant::from_godot_string(&#name);
+                    }
+                }
+                _ => {
+                    quote! {
+                       let #name: Variant = (&#name).to_variant();
+                    }
+                }
+            });
+
+            let args_buffer = {
+                let arg_assigns = arguments.clone().map(|(name, _)| quote! {#name});
+                quote! {
+
+                    let mut argument_buffer: [*const sys::godot_variant; #arg_count] = [
+                        #(#arg_assigns.sys() as *const _),*
+                    ];
+                }
+            };
+
+            let body = quote! {
+                let ret = (gd_api.godot_method_bind_call)(method_bind, obj_ptr, argument_buffer.as_mut_ptr(), argument_buffer.len() as _, ptr::null_mut());
+            };
+
+            let drop_args = arguments.clone().map(|(name, _)| {
+                quote! { drop(#name); }
+            });
+
             quote! {
-                let mut ret: sys::godot_variant_operator = sys::godot_variant_operator_GODOT_VARIANT_OP_MAX;
-                let ret_ptr = (&mut ret) as *mut _;
+                let gd_api = get_api();
+
+                #(#arg_bindings)*
+                #args_buffer
+                #body
+                #(#drop_args)*
+
+                Variant::from_sys(ret)
             }
-        }
-        &Ty::Vector3Axis => {
-            quote! {
-                let mut ret = crate::generated::vector3::Axis::X;
-                let ret_ptr = (&mut ret) as *mut _;
-            }
-        }
-        &Ty::Enum(ref path) => {
-            quote! {
-                let mut ret = <#path>::from(0i64);
-                let ret_ptr = (&mut ret) as *mut _;
+        };
+
+        quote! {
+            #[doc(hidden)]
+            #[inline(never)]
+            pub(crate) unsafe fn #name_ident(method_bind: *mut sys::godot_method_bind, obj_ptr: *mut sys::godot_object, #(#args,)*) -> Variant {
+                #method_body
             }
         }
     }

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -85,7 +85,8 @@ pub fn generate_queue_free_impl(api: &Api, class: &GodotClass) -> TokenStream {
             impl QueueFree for #class_name {
                 #[inline]
                 unsafe fn godot_queue_free(obj: *mut sys::godot_object) {
-                    crate::generated::node::Node_queue_free(obj)
+                    let method_bind: *mut sys::godot_method_bind = crate::generated::node::NodeMethodTable::get(get_api()).queue_free;
+                    crate::icalls::icallptr_void(method_bind, obj)
                 }
             }
         }
@@ -126,14 +127,14 @@ pub fn generate_singleton_getter(class: &GodotClass) -> TokenStream {
     }
 }
 
-pub fn generate_upcast(api: &Api, base_class_name: &str, is_pointer_safe: bool) -> TokenStream {
+pub fn generate_upcast(api: &Api, base_class_name: &str) -> TokenStream {
     if let Some(parent) = api.find_class(&base_class_name) {
         let snake_name = class_name_to_snake_case(&base_class_name);
         let parent_class = format_ident!("{}", parent.name);
         let parent_class_module = format_ident!("{}", parent.name.to_snake_case());
         let to_snake_name = format_ident!("to_{}", snake_name);
 
-        let upcast = generate_upcast(api, &parent.base_class, is_pointer_safe);
+        let upcast = generate_upcast(api, &parent.base_class);
         let qualified_parent_class = quote! {
             crate::generated::#parent_class_module::#parent_class
         };

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -19,4 +19,5 @@ libc = "0.2"
 bitflags = "1.2"
 
 [build-dependencies]
+heck = "0.3.0"
 gdnative_bindings_generator = { path = "../bindings_generator", version = "0.8.1" }

--- a/gdnative-bindings/src/generated.rs
+++ b/gdnative-bindings/src/generated.rs
@@ -1,4 +1,9 @@
+#![allow(unused_variables)]
+
 use libc;
+use libc::c_char;
+use std::mem;
+use std::ptr;
 use std::sync::Once;
 
 use gdnative_core::core_types::*;

--- a/gdnative-bindings/src/icalls.rs
+++ b/gdnative-bindings/src/icalls.rs
@@ -1,0 +1,11 @@
+#![allow(unused_variables)]
+
+use libc;
+use std::ptr;
+
+use gdnative_core::core_types::*;
+use gdnative_core::private::get_api;
+use gdnative_core::sys;
+use gdnative_core::*;
+
+include!(concat!(env!("OUT_DIR"), "/icalls.rs"));

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -7,3 +7,5 @@
 
 mod generated;
 pub use generated::*;
+
+pub(crate) mod icalls;

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -340,7 +340,14 @@ impl Variant {
         unsafe { R::to_arg_variant(&val) }
     }
 
-    pub(crate) unsafe fn from_object_ptr(val: *mut sys::godot_object) -> Variant {
+    /// Creats a `Variant` from a raw object pointer.
+    ///
+    /// # Safety
+    ///
+    /// The object pointer must be a valid pointer to a godot object.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_object_ptr(val: *mut sys::godot_object) -> Variant {
         let api = get_api();
         let mut dest = sys::godot_variant::default();
         (api.godot_variant_new_object)(&mut dest, val);

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -7,6 +7,7 @@ mod test_derive;
 mod test_free_ub;
 mod test_register;
 mod test_return_leak;
+mod test_vararray_return;
 mod test_variant_call_args;
 mod test_variant_ops;
 
@@ -63,6 +64,7 @@ pub extern "C" fn run_tests(
     status &= test_return_leak::run_tests();
     status &= test_variant_call_args::run_tests();
     status &= test_variant_ops::run_tests();
+    status &= test_vararray_return::run_tests();
 
     gdnative::core_types::Variant::from_bool(status).forget()
 }
@@ -225,6 +227,7 @@ fn init(handle: InitHandle) {
     test_return_leak::register(handle);
     test_variant_call_args::register(handle);
     test_variant_ops::register(handle);
+    test_vararray_return::register(handle);
 }
 
 gdnative::godot_gdnative_init!();

--- a/test/src/test_vararray_return.rs
+++ b/test/src/test_vararray_return.rs
@@ -1,0 +1,34 @@
+use gdnative::api::Camera;
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    let mut status = true;
+
+    status &= test_vararray_return_crash();
+
+    status
+}
+
+pub(crate) fn register(_handle: InitHandle) {}
+
+fn test_vararray_return_crash() -> bool {
+    println!(" -- test_vararray_return_crash");
+
+    let ok = std::panic::catch_unwind(|| {
+        // See https://github.com/godot-rust/godot-rust/issues/422
+        let camera = Camera::new();
+
+        camera.set_frustum(5.0, Vector2::new(1.0, 2.0), 0.0, 1.0);
+
+        camera.get_frustum(); // this should not crash!
+
+        camera.free();
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_vararray_return_crash failed");
+    }
+
+    ok
+}


### PR DESCRIPTION
closes #422
closes #412

Instead of generating one "method implementation" (which does the call
to Godot) for each method for each class, now "icalls" (internal-calls,
internal refering to Godot) are generated and shared between multiple
methods.

For reference, before this change roughly 8100 method impls were
generated. With this change only 692 icalls are generated.

For different types of icalls there are different calling conventions.
These are:
 - ptrcall, using a direct (but very unsafe and weakly typed) way to
   call methods. The fastest, but does have some compatibility issues.
 - varargs_call, allows the use of varargs and always returns Variant.
   Very good compatilibilty but is specialised to work with varargs only.
   Slower to perform than a ptrcall.
 - varcall, uses an interface that exclusively uses Variants for arguments
   and return values. Very good compatibility but slower to perform than
   ptrcalls.