### PR TITLE
Fix incorrect references to Rid arguments in ptrcall

### DIFF
--- a/gdnative-core/src/core_types/rid.rs
+++ b/gdnative-core/src/core_types/rid.rs
@@ -43,7 +43,10 @@ impl Rid {
 
     #[doc(hidden)]
     #[inline]
-    pub fn sys(self) -> *const sys::godot_rid {
+    // Passing `self` by value will create a temporary copy, changing the value of the resulting
+    // pointer. See https://github.com/godot-rust/godot-rust/issues/562.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn sys(&self) -> *const sys::godot_rid {
         &self.0
     }
 


### PR DESCRIPTION
The references passed to API methods for Rid arguments are incorrect. This bug was introduced in #438, commit `3468c31`. Changing `Rid::sys` to take `self` caused a temporary value to be created for the `sys` call, which is in turn invalidated by the time the ptrcall is performed.

Unfortunately, I don't think there is any way to test this against regression.

Close #562