### PR TITLE
Update examples and readme, make NodePath arguments generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ crate-type = ["cdylib"]
 In the `src/lib.rs` file should have the following contents:
 
 ```rust
-use gdnative::*;
-use gdnative::api::Node;
+use gdnative::prelude::*;
 
 /// The HelloWorld "class"
 #[derive(NativeClass)]
@@ -113,7 +112,7 @@ pub struct HelloWorld;
 impl HelloWorld {
 
     /// The "constructor" of the class.
-    fn new(_owner: Node) -> Self {
+    fn new(_owner: &Node) -> Self {
         HelloWorld
     }
 
@@ -126,7 +125,7 @@ impl HelloWorld {
     // methods MUST have `owner: BaseClass` as their second arguments,
     // before all other arguments in the signature.
     #[export]
-    fn _ready(&self, _owner: Node) {
+    fn _ready(&self, _owner: &Node) {
         // The `godot_print!` macro works like `println!` but prints to the Godot-editor
         // output tab as well.
         godot_print!("hello, world.");
@@ -134,7 +133,7 @@ impl HelloWorld {
 }
 
 // Function that registers all exposed classes to Godot
-fn init(handle: gdnative::init::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<HelloWorld>();
 }
 

--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -425,6 +425,7 @@ impl Ty {
     pub fn to_rust_arg(&self) -> syn::Type {
         match self {
             Ty::Variant => syn::parse_quote! { impl OwnedToVariant },
+            Ty::NodePath => syn::parse_quote! { impl Into<NodePath> },
             Ty::String => syn::parse_quote! { impl Into<GodotString> },
             Ty::Object(ref name) => {
                 syn::parse_quote! { impl AsArg<#name> }

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -272,7 +272,7 @@ pub(crate) fn generate_methods(
 
             Ty::Variant => quote! { #name.owned_to_variant() },
 
-            Ty::String => quote! { #name.into() },
+            Ty::String | Ty::NodePath => quote! { #name.into() },
 
             Ty::Enum(_) => quote! { #name.0 },
 

--- a/examples/dodge_the_creeps/src/lib.rs
+++ b/examples/dodge_the_creeps/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate gdnative;
+use gdnative::prelude::*;
 
 mod extensions;
 mod hud;
@@ -7,7 +6,7 @@ mod main_scene;
 mod mob;
 mod player;
 
-fn init(handle: gdnative::prelude::InitHandle) {
+fn init(handle: InitHandle) {
     handle.add_class::<player::Player>();
     handle.add_class::<mob::Mob>();
     handle.add_class::<main_scene::Main>();

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -45,16 +45,16 @@ impl Player {
         let input = Input::godot_singleton();
         let mut velocity = Vector2::new(0.0, 0.0);
 
-        if Input::is_action_pressed(&input, GodotString::from_str("ui_right")) {
+        if Input::is_action_pressed(&input, "ui_right") {
             velocity.x += 1.0
         }
-        if Input::is_action_pressed(&input, GodotString::from_str("ui_left")) {
+        if Input::is_action_pressed(&input, "ui_left") {
             velocity.x -= 1.0
         }
-        if Input::is_action_pressed(&input, GodotString::from_str("ui_down")) {
+        if Input::is_action_pressed(&input, "ui_down") {
             velocity.y += 1.0
         }
-        if Input::is_action_pressed(&input, GodotString::from_str("ui_up")) {
+        if Input::is_action_pressed(&input, "ui_up") {
             velocity.y -= 1.0
         }
 
@@ -74,7 +74,7 @@ impl Player {
                 animated_sprite.set_flip_v(velocity.y > 0.0)
             }
 
-            animated_sprite.play(GodotString::from_str(animation), false);
+            animated_sprite.play(animation, false);
         } else {
             animated_sprite.stop();
         }

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -60,7 +60,7 @@ impl SceneCreate {
             Ok(spatial) => {
                 // Here is how you rename the child...
                 let key_str = format!("child_{}", self.children_spawned);
-                spatial.set_name(GodotString::from_str(&key_str));
+                spatial.set_name(&key_str);
 
                 let x = (self.children_spawned % 10) as f32;
                 let z = (self.children_spawned / 10) as f32;
@@ -80,7 +80,7 @@ impl SceneCreate {
 
     #[export]
     fn remove_one(&mut self, owner: &Spatial, str: GodotString) {
-        godot_print!("Called remove_one({})", str.to_string());
+        godot_print!("Called remove_one({})", str);
         let num_children = owner.get_child_count();
         if num_children <= 0 {
             godot_print!("No children to delete");
@@ -107,8 +107,8 @@ fn init(handle: InitHandle) {
 
 pub fn load_scene(path: &str) -> Option<Ref<PackedScene, ThreadLocal>> {
     let scene = ResourceLoader::godot_singleton().load(
-        GodotString::from_str(path), // could also use path.into() here
-        GodotString::from_str("PackedScene"),
+        path,
+        "PackedScene",
         false,
     )?;
 
@@ -138,7 +138,7 @@ fn update_panel(owner: &Spatial, num_children: i64) {
     //   from earlier)
     let panel_node_opt = owner.get_parent().and_then(|parent| {
         let parent = unsafe { parent.assume_safe() };
-        parent.find_node(GodotString::from_str("Panel"), true, false)
+        parent.find_node("Panel", true, false)
     });
 
     if let Some(panel_node) = panel_node_opt {
@@ -147,7 +147,7 @@ fn update_panel(owner: &Spatial, num_children: i64) {
         // Put the Node
         let mut as_variant = Variant::from_object(panel_node);
         match as_variant.call(
-            &GodotString::from_str("set_num_children"),
+            "set_num_children",
             &[Variant::from_u64(num_children as u64)],
         ) {
             Ok(_) => godot_print!("Called Panel OK."),

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -106,11 +106,7 @@ fn init(handle: InitHandle) {
 }
 
 pub fn load_scene(path: &str) -> Option<Ref<PackedScene, ThreadLocal>> {
-    let scene = ResourceLoader::godot_singleton().load(
-        path,
-        "PackedScene",
-        false,
-    )?;
+    let scene = ResourceLoader::godot_singleton().load(path, "PackedScene", false)?;
 
     let scene = unsafe { scene.assume_thread_local() };
 

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -48,10 +48,7 @@ impl SignalEmitter {
         if self.data % 2 == 0 {
             owner.emit_signal("tick", &[]);
         } else {
-            owner.emit_signal(
-                "tick_with_data",
-                &[Variant::from_i64(self.data)],
-            );
+            owner.emit_signal("tick_with_data", &[Variant::from_i64(self.data)]);
         }
     }
 }
@@ -70,19 +67,11 @@ impl SignalSubscriber {
 
     #[export]
     fn _ready(&mut self, owner: TRef<Label>) {
-        let emitter = &mut owner
-            .get_node(NodePath::from_str("../SignalEmitter"))
-            .unwrap();
+        let emitter = &mut owner.get_node("../SignalEmitter").unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
         emitter
-            .connect(
-                "tick",
-                owner,
-                "notify",
-                VariantArray::new_shared(),
-                0,
-            )
+            .connect("tick", owner, "notify", VariantArray::new_shared(), 0)
             .unwrap();
         emitter
             .connect(

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -46,10 +46,10 @@ impl SignalEmitter {
         self.data += 1;
 
         if self.data % 2 == 0 {
-            owner.emit_signal(GodotString::from_str("tick"), &[]);
+            owner.emit_signal("tick", &[]);
         } else {
             owner.emit_signal(
-                GodotString::from_str("tick_with_data"),
+                "tick_with_data",
                 &[Variant::from_i64(self.data)],
             );
         }
@@ -77,18 +77,18 @@ impl SignalSubscriber {
 
         emitter
             .connect(
-                GodotString::from_str("tick"),
+                "tick",
                 owner,
-                GodotString::from_str("notify"),
+                "notify",
                 VariantArray::new_shared(),
                 0,
             )
             .unwrap();
         emitter
             .connect(
-                GodotString::from_str("tick_with_data"),
+                "tick_with_data",
                 owner,
-                GodotString::from_str("notify_with_data"),
+                "notify_with_data",
                 VariantArray::new_shared(),
                 0,
             )
@@ -100,7 +100,7 @@ impl SignalSubscriber {
         self.times_received += 1;
         let msg = format!("Received signal \"tick\" {} times", self.times_received);
 
-        owner.set_text(GodotString::from_str(msg.as_str()));
+        owner.set_text(msg);
     }
 
     #[export]
@@ -110,7 +110,7 @@ impl SignalSubscriber {
             data.try_to_u64().unwrap()
         );
 
-        owner.set_text(GodotString::from_str(msg.as_str()));
+        owner.set_text(msg);
     }
 }
 

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -665,12 +665,14 @@ impl Variant {
     }
 
     #[inline]
-    pub fn has_method(&self, method: &GodotString) -> bool {
+    pub fn has_method(&self, method: impl Into<GodotString>) -> bool {
+        let method = method.into();
         unsafe { (get_api().godot_variant_has_method)(&self.0, &method.0) }
     }
 
     #[inline]
-    pub fn call(&mut self, method: &GodotString, args: &[Variant]) -> Result<Variant, CallError> {
+    pub fn call(&mut self, method: impl Into<GodotString>, args: &[Variant]) -> Result<Variant, CallError> {
+        let method = method.into();
         unsafe {
             let api = get_api();
             let mut err = sys::godot_variant_call_error::default();
@@ -893,7 +895,7 @@ godot_test!(
         assert!(nil.try_to_vector2().is_none());
         assert!(nil.try_to_basis().is_none());
 
-        assert!(!nil.has_method(&GodotString::from_str("foo")));
+        assert!(!nil.has_method("foo"));
 
         let clone = nil.clone();
         assert!(clone == nil);

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -671,7 +671,11 @@ impl Variant {
     }
 
     #[inline]
-    pub fn call(&mut self, method: impl Into<GodotString>, args: &[Variant]) -> Result<Variant, CallError> {
+    pub fn call(
+        &mut self,
+        method: impl Into<GodotString>,
+        args: &[Variant],
+    ) -> Result<Variant, CallError> {
         let method = method.into();
         unsafe {
             let api = get_api();

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -59,12 +59,12 @@ fn test_variant_call_args() -> bool {
 
         assert_eq!(
             Some(42),
-            base.call(&"zero".into(), &[]).unwrap().try_to_i64()
+            base.call("zero", &[]).unwrap().try_to_i64()
         );
 
         assert_eq!(
             Some(126),
-            base.call(&"one".into(), &[Variant::from_i64(3),])
+            base.call("one", &[Variant::from_i64(3),])
                 .unwrap()
                 .try_to_i64()
         );
@@ -72,7 +72,7 @@ fn test_variant_call_args() -> bool {
         assert_eq!(
             Some(-10),
             base.call(
-                &"two".into(),
+                "two",
                 &[Variant::from_i64(-1), Variant::from_i64(32),]
             )
             .unwrap()
@@ -82,7 +82,7 @@ fn test_variant_call_args() -> bool {
         assert_eq!(
             Some(-52),
             base.call(
-                &"three".into(),
+                "three",
                 &[
                     Variant::from_i64(-2),
                     Variant::from_i64(4),

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -57,10 +57,7 @@ fn test_variant_call_args() -> bool {
 
         let mut base = obj.into_base().into_shared().to_variant();
 
-        assert_eq!(
-            Some(42),
-            base.call("zero", &[]).unwrap().try_to_i64()
-        );
+        assert_eq!(Some(42), base.call("zero", &[]).unwrap().try_to_i64());
 
         assert_eq!(
             Some(126),
@@ -71,12 +68,9 @@ fn test_variant_call_args() -> bool {
 
         assert_eq!(
             Some(-10),
-            base.call(
-                "two",
-                &[Variant::from_i64(-1), Variant::from_i64(32),]
-            )
-            .unwrap()
-            .try_to_i64()
+            base.call("two", &[Variant::from_i64(-1), Variant::from_i64(32),])
+                .unwrap()
+                .try_to_i64()
         );
 
         assert_eq!(


### PR DESCRIPTION
- updates examples to not use unneeded conversions since #485
- make `NodePath` arguments use `impl Into<NodePath>`
- update the code example in the README