### PR TITLE
Fix `Send` and `Sync` impls for API types

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -105,6 +105,14 @@ impl GodotClass {
         }
     }
 
+    pub fn is_singleton_thread_safe(&self) -> bool {
+        assert!(self.singleton, "class is not a singleton");
+        match self.name.as_str() {
+            "VisualServer" | "PhysicsServer" | "Physics3DServer" | "Physics2DServer" => false,
+            _ => true,
+        }
+    }
+
     /// Returns the base class from `api` if `base_class` is not empty. Returns `None` otherwise.
     pub fn base_class<'a>(&self, api: &'a Api) -> Option<&'a Self> {
         self.base_class_name()

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -110,12 +110,19 @@ fn generate_class_bindings(
             Default::default()
         };
 
+        let send_sync = if class.singleton && class.is_singleton_thread_safe() {
+            generate_send_sync_impls(class)
+        } else {
+            Default::default()
+        };
+
         quote! {
             #object_impl
             #free_impl
             #base_class
             #sub_class
             #instantiable
+            #send_sync
         }
     };
 

--- a/gdnative-core/src/object/raw.rs
+++ b/gdnative-core/src/object/raw.rs
@@ -16,7 +16,7 @@ use super::GodotObject;
 #[repr(C)]
 pub struct RawObject<T> {
     _opaque: [u8; 0],
-    _marker: PhantomData<T>,
+    _marker: PhantomData<(T, *const ())>,
 }
 
 impl<T: GodotObject> RawObject<T> {


### PR DESCRIPTION
`Send` and `Sync` is now only implemented for singletons that are always thread-safe. Documentation added for the `godot_singleton` function when the safety depends on project settings.

`Send` and `Sync` were previously derived for all API types by mistake. This is fixed in this PR.

Close #446