### PR TITLE
Adding is_instance_sane() to more types.

### DIFF
--- a/gdnative-core/src/nativescript/class.rs
+++ b/gdnative-core/src/nativescript/class.rs
@@ -358,6 +358,23 @@ impl<T: NativeClass> Instance<T, Shared> {
     }
 }
 
+impl<T: NativeClass> Instance<T, Shared>
+where
+    T::Base: GodotObject<RefKind = ManuallyManaged>,
+{
+    /// Returns `true` if the pointer currently points to a valid object of the correct type.
+    /// **This does NOT guarantee that it's safe to use this pointer.**
+    ///
+    /// # Safety
+    ///
+    /// This thread must have exclusive access to the object during the call.
+    #[inline]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub unsafe fn is_instance_sane(&self) -> bool {
+        self.owner.is_instance_sane()
+    }
+}
+
 impl<T: NativeClass> Instance<T, Unique>
 where
     T::Base: GodotObject<RefKind = ManuallyManaged>,


### PR DESCRIPTION
Consider the following code example:
```rust
    async fn async_push_me<'a>(instance: RefInstance<'a, Self, Shared>) {
        instance
            .map(|_, owner| {
                unsafe { owner.get_typed_node::<Label, _>("Status") }
                    .unwrap()
                    .set_text("Async Starting...");
            })
            .unwrap();

        Timer::new(std::time::Duration::from_secs(10)).await;

        if !unsafe { instance.is_instance_sane() } {
            godot_error!("Scene has gone away!!");
            return;
        }

        instance
            .map(|_, owner| {
                unsafe { owner.get_typed_node::<Label, _>("Status") }
                    .unwrap()
                    .set_text("We made it!!");
            }).unwrap();
    }
```

Adding `is_instance_sane()` to `TRef`, `Instance`, and `RefInstance`.