### PR TITLE
Implement Display for GodotError

### DIFF
--- a/gdnative-core/src/core_types/error.rs
+++ b/gdnative-core/src/core_types/error.rs
@@ -72,3 +72,12 @@ impl GodotError {
         Err(std::mem::transmute(err as u32))
     }
 }
+
+impl std::fmt::Display for GodotError {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Godot API error: {:?}", self)
+    }
+}
+
+impl std::error::Error for GodotError {}


### PR DESCRIPTION
Basic implementation of Display/Error traits for GodotError to support error type casting with `?` syntax.

I suppose `Display` implementation should output human-readable text, but in case of engine's internal API error types preserving original naming in output may help looking into Godot's documentation, so currently it prints `Godot API error: <error-name>`.