### PR TITLE
Make FromVariantError implement std::error::Error.

### DIFF
--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -1161,6 +1161,8 @@ impl fmt::Display for FromVariantError {
     }
 }
 
+impl std::error::Error for FromVariantError {}
+
 impl<T: ToVariant> OwnedToVariant for T {
     #[inline]
     fn owned_to_variant(self) -> Variant {


### PR DESCRIPTION
This allows the use of generic error handling crates like anyhow.

All tests pass and I formatted the code with cargo fmt as in the contribution guidelines.