### PR TITLE
Derive everything for marker types

### DIFF
--- a/gdnative-core/src/ref_kind.rs
+++ b/gdnative-core/src/ref_kind.rs
@@ -3,9 +3,11 @@
 use crate::object::RefKindSpec;
 
 /// Marker that indicates that a type is manually managed.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ManuallyManaged;
 
 /// Marker that indicates that a type is reference-counted.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct RefCounted;
 
 /// Trait to parameterize over the memory management markers

--- a/gdnative-core/src/thread_access.rs
+++ b/gdnative-core/src/thread_access.rs
@@ -4,16 +4,19 @@
 /// single unique reference.
 ///
 /// Using this marker causes the type to be `!Sync`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Unique(std::marker::PhantomData<*const ()>);
 unsafe impl Send for Unique {}
 
 /// Marker that indicates that a value currently might be shared in the same or
 /// over multiple threads.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Shared;
 
 /// Marker that indicates that a value can currently only be shared in the same thread.
 ///
 /// Using this marker causes the type to be `!Send + !Sync`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ThreadLocal(std::marker::PhantomData<*const ()>);
 
 /// Trait to parametrise over the access markers [`Unique`](struct.Unique.html),


### PR DESCRIPTION
This makes it possible to derive standard traits for user types containing types that use these as typestates.