### PR TITLE
Fixing docs `Ptr::` -> Ref::`

### DIFF
--- a/bindings_generator/src/documentation.rs
+++ b/bindings_generator/src/documentation.rs
@@ -72,7 +72,7 @@ only exist in the unsafe `Ref<{name}>` form.
 
 In the cases where Rust code owns an object of this type, for example if the object was just
 created on the Rust side and not passed to the engine yet, ownership should be either given
-to the engine or the object must be manually destroyed using `Ptr::free`, or `Ptr::queue_free`
+to the engine or the object must be manually destroyed using `Ref::free`, or `Ref::queue_free`
 if it is a `Node`."#,
             name = class.name
         )

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -19,8 +19,8 @@ is *not* automatically managed.
 
 Immediately after creation, the object is owned by the caller, and can be
 passed to the engine (in which case the engine will be responsible for
-destroying the object) or destroyed manually using `Ptr::free`, or preferably
-`Ptr::queue_free` if it is a `Node`."#
+destroying the object) or destroyed manually using `Ref::free`, or preferably
+`Ref::queue_free` if it is a `Node`."#
     };
 
     quote! {


### PR DESCRIPTION
Smaller PR with just the fixes for references of `Ptr`.