### PR TITLE
parse default args

### DIFF
--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -38,6 +38,7 @@ fn main() {
     // build.rs will automatically be recompiled and run if it's dependencies are updated.
     // Ignoring all but build.rs will keep from needless rebuilds.
     // Manually rebuilding the crate will ignore this.
+    println!("cargo:rerun-if-changed=docs/");
     println!("cargo:rerun-if-changed=api.json");
     println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
related to #104 

one problem remains.
for some reason rust parses this (when being put into a doc-comment) and thinks its code and wants to run it in the docs-tests:

<img width="738" alt="image" src="https://user-images.githubusercontent.com/776816/93690419-61dd6280-fad8-11ea-8f15-1c934d5fdbb2.png">

resulting in this rust doc:
<img width="728" alt="image" src="https://user-images.githubusercontent.com/776816/93690458-e7611280-fad8-11ea-9c7b-bc13907811ac.png">
