### PR TITLE
Use impl trait in methods that take strings or variants

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -416,6 +416,8 @@ impl Ty {
 
     pub fn to_rust_arg(&self) -> syn::Type {
         match self {
+            Ty::Variant => syn::parse_quote! { impl ToVariant },
+            Ty::String => syn::parse_quote! { impl Into<GodotString> },
             Ty::Object(ref name) => {
                 syn::parse_quote! { impl AsArg<#name> }
             }

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -266,6 +266,10 @@ pub(crate) fn generate_methods(
                 quote! { (#name as u32) as i64 }
             }
 
+            Ty::Variant => quote! { #name.to_variant() },
+
+            Ty::String => quote! { #name.into() },
+
             Ty::Enum(_) => quote! { #name.0 },
 
             Ty::Object(_) => quote! { #name.as_arg_ptr() },

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -23,7 +23,7 @@ impl HUD {
     #[export]
     pub fn show_message(&self, owner: &CanvasLayer, text: String) {
         let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
-        message_label.set_text(text.into());
+        message_label.set_text(text);
         message_label.show();
 
         let timer = unsafe { owner.get_typed_node::<Timer, _>("message_timer") };
@@ -34,7 +34,7 @@ impl HUD {
         self.show_message(owner, "Game Over".into());
 
         let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
-        message_label.set_text("Dodge the\nCreeps!".into());
+        message_label.set_text("Dodge the\nCreeps!");
         message_label.show();
 
         let button = unsafe { owner.get_typed_node::<Button, _>("start_button") };
@@ -44,14 +44,14 @@ impl HUD {
     #[export]
     pub fn update_score(&self, owner: &CanvasLayer, score: i64) {
         let label = unsafe { owner.get_typed_node::<Label, _>("score_label") };
-        label.set_text(score.to_string().into());
+        label.set_text(score.to_string());
     }
 
     #[export]
     fn on_start_button_pressed(&self, owner: &CanvasLayer) {
         let button = unsafe { owner.get_typed_node::<Button, _>("start_button") };
         button.hide();
-        owner.emit_signal("start_game".into(), &[]);
+        owner.emit_signal("start_game", &[]);
     }
 
     #[export]

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -128,9 +128,9 @@ impl Main {
 
             hud.map(|_, o| {
                 o.connect(
-                    "start_game".into(),
+                    "start_game",
                     mob_owner,
-                    "on_start_game".into(),
+                    "on_start_game",
                     VariantArray::new_shared(),
                     0,
                 )

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -46,7 +46,7 @@ impl Mob {
         let mut rng = rand::thread_rng();
         let animated_sprite =
             unsafe { owner.get_typed_node::<AnimatedSprite, _>("animated_sprite") };
-        animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str().into())
+        animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str())
     }
 
     #[export]

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -88,12 +88,12 @@ impl Player {
     #[export]
     fn on_player_body_entered(&self, owner: &Area2D, _body: Ref<PhysicsBody2D>) {
         owner.hide();
-        owner.emit_signal("hit".into(), &[]);
+        owner.emit_signal("hit", &[]);
 
         let collision_shape =
             unsafe { owner.get_typed_node::<CollisionShape2D, _>("collision_shape_2d") };
 
-        collision_shape.set_deferred("disabled".into(), true.into());
+        collision_shape.set_deferred("disabled", true);
     }
 
     #[export]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -171,9 +171,7 @@ fn test_rust_class_construction() -> bool {
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));
 
         let base = foo.into_base();
-        assert_eq!(Some(42), unsafe {
-            base.call("answer".into(), &[]).try_to_i64()
-        });
+        assert_eq!(Some(42), unsafe { base.call("answer", &[]).try_to_i64() });
 
         let foo = Instance::<Foo, _>::try_from_base(base).expect("should be able to downcast");
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -74,9 +74,7 @@ fn test_owner_free_ub() -> bool {
                 .expect("lock should not fail");
 
             assert_eq!(Some(true), unsafe {
-                bar.base()
-                    .call("set_script_is_not_ub".into(), &[])
-                    .try_to_bool()
+                bar.base().call("set_script_is_not_ub", &[]).try_to_bool()
             });
 
             bar.into_base().free();
@@ -88,7 +86,7 @@ fn test_owner_free_ub() -> bool {
                 .expect("lock should not fail");
 
             assert_eq!(Some(true), unsafe {
-                bar.base().call("free_is_not_ub".into(), &[]).try_to_bool()
+                bar.base().call("free_is_not_ub", &[]).try_to_bool()
             });
         }
 

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -86,19 +86,19 @@ fn test_register_property() -> bool {
         let base = obj.into_base();
 
         assert_eq!(Some(42), unsafe {
-            base.call("get_value".into(), &[]).try_to_i64()
+            base.call("get_value", &[]).try_to_i64()
         });
 
-        base.set("value".into(), 54.to_variant());
+        base.set("value", 54.to_variant());
 
         assert_eq!(Some(54), unsafe {
-            base.call("get_value".into(), &[]).try_to_i64()
+            base.call("get_value", &[]).try_to_i64()
         });
 
-        unsafe { base.call("set_value".into(), &[4242.to_variant()]) };
+        unsafe { base.call("set_value", &[4242.to_variant()]) };
 
         assert_eq!(Some(4242), unsafe {
-            base.call("get_value".into(), &[]).try_to_i64()
+            base.call("get_value", &[]).try_to_i64()
         });
     })
     .is_ok();


### PR DESCRIPTION
This happens to break code already using `into` due to problems with inference.

Close #318