### PR TITLE
Added Vector2 move_towards function

### DIFF
--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -11,19 +11,16 @@ edition = "2018"
 
 [features]
 default = ["nativescript"]
-gd_test = ["approx"]
+gd_test = []
 nativescript = ["bitflags", "parking_lot"]
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.9.0-preview.0" }
 libc = "0.2"
-
+approx = "0.3.2"
 euclid = "0.20.13"
 
 gdnative-impl-proc-macros = { path = "../impl/proc_macros", version = "=0.9.0-preview.0" }
-
-# Used for float comparisons in godot tests
-approx = { version = "0.3.2", optional = true }
 
 bitflags = { version = "1.2", optional = true }
 parking_lot = { version = "0.9.0", optional = true }

--- a/gdnative-core/src/core_types/vector2.rs
+++ b/gdnative-core/src/core_types/vector2.rs
@@ -19,7 +19,8 @@ pub trait Vector2Godot {
     fn snapped(self, by: Self) -> Self;
     /// Returns a perpendicular vector.
     fn tangent(self) -> Self;
-
+    /// Returns `self` moved towards `to` by the distance `delta`, clamped by `to`.
+    fn move_towards(self, to: Vector2, delta: f32) -> Self;
     /// Internal API for converting to `sys` representation. Makes it possible to remove
     /// `transmute`s elsewhere.
     #[doc(hidden)]
@@ -87,6 +88,17 @@ impl Vector2Godot for Vector2 {
     #[inline]
     fn tangent(self) -> Self {
         Vector2::new(self.y, -self.x)
+    }
+
+    #[inline]
+    fn move_towards(self, to: Vector2, delta: f32) -> Self {
+        let vd = to - self;
+        let len = vd.length();
+        if len <= delta || approx::abs_diff_eq!(0.0, len) {
+            to
+        } else {
+            Vector2::lerp(&self, to, delta / len)
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Hello, i added Vector2 move_towards function, there is no similar euclid::Vector2D function(or i can't find it), its basically copy/paste from Godot implementation. I think this should be moved to separate file:
`const CMP_EPSILON: f32 = 0.00001;`
In godot its in godot/core/math/math_defs.h
My test shows that is some cases there might be rounding difference:
tested vector was: (123.3, -456.7), target vector: (0, 0), delta: 43.2
`gd_Test_8:   beginning_vector: (123.300003, -456.700012), final_vector: (112.040001, -414.993256), delta: 43.2`
`rust_Test_8: beginning_vector: (123.3,-456.7),  final_vector: (112.04,-414.99326), delta: 43.2`