### PR TITLE
[357] Removing sys from godot_gdnative_init() args.

### DIFF
--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -206,6 +206,17 @@ impl GodotString {
     pub fn from_sys(sys: sys::godot_string) -> Self {
         GodotString(sys)
     }
+
+    /// Clones `sys` into a `GodotString` without droping `sys`
+    #[doc(hidden)]
+    #[inline]
+    pub fn clone_from_sys(sys: sys::godot_string) -> Self {
+        let sys_string = GodotString(sys);
+        let this = sys_string.clone();
+        sys_string.forget();
+        this
+    }
+
     // TODO: many missing methods.
 }
 

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -1,0 +1,93 @@
+use crate::core_types::GodotString;
+
+pub struct TerminateInfo {
+    in_editor: bool,
+}
+
+impl TerminateInfo {
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn new(options: *mut crate::sys::godot_gdnative_terminate_options) -> Self {
+        assert!(!options.is_null(), "options were NULL");
+
+        let crate::sys::godot_gdnative_terminate_options { in_editor } = *options;
+
+        Self { in_editor }
+    }
+
+    /// Returns `true` if the library is loaded in the Godot Editor.
+    #[inline]
+    pub fn in_editor(&self) -> bool {
+        self.in_editor
+    }
+}
+
+pub struct InitializeInfo {
+    in_editor: bool,
+    active_library_path: GodotString,
+    options: *mut crate::sys::godot_gdnative_init_options,
+}
+
+impl InitializeInfo {
+    /// Returns true if the library is loaded in the Godot Editor.
+    #[inline]
+    pub fn in_editor(&self) -> bool {
+        self.in_editor
+    }
+
+    /// Returns a path to the library relative to the project.
+    ///
+    /// Example: `res://../../target/debug/libhello_world.dylib`
+    #[inline]
+    pub fn active_library_path(&self) -> &GodotString {
+        &self.active_library_path
+    }
+
+    /// # Safety
+    ///
+    /// Will `panic!()` if options is NULL or invalid.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn new(options: *mut crate::sys::godot_gdnative_init_options) -> Self {
+        assert!(!options.is_null(), "options were NULL");
+        let crate::sys::godot_gdnative_init_options {
+            in_editor,
+            active_library_path,
+            ..
+        } = *options;
+
+        let active_library_path =
+            crate::core_types::GodotString::clone_from_sys(*active_library_path);
+
+        Self {
+            options,
+            in_editor,
+            active_library_path,
+        }
+    }
+
+    #[inline]
+    pub fn report_loading_error<T>(&self, message: T)
+    where
+        T: std::fmt::Display,
+    {
+        let crate::sys::godot_gdnative_init_options {
+            report_loading_error,
+            gd_native_library,
+            ..
+        } = unsafe { *self.options };
+
+        if let Some(report_loading_error_fn) = report_loading_error {
+            // Add the trailing zero and convert Display => String
+            let message = format!("{}\0", message);
+
+            // Convert to FFI compatible string
+            let message = std::ffi::CStr::from_bytes_with_nul(message.as_bytes())
+                .expect("message should not have a NULL");
+
+            unsafe {
+                report_loading_error_fn(gd_native_library, message.as_ptr());
+            }
+        }
+    }
+}

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -36,6 +36,7 @@ extern crate approx;
 mod macros;
 
 pub mod core_types;
+mod init;
 
 #[cfg(feature = "nativescript")]
 pub mod nativescript;
@@ -53,6 +54,7 @@ pub mod private;
 // Re-exports
 //
 
+pub use init::{InitializeInfo, TerminateInfo};
 pub use new_ref::NewRef;
 pub use object::{GodotObject, Null, Ref, TRef};
 

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -16,11 +16,11 @@
 #[macro_export]
 macro_rules! godot_gdnative_init {
     () => {
-        fn godot_gdnative_init_empty(_options: *mut $crate::sys::godot_gdnative_init_options) {}
+        fn godot_gdnative_init_empty(_options: &$crate::InitializeInfo) {}
         $crate::godot_gdnative_init!(godot_gdnative_init_empty);
     };
     (_ as $fn_name:ident) => {
-        fn godot_gdnative_init_empty(_options: *mut $crate::sys::godot_gdnative_init_options) {}
+        fn godot_gdnative_init_empty(_options: &$crate::InitializeInfo) {}
         $crate::godot_gdnative_init!(godot_gdnative_init_empty as $fn_name);
     };
     ($callback:ident) => {
@@ -37,7 +37,10 @@ macro_rules! godot_gdnative_init {
                 return;
             }
 
-            let __result = ::std::panic::catch_unwind(|| $callback(options));
+            let __result = ::std::panic::catch_unwind(|| {
+                let callback_options = $crate::InitializeInfo::new(options);
+                $callback(&callback_options)
+            });
             if __result.is_err() {
                 $crate::godot_error!("gdnative-core: gdnative_init callback panicked");
             }
@@ -61,20 +64,14 @@ macro_rules! godot_gdnative_init {
 #[macro_export]
 macro_rules! godot_gdnative_terminate {
     () => {
-        fn godot_gdnative_terminate_empty(
-            _options: *mut $crate::sys::godot_gdnative_terminate_options,
-        ) {
-        }
+        fn godot_gdnative_terminate_empty(_term_info: $crate::TerminateInfo) {}
         $crate::godot_gdnative_terminate!(godot_gdnative_terminate_empty);
     };
     ($callback:ident) => {
         $crate::godot_gdnative_terminate!($callback as godot_gdnative_terminate);
     };
     (_ as $fn_name:ident) => {
-        fn godot_gdnative_terminate_empty(
-            _options: *mut $crate::sys::godot_gdnative_terminate_options,
-        ) {
-        }
+        fn godot_gdnative_terminate_empty(_term_info: $crate::TerminateInfo) {}
         $crate::godot_gdnative_terminate!(godot_gdnative_terminate_empty as $fn_name);
     };
     ($callback:ident as $fn_name:ident) => {
@@ -88,7 +85,10 @@ macro_rules! godot_gdnative_terminate {
                 return;
             }
 
-            let __result = ::std::panic::catch_unwind(|| $callback(options));
+            let __result = ::std::panic::catch_unwind(|| {
+                let term_info = $crate::TerminateInfo::new(options);
+                $callback(term_info)
+            });
             if __result.is_err() {
                 $crate::godot_error!("gdnative-core: nativescript_init callback panicked");
             }


### PR DESCRIPTION
`godot_gdnative_init()` callbacks can now report loading errors via `InitCallbackInfo:: report_loading_error()`