### PR TITLE
Fix module path in user_data documentation example

### DIFF
--- a/gdnative-core/src/nativescript/user_data.rs
+++ b/gdnative-core/src/nativescript/user_data.rs
@@ -24,8 +24,8 @@
 //!
 //! ```ignore
 //! #[derive(NativeClass)]
-//! #[inherit(gdnative::Node)]
-//! #[user_data(gdnative::user_data::MutexData<HelloWorld>)]
+//! #[inherit(gdnative::api::Node)]
+//! #[user_data(gdnative::nativescript::user_data::MutexData<HelloWorld>)]
 //! struct HelloWorld;
 //! ```
 //!


### PR DESCRIPTION
Example code in `user_data` wrapper documentation contains old module paths, this patch updates it to the new location.