### PR TITLE
Add procedural macro for Godot's built-in profiler

### DIFF
--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -318,3 +318,28 @@ macro_rules! godot_wrap_method {
         )
     };
 }
+
+/// Convenience macro to create a profiling signature with a given tag.
+///
+/// The expanded code will panic at runtime if the file name or `tag` contains `::` or
+/// any NUL-bytes.
+///
+/// See `nativescript::profiling::Signature` for more information.
+///
+/// # Examples
+///
+/// ```rust
+/// # fn main() {
+/// use gdnative_core::profile_sig;
+/// use gdnative_core::nativescript::profiling::profile;
+///
+/// let answer = profile(profile_sig!("foo"), || 42);
+/// assert_eq!(42, answer);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! profile_sig {
+    ($tag:expr) => {
+        $crate::nativescript::profiling::Signature::new(file!(), line!(), $tag)
+    };
+}

--- a/gdnative-core/src/nativescript/profiling.rs
+++ b/gdnative-core/src/nativescript/profiling.rs
@@ -1,31 +1,157 @@
+//! Interface to Godot's built-in profiler.
+
+use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
+use std::time::{Duration, Instant};
 
-use crate::private::get_api;
+use crate::private::try_get_api;
 
-pub struct ProfileSignature {
-    pub file: String,
-    pub line: u32,
-    pub tag: String,
-}
-
-/// Function to add data to Godot's built-in profiler.
-#[inline]
-pub fn add_data(signature: &ProfileSignature, time_in_usec: u64) {
-    let signature = CString::new(format!(
-        "{}::{}::{}",
-        signature.file, signature.line, signature.tag
-    ))
-    .expect("Failed to create signature CString");
-    add_data_native(&signature, time_in_usec);
-}
-
-/// Low level function to add data to Godot's built-in profiler.
+/// A string encoding information about the code being profiled for Godot's built-in profiler.
 ///
-/// For a high level interface see the [`add_data`].
-#[inline]
-pub fn add_data_native(signature: &CStr, time_in_usec: u64) {
-    unsafe {
-        let api = get_api();
-        (api.godot_nativescript_profiling_add_data)(signature.as_ptr(), time_in_usec);
+/// The string should be in the form of `{file}::{line_number}::{tag}`, where `tag` is an
+/// identifier of the code, usually be the name of the method. None of the substrings should
+/// contain `::`.
+///
+/// To create a `Signature` in the correct form, see `Signature::new` or `profile_sig!`. To
+/// create a `Signature` from an existing `CStr` or `CString`, see `Signature::from_raw` and
+/// `Signature::from_raw_owned`.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Signature<'a> {
+    sig: Cow<'a, CStr>,
+}
+
+impl<'a> Signature<'a> {
+    /// Creates a `Signature` from a `CStr` in the specified format. The format is not
+    /// checked.
+    ///
+    /// Adding profiling data using an invalid `Signature` may cause incorrect information to
+    /// show up in the editor.
+    #[inline(always)]
+    pub const fn from_raw(sig: &'a CStr) -> Self {
+        Signature {
+            sig: Cow::Borrowed(sig),
+        }
     }
+
+    /// Creates a `Signature` from a NUL-terminated byte slice, containing a string in the
+    /// specified format. Neither the format nor whether the slice is correctly NUL-terminated
+    /// is checked.
+    ///
+    /// This is a convenience method for `Signature::from_raw(CStr::from_bytes_with_nul_unchecked(bytes))`.
+    ///
+    /// Adding profiling data using an invalid `Signature` may cause incorrect information to
+    /// show up in the editor.
+    ///
+    /// # Safety
+    ///
+    /// This function will cast the provided `bytes` to a `CStr` wrapper without performing any
+    /// sanity checks. The provided slice **must** be nul-terminated and not contain any
+    /// interior nul bytes.
+    #[inline(always)]
+    pub unsafe fn from_bytes_with_nul_unchecked(bytes: &'a [u8]) -> Self {
+        let sig = CStr::from_bytes_with_nul_unchecked(bytes);
+        Self::from_raw(sig)
+    }
+
+    /// Create a borrowed version of `self` for repeated use with `add_data` or `profile`.
+    #[inline(always)]
+    pub fn borrow(&self) -> Signature<'_> {
+        Signature {
+            sig: Cow::Borrowed(&*self.sig),
+        }
+    }
+
+    /// Add a data point to Godot's built-in profiler using this signature.
+    ///
+    /// See the free function `gdnative::nativescript::profiling::add_data`.
+    #[inline]
+    pub fn add_data(&self, time: Duration) {
+        add_data(self.borrow(), time)
+    }
+
+    /// Times a closure and adds the measured time to Godot's built-in profiler with this
+    /// signature, and then returns it's return value.
+    ///
+    /// See the free function `gdnative::nativescript::profiling::profile`.
+    #[inline]
+    pub fn profile<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        profile(self.borrow(), f)
+    }
+
+    fn as_ptr(&self) -> *const libc::c_char {
+        self.sig.as_ptr()
+    }
+}
+
+impl Signature<'static> {
+    /// Creates a `Signature` in the correct form using the given variables. The format is
+    /// checked at runtime.
+    ///
+    /// # Panics
+    ///
+    /// If `file` or `tag` contain `::` or NUL-bytes.
+    #[inline]
+    pub fn new(file: &str, line: u32, tag: &str) -> Self {
+        if file.find("::").is_some() {
+            panic!("file name should not contain `::`");
+        }
+
+        if tag.find("::").is_some() {
+            panic!("tag should not contain `::`");
+        }
+
+        let sig = CString::new(format!("{}::{}::{}", file, line, tag))
+            .expect("file and tag should not contain NUL bytes");
+        Self::from_raw_owned(sig)
+    }
+
+    /// Creates a `Signature` from an owned `CString` in the specified format. The format is not
+    /// checked.
+    ///
+    /// Adding profiling data using an invalid `Signature` may cause incorrect information to
+    /// show up in the editor.
+    #[inline(always)]
+    pub const fn from_raw_owned(sig: CString) -> Self {
+        Signature {
+            sig: Cow::Owned(sig),
+        }
+    }
+}
+
+/// Add a data point to Godot's built-in profiler. The profiler only has microsecond precision.
+/// Sub-microsecond time is truncated.
+///
+/// If the GDNative API is not initialized at the point when this is called, the function will
+/// fail silently.
+///
+/// # Panics
+///
+/// If the number of microseconds in `time` exceeds the range of `u64`.
+#[inline]
+pub fn add_data(signature: Signature<'_>, time: Duration) {
+    if let Some(api) = try_get_api() {
+        let time_in_usec = u64::try_from(time.as_micros())
+            .expect("microseconds in `time` should not exceed the range of u64");
+
+        unsafe {
+            (api.godot_nativescript_profiling_add_data)(signature.as_ptr(), time_in_usec);
+        }
+    }
+}
+
+/// Times a closure and adds the measured time to Godot's built-in profiler with the given
+/// signature, and then returns it's return value.
+#[inline]
+pub fn profile<F, R>(signature: Signature<'_>, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let start = Instant::now();
+    let ret = f();
+    add_data(signature, Instant::now() - start);
+    ret
 }

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -79,6 +79,12 @@ pub fn get_api() -> &'static sys::GodotApi {
     unsafe { GODOT_API.as_ref().unwrap_or_else(|| std::process::abort()) }
 }
 
+/// Returns a reference to the current API struct if it is bounds, or `None` otherwise.
+#[inline]
+pub(crate) fn try_get_api() -> Option<&'static sys::GodotApi> {
+    unsafe { GODOT_API.as_ref() }
+}
+
 /// Returns whether the API is bound.
 ///
 /// This is intended to be an internal interface.

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -9,11 +9,47 @@ use proc_macro::TokenStream;
 
 mod methods;
 mod native_script;
+mod profiled;
 mod variant;
 
 #[proc_macro_attribute]
 pub fn methods(meta: TokenStream, input: TokenStream) -> TokenStream {
     methods::derive_methods(meta, input)
+}
+
+/// Makes a function profiled in Godot's built-in profiler. This macro automatically
+/// creates a tag using the name of the current module and the function by default.
+///
+/// This attribute may also be used on non-exported functions. If the GDNative API isn't
+/// initialized when the function is called, the data will be ignored silently.
+///
+/// A custom tag can also be provided using the `tag` option.
+///
+/// See the `gdnative::nativescript::profiling` for a lower-level API to the profiler with
+/// more control.
+///
+/// # Examples
+///
+/// ```ignore
+/// mod foo {
+///     // This function will show up as `foo/bar` under Script Functions.
+///     #[gdnative::profiled]
+///     fn bar() {
+///         std::thread::sleep(std::time::Duration::from_millis(1));
+///     }
+/// }
+/// ```
+///
+/// ```ignore
+/// // This function will show up as `my_custom_tag` under Script Functions.
+/// #[gdnative::profiled(tag = "my_custom_tag")]
+/// fn baz() {
+///     std::thread::sleep(std::time::Duration::from_millis(1));
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
+    profiled::derive_profiled(meta, input)
 }
 
 #[proc_macro_derive(

--- a/gdnative-derive/src/profiled.rs
+++ b/gdnative-derive/src/profiled.rs
@@ -1,0 +1,117 @@
+use syn::{spanned::Spanned, AttributeArgs, ItemFn, Meta, NestedMeta};
+
+use proc_macro::TokenStream;
+
+pub struct ProfiledAttrArgs {
+    pub tag: Option<String>,
+}
+
+#[derive(Default)]
+pub struct ProfiledAttrArgsBuilder {
+    tag: Option<String>,
+    errors: Vec<syn::Error>,
+}
+
+impl<'a> Extend<&'a syn::NestedMeta> for ProfiledAttrArgsBuilder {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = &'a syn::NestedMeta>,
+    {
+        for meta in iter.into_iter() {
+            let pair = match meta {
+                NestedMeta::Meta(Meta::NameValue(name_value)) => name_value,
+                _ => {
+                    self.errors
+                        .push(syn::Error::new(meta.span(), "expecting name-value pair"));
+                    continue;
+                }
+            };
+
+            let name = pair
+                .path
+                .get_ident()
+                .expect("should be single identifier")
+                .to_string();
+            match name.as_str() {
+                "tag" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        self.errors.push(syn::Error::new(
+                            pair.lit.span(),
+                            "tag value is not a string literal",
+                        ));
+                        continue;
+                    };
+
+                    if let Some(old) = self.tag.replace(string) {
+                        self.errors.push(syn::Error::new(
+                            pair.lit.span(),
+                            format!("there is already a tag set: {:?}", old),
+                        ));
+                    }
+                }
+                _ => {
+                    self.errors
+                        .push(syn::Error::new(pair.span(), "unexpected argument"));
+                }
+            }
+        }
+    }
+}
+
+impl ProfiledAttrArgsBuilder {
+    pub fn done(self) -> Result<ProfiledAttrArgs, Vec<syn::Error>> {
+        if self.errors.is_empty() {
+            Ok(ProfiledAttrArgs { tag: self.tag })
+        } else {
+            Err(self.errors)
+        }
+    }
+}
+
+pub(crate) fn derive_profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(meta as AttributeArgs);
+    let mut input = parse_macro_input!(input as ItemFn);
+
+    let args = {
+        let mut args_builder = ProfiledAttrArgsBuilder::default();
+        args_builder.extend(args.iter());
+        match args_builder.done() {
+            Ok(args) => args,
+            Err(errors) => {
+                return errors
+                    .into_iter()
+                    .map(|e| TokenStream::from(e.to_compile_error()))
+                    .collect()
+            }
+        }
+    };
+
+    let tag = match args.tag {
+        Some(tag) => quote!(#tag),
+        None => {
+            let ident = input.sig.ident.to_string();
+
+            quote! {
+                &format!(
+                    "{}/{}",
+                    module_path!()
+                        .split("::")
+                        .last()
+                        .expect("module path should be non-empty"),
+                    #ident,
+                )
+            }
+        }
+    };
+
+    let stmts = std::mem::take(&mut input.block.stmts);
+    input.block = Box::new(parse_quote!({
+        ::gdnative::nativescript::profiling::profile(::gdnative::profile_sig!(#tag), move || {
+            #(#stmts)*
+        })
+    }));
+
+    quote!(#input).into()
+}


### PR DESCRIPTION
Adds the `#[gdnative::profiled]` attribute, which makes the function it decorates timed in Godot's built-in profiler. By default, the tag is automatically generated based on the names of the function and the current module. Users may also specify custom tags with the `tag` option.

Modified the profiling interface to allow borrowing, and low-level control over how the signature is formatted in a unified interface.