### PR TITLE
Add property set/get hooks.

### DIFF
--- a/gdnative-derive/src/native_script/property_args.rs
+++ b/gdnative-derive/src/native_script/property_args.rs
@@ -1,12 +1,20 @@
 pub struct PropertyAttrArgs {
     pub path: Option<String>,
     pub default: Option<syn::Lit>,
+    pub before_get: Option<syn::Path>,
+    pub after_get: Option<syn::Path>,
+    pub before_set: Option<syn::Path>,
+    pub after_set: Option<syn::Path>,
 }
 
 #[derive(Default)]
 pub struct PropertyAttrArgsBuilder {
     path: Option<String>,
     default: Option<syn::Lit>,
+    before_get: Option<syn::Path>,
+    after_get: Option<syn::Path>,
+    before_set: Option<syn::Path>,
+    after_set: Option<syn::Path>,
 }
 
 impl<'a> Extend<&'a syn::MetaNameValue> for PropertyAttrArgsBuilder {
@@ -37,6 +45,58 @@ impl<'a> Extend<&'a syn::MetaNameValue> for PropertyAttrArgsBuilder {
                         panic!("there is already a path set: {:?}", old);
                     }
                 }
+                "before_get" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        panic!("before_get value is not a string literal");
+                    };
+
+                    let path = syn::parse_str::<syn::Path>(string.as_str())
+                        .expect("Invalid path expression.");
+                    if let Some(old) = self.before_get.replace(path) {
+                        panic!("there is already a before_get value set: {:?}", old);
+                    }
+                }
+                "after_get" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        panic!("after_get value is not a string literal");
+                    };
+
+                    let path = syn::parse_str::<syn::Path>(string.as_str())
+                        .expect("Invalid path expression.");
+                    if let Some(old) = self.after_get.replace(path) {
+                        panic!("there is already a after_get value set: {:?}", old);
+                    }
+                }
+                "before_set" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        panic!("before_set value is not a string literal");
+                    };
+
+                    let path = syn::parse_str::<syn::Path>(string.as_str())
+                        .expect("Invalid path expression.");
+                    if let Some(old) = self.before_set.replace(path) {
+                        panic!("there is already a before_set value set: {:?}", old);
+                    }
+                }
+                "after_set" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        panic!("after_set value is not a string literal");
+                    };
+
+                    let path = syn::parse_str::<syn::Path>(string.as_str())
+                        .expect("Invalid path expression.");
+                    if let Some(old) = self.after_set.replace(path) {
+                        panic!("there is already a after_set value set: {:?}", old);
+                    }
+                }
                 _ => panic!("unexpected argument: {}", &name),
             }
         }
@@ -48,6 +108,10 @@ impl PropertyAttrArgsBuilder {
         PropertyAttrArgs {
             path: self.path,
             default: self.default,
+            before_get: self.before_get,
+            after_get: self.after_get,
+            before_set: self.before_set,
+            after_set: self.after_set,
         }
     }
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd_test"] }
+gdnative-derive = { path = "../gdnative-derive" }

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -1,4 +1,5 @@
-// use gdnative::*;
+use std::cell::Cell;
+
 use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
@@ -6,11 +7,14 @@ pub(crate) fn run_tests() -> bool {
 
     status &= test_derive_to_variant();
     status &= test_derive_owned_to_variant();
+    status &= test_derive_nativeclass_with_property_hooks();
 
     status
 }
 
-pub(crate) fn register(_handle: InitHandle) {}
+pub(crate) fn register(handle: InitHandle) {
+    handle.add_class::<PropertyHooks>();
+}
 
 fn test_derive_to_variant() -> bool {
     println!(" -- test_derive_to_variant");
@@ -151,6 +155,117 @@ fn test_derive_owned_to_variant() -> bool {
                 .collect::<Vec<_>>()
                 .as_slice()
         );
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_derive_owned_to_variant failed");
+    }
+
+    ok
+}
+
+#[derive(gdnative::NativeClass)]
+#[inherit(Node)]
+struct PropertyHooks {
+    #[property(
+        before_get = "Self::before_get",
+        after_get = "Self::after_get",
+        before_set = "Self::before_set",
+        after_set = "Self::after_set"
+    )]
+    value: u32,
+
+    pub before_get_called: Cell<u32>,
+    pub after_get_called: Cell<u32>,
+    pub before_set_value: Option<u32>,
+    pub after_set_value: Option<u32>,
+}
+
+#[gdnative_derive::methods]
+impl PropertyHooks {
+    fn new(_owner: &Node) -> Self {
+        Self {
+            value: 0,
+            before_get_called: Cell::new(0),
+            after_get_called: Cell::new(0),
+            before_set_value: None,
+            after_set_value: None,
+        }
+    }
+
+    fn before_get(&self, _owner: TRef<Node, Shared>) {
+        assert_eq!(self.before_get_called.get(), self.after_get_called.get());
+        self.before_get_called.set(self.before_get_called.get() + 1);
+    }
+
+    fn after_get(&self, _owner: TRef<Node, Shared>) {
+        assert_eq!(
+            self.before_get_called.get(),
+            self.after_get_called.get() + 1
+        );
+        self.after_get_called.set(self.after_get_called.get() + 1);
+    }
+
+    fn assert_get_calls(&self, times: u32) {
+        assert_eq!(times, self.before_get_called.get());
+        assert_eq!(times, self.after_get_called.get());
+    }
+
+    fn before_set(&mut self, _owner: TRef<Node, Shared>) {
+        self.before_set_value = Some(self.value);
+    }
+
+    fn after_set(&mut self, _owner: TRef<Node, Shared>) {
+        self.after_set_value = Some(self.value);
+    }
+
+    fn reset_set_value(&mut self) {
+        self.before_set_value = None;
+        self.after_set_value = None;
+    }
+}
+
+fn test_derive_nativeclass_with_property_hooks() -> bool {
+    println!(" -- test_derive_nativeclass_with_property_hooks");
+
+    let ok = std::panic::catch_unwind(|| {
+        use gdnative::nativescript::user_data::MapMut;
+
+        let thing = Instance::<PropertyHooks, _>::new();
+        let (owner, script) = thing.decouple();
+
+        owner.set("value", 42);
+        script
+            .map_mut(|script| {
+                assert_eq!(Some(0), script.before_set_value);
+                assert_eq!(Some(42), script.after_set_value);
+                script.reset_set_value();
+            })
+            .unwrap();
+
+        script
+            .map_mut(|script| {
+                script.assert_get_calls(0);
+            })
+            .unwrap();
+        assert_eq!(42, u32::from_variant(&owner.get("value")).unwrap());
+        script
+            .map_mut(|script| {
+                script.assert_get_calls(1);
+            })
+            .unwrap();
+
+        owner.set("value", 12345);
+        script
+            .map_mut(|script| {
+                assert_eq!(Some(42), script.before_set_value);
+                assert_eq!(Some(12345), script.after_set_value);
+                script.reset_set_value();
+            })
+            .unwrap();
+
+        owner.free();
     })
     .is_ok();
 


### PR DESCRIPTION
This change adds a number of property modifiers that add the ability to specify a hook functions to run before and/or after setting and/or getting the values of properties.

Thanks to @wt for the original PR.

Supersedes #581.