### PR TITLE
Implement trait-based static upcast

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -96,6 +96,21 @@ pub struct GodotClass {
 }
 
 impl GodotClass {
+    /// Returns the name of the base class if `base_class` is not empty. Returns `None` otherwise.
+    pub fn base_class_name(&self) -> Option<&str> {
+        if self.base_class.is_empty() {
+            None
+        } else {
+            Some(&self.base_class)
+        }
+    }
+
+    /// Returns the base class from `api` if `base_class` is not empty. Returns `None` otherwise.
+    pub fn base_class<'a>(&self, api: &'a Api) -> Option<&'a Self> {
+        self.base_class_name()
+            .map(|name| api.find_class(name).expect("base class should exist"))
+    }
+
     pub fn is_refcounted(&self) -> bool {
         self.is_reference || &self.name == "Reference"
     }
@@ -402,7 +417,7 @@ impl Ty {
     pub fn to_rust_arg(&self) -> syn::Type {
         match self {
             Ty::Object(ref name) => {
-                syn::parse_quote! { impl AsArg<Target = #name> }
+                syn::parse_quote! { impl AsArg<#name> }
             }
             _ => self.to_rust(),
         }

--- a/bindings_generator/src/classes.rs
+++ b/bindings_generator/src/classes.rs
@@ -21,7 +21,6 @@ pub(crate) fn generate_class_struct(class: &GodotClass) -> TokenStream {
 }
 
 pub(crate) fn generate_class_impl(
-    api: &Api,
     class: &GodotClass,
     icalls: &mut HashMap<String, methods::MethodSig>,
 ) -> TokenStream {
@@ -45,8 +44,6 @@ pub(crate) fn generate_class_impl(
 
     let class_methods = methods::generate_methods(class, icalls);
 
-    let class_upcast = special_methods::generate_upcast(&api, &class.base_class);
-
     let class_name = format_ident!("{}", class.name);
     quote! {
         impl #class_name {
@@ -54,7 +51,6 @@ pub(crate) fn generate_class_impl(
             #class_singleton_getter
             #class_instanciable
             #class_methods
-            #class_upcast
         }
     }
 }

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -78,7 +78,7 @@ fn generate_class_bindings(
             Default::default()
         };
 
-        let class_impl = generate_class_impl(&api, class, icalls);
+        let class_impl = generate_class_impl(class, icalls);
 
         quote! {
             #documentation
@@ -101,6 +101,8 @@ fn generate_class_bindings(
             Default::default()
         };
 
+        let sub_class = generate_sub_class_impls(&api, class);
+
         // Instantiable
         let instantiable = if class.instantiable {
             generate_instantiable_impl(class)
@@ -112,6 +114,7 @@ fn generate_class_bindings(
             #object_impl
             #free_impl
             #base_class
+            #sub_class
             #instantiable
         }
     };
@@ -191,7 +194,7 @@ pub(crate) mod test_prelude {
                 validate_and_clear_buffer!(buffer);
             }
 
-            let code = generate_class_impl(&api, &class, &mut icalls);
+            let code = generate_class_impl(&class, &mut icalls);
             write!(&mut buffer, "{}", code).unwrap();
             validate_and_clear_buffer!(buffer);
 

--- a/examples/dodge_the_creeps/src/extensions.rs
+++ b/examples/dodge_the_creeps/src/extensions.rs
@@ -6,17 +6,18 @@ pub trait NodeExt {
     /// # Safety
     ///
     /// See `Ptr::assume_safe`.
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
-        &self,
-        path: P,
-    ) -> TRef<'_, T, Shared>;
+    unsafe fn get_typed_node<T, P>(&self, path: P) -> TRef<'_, T, Shared>
+    where
+        T: GodotObject + SubClass<Node>,
+        P: Into<NodePath>;
 }
 
 impl NodeExt for Node {
-    unsafe fn get_typed_node<T: GodotObject, P: Into<NodePath>>(
-        &self,
-        path: P,
-    ) -> TRef<'_, T, Shared> {
+    unsafe fn get_typed_node<T, P>(&self, path: P) -> TRef<'_, T, Shared>
+    where
+        T: GodotObject + SubClass<Node>,
+        P: Into<NodePath>,
+    {
         self.get_node(path.into())
             .expect("node should exist")
             .assume_safe()

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -112,7 +112,7 @@ impl Main {
         let d = direction as f32;
 
         let mob_scene = unsafe { mob_scene.into_shared().assume_safe() };
-        owner.add_child(mob_scene.cast().unwrap(), false);
+        owner.add_child(mob_scene, false);
 
         let mob = mob_scene.cast_instance::<mob::Mob>().unwrap();
 
@@ -129,7 +129,7 @@ impl Main {
             hud.map(|_, o| {
                 o.connect(
                     "start_game".into(),
-                    mob_owner.cast().unwrap(),
+                    mob_owner,
                     "on_start_game".into(),
                     VariantArray::new_shared(),
                     0,

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -72,8 +72,7 @@ impl SceneCreate {
 
                 // You need to parent the new scene under some node if you want it in the scene.
                 //   We parent it under ourselves.
-                let node: Ref<Node, _> = spatial.cast().unwrap();
-                owner.add_child(node.into_shared(), false);
+                owner.add_child(spatial.into_shared(), false);
                 self.children_spawned += 1;
             }
             Err(err) => godot_print!("Could not instance Child : {:?}", err),

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -75,11 +75,10 @@ impl SignalSubscriber {
             .unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
-        let object = owner.cast().unwrap();
         emitter
             .connect(
                 GodotString::from_str("tick"),
-                object,
+                owner,
                 GodotString::from_str("notify"),
                 VariantArray::new_shared(),
                 0,
@@ -88,7 +87,7 @@ impl SignalSubscriber {
         emitter
             .connect(
                 GodotString::from_str("tick_with_data"),
-                object,
+                owner,
                 GodotString::from_str("notify_with_data"),
                 VariantArray::new_shared(),
                 0,

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -335,7 +335,7 @@ impl Variant {
     #[inline]
     pub fn from_object<R>(val: R) -> Variant
     where
-        R: AsArg,
+        R: AsVariant,
     {
         unsafe { R::to_arg_variant(&val) }
     }
@@ -869,7 +869,7 @@ impl<'l> From<&'l str> for Variant {
 
 impl<R> From<R> for Variant
 where
-    R: AsArg,
+    R: AsVariant,
 {
     #[inline]
     fn from(val: R) -> Variant {

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -8,7 +8,9 @@ pub use gdnative_core::core_types::{
     FromVariant, OwnedToVariant, ToVariant, Vector2Godot, Vector3Godot,
 };
 
-pub use gdnative_core::object::{AsArg, GodotObject, Instanciable, Null, QueueFree, Ref, TRef};
+pub use gdnative_core::object::{
+    AsArg, GodotObject, Instanciable, Null, QueueFree, Ref, SubClass, TRef,
+};
 pub use gdnative_core::ref_kind::{ManuallyManaged, RefCounted};
 pub use gdnative_core::thread_access::{Shared, ThreadLocal, Unique};
 

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -72,7 +72,7 @@ fn test_return_leak() -> bool {
                 .expect("lock should not fail");
 
             let base = probe.into_base().into_shared();
-            animation_tree.set_tree_root(base.cast().unwrap());
+            animation_tree.set_tree_root(base);
         }
 
         assert_eq!(0, drop_counter.load(AtomicOrdering::Acquire));


### PR DESCRIPTION
This replaces the old generated upcast methods on objects, and makes it so that dynamic casts can only be used for conversion to actual subclasses.

Unfortunately, standard conversion traits cannot be implemented due to conflict with blanket impls.

This did not have a negative impact on build times. The timings on my machine are as follows:

| | `dev` | `release` |
|-|-|-|
| This PR | 51.1s | 51.8s |
| `master` | 51.1s | 53.47s |

Close #252