### PR TITLE
Add `OwnedToVariant` derive macro, make Dictionary and VariantArray methods generic

### DIFF
--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -998,12 +998,16 @@ pub trait ToVariant {
 
 /// Types that can only be safely converted to a `Variant` as owned values. Such types cannot
 /// implement `ToVariant` in general, but can still be passed to API methods as arguments, or
-/// used as return values. Notably, this includes `Unique` references to Godot objects and
-/// instances.
+/// used as return values. Notably, this includes `Unique` arrays, dictionaries, and references
+/// to Godot objects and instances.
 ///
-/// This trait should not be implemented by users.
+/// This has a blanket implementation for all types that have `ToVariant`. As such, users
+/// should only derive or implement `OwnedToVariant` when `ToVariant` is not applicable.
 ///
-/// This has a blanket implementation for all types that have `ToVariant`.
+/// ## Deriving `OwnedToVariant`
+///
+/// The derive macro behaves the same as `ToVariant`. See the documentation for the latter for
+/// a detailed explanation.
 pub trait OwnedToVariant {
     fn owned_to_variant(self) -> Variant;
 }

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -26,7 +26,12 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(ToVariant, attributes(variant))]
 pub fn derive_to_variant(input: TokenStream) -> TokenStream {
-    variant::derive_to_variant(input)
+    variant::derive_to_variant(variant::ToVariantTrait::ToVariant, input)
+}
+
+#[proc_macro_derive(OwnedToVariant, attributes(variant))]
+pub fn derive_owned_to_variant(input: TokenStream) -> TokenStream {
+    variant::derive_to_variant(variant::ToVariantTrait::OwnedToVariant, input)
 }
 
 #[proc_macro_derive(FromVariant, attributes(variant))]

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -5,6 +5,7 @@ pub(crate) fn run_tests() -> bool {
     let mut status = true;
 
     status &= test_derive_to_variant();
+    status &= test_derive_owned_to_variant();
 
     status
 }
@@ -117,6 +118,44 @@ fn test_derive_to_variant() -> bool {
 
     if !ok {
         gdnative::godot_error!("   !! Test test_derive_to_variant failed");
+    }
+
+    ok
+}
+
+fn test_derive_owned_to_variant() -> bool {
+    println!(" -- test_derive_owned_to_variant");
+
+    #[derive(OwnedToVariant)]
+    struct ToVar {
+        arr: VariantArray<Unique>,
+    }
+
+    let ok = std::panic::catch_unwind(|| {
+        let data = ToVar {
+            arr: [1, 2, 3].iter().collect(),
+        };
+
+        let variant = data.owned_to_variant();
+        let dictionary = variant.try_to_dictionary().expect("should be dictionary");
+        let array = dictionary
+            .get(&"arr".into())
+            .try_to_array()
+            .expect("should be array");
+        assert_eq!(3, array.len());
+        assert_eq!(
+            &[1, 2, 3],
+            array
+                .iter()
+                .map(|v| v.try_to_i64().unwrap())
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_derive_owned_to_variant failed");
     }
 
     ok

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -77,19 +77,19 @@ fn test_derive_to_variant() -> bool {
 
         let variant = data.to_variant();
         let dictionary = variant.try_to_dictionary().expect("should be dictionary");
-        assert_eq!(Some(42), dictionary.get(&"foo".into()).try_to_i64());
-        assert_eq!(Some(54.0), dictionary.get(&"bar".into()).try_to_f64());
+        assert_eq!(Some(42), dictionary.get("foo").try_to_i64());
+        assert_eq!(Some(54.0), dictionary.get("bar").try_to_f64());
         assert_eq!(
             Some("*mut ()".into()),
-            dictionary.get(&"ptr".into()).try_to_string()
+            dictionary.get("ptr").try_to_string()
         );
-        assert!(!dictionary.contains(&"skipped".into()));
+        assert!(!dictionary.contains("skipped"));
 
         let enum_dict = dictionary
-            .get(&"baz".into())
+            .get("baz")
             .try_to_dictionary()
             .expect("should be dictionary");
-        assert_eq!(Some(true), enum_dict.get(&"Foo".into()).try_to_bool());
+        assert_eq!(Some(true), enum_dict.get("Foo").try_to_bool());
 
         assert_eq!(
             Ok(ToVar::<f64, i128> {
@@ -139,7 +139,7 @@ fn test_derive_owned_to_variant() -> bool {
         let variant = data.owned_to_variant();
         let dictionary = variant.try_to_dictionary().expect("should be dictionary");
         let array = dictionary
-            .get(&"arr".into())
+            .get("arr")
             .try_to_array()
             .expect("should be array");
         assert_eq!(3, array.len());


### PR DESCRIPTION
The macro is a parameterization of the original `ToVariant` macro. Behavior is unchanged beside the trait and function names.

Also made some `Dictionary` and `VariantArray` methods generic. This should help simply patterns like `&"foo".into()`.

Close #493