### PR TITLE
Work around rustdoc showing hidden re-exports

### DIFF
--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -3,6 +3,7 @@ name = "hello_world"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate gdnative;
-
 use gdnative::prelude::*;
 
 #[derive(NativeClass)]

--- a/examples/scene_create/Cargo.toml
+++ b/examples/scene_create/Cargo.toml
@@ -3,6 +3,7 @@ name = "scene_create"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate gdnative;
-extern crate euclid;
-
 use euclid::vec3;
 use gdnative::prelude::*;
 

--- a/examples/spinning_cube/Cargo.toml
+++ b/examples/spinning_cube/Cargo.toml
@@ -3,6 +3,7 @@ name = "spinning_cube"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate gdnative;
-
 use gdnative::api::MeshInstance;
 use gdnative::prelude::*;
 

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -51,11 +51,22 @@
 
 // TODO: add logo using #![doc(html_logo_url = "https://<url>")]
 
+// Workaround: rustdoc currently shows hidden items in the original crate when they are
+//             re-exported. Manually re-exporting the public items works around that.
 #[doc(inline)]
+pub use gdnative_core::{
+    core_types, godot_dbg, godot_error, godot_gdnative_init, godot_gdnative_terminate,
+    godot_nativescript_init, godot_print, godot_warn, godot_wrap_method, nativescript, object,
+    ref_kind, thread_access, GodotObject, GodotResult, NewRef, Null, Ref, TRef,
+};
+
+#[doc(hidden)]
 pub use gdnative_core::*;
+
 #[doc(inline)]
 pub use gdnative_derive::*;
 
+/// Curated re-exports of common items.
 pub mod prelude;
 
 #[doc(inline)]

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -22,6 +22,11 @@ pub use gdnative_core::nativescript::{
     ExportInfo, NativeClass, NativeClassMethods, PropertyUsage,
 };
 
+pub use gdnative_core::{
+    godot_dbg, godot_error, godot_gdnative_init, godot_gdnative_terminate, godot_nativescript_init,
+    godot_print, godot_warn,
+};
+
 pub use gdnative_derive::*;
 
 #[cfg(feature = "bindings")]


### PR DESCRIPTION
Also bumps several examples to Edition 2018.