### PR TITLE
Implement RPC Modes

### DIFF
--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -255,8 +255,8 @@ impl<C: NativeClass> ClassBuilder<C> {
         let rpc = match method.attributes.rpc_mode {
             RpcMode::Master => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTER,
             RpcMode::Remote => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTE,
-            RpcMode::Puppet => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_SLAVE,
-            RpcMode::RemoteSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_SYNC,
+            RpcMode::Puppet => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPET,
+            RpcMode::RemoteSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTESYNC,
             RpcMode::Disabled => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED,
             RpcMode::MasterSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTERSYNC,
             RpcMode::PuppetSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPETSYNC,
@@ -282,21 +282,24 @@ impl<C: NativeClass> ClassBuilder<C> {
     }
 
     #[inline]
-    pub fn add_method(&self, name: &str, method: ScriptMethodFn, rpc: &str) {
-        let rpc_mode = match rpc {
-            "remote" => RpcMode::Remote,
-            "remotesync" => RpcMode::RemoteSync,
-            "master" => RpcMode::Master,
-            "puppet" => RpcMode::Puppet,
-            "puppetsync" => RpcMode::PuppetSync,
-            "mastersync" => RpcMode::MasterSync,
-            _ => RpcMode::Disabled,
-        };
-
+    pub fn add_method_with_rpc_mode(&self, name: &str, method: ScriptMethodFn, rpc_mode: RpcMode) {
         self.add_method_advanced(ScriptMethod {
             name,
             method_ptr: Some(method),
-            attributes: ScriptMethodAttributes { rpc_mode: rpc_mode },
+            attributes: ScriptMethodAttributes { rpc_mode },
+            method_data: ptr::null_mut(),
+            free_func: None,
+        });
+    }
+
+    #[inline]
+    pub fn add_method(&self, name: &str, method: ScriptMethodFn) {
+        self.add_method_advanced(ScriptMethod {
+            name,
+            method_ptr: Some(method),
+            attributes: ScriptMethodAttributes {
+                rpc_mode: RpcMode::Disabled,
+            },
             method_data: ptr::null_mut(),
             free_func: None,
         });

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -223,6 +223,8 @@ pub enum RpcMode {
     RemoteSync,
     Master,
     Puppet,
+    MasterSync,
+    PuppetSync,
 }
 
 pub struct ScriptMethodAttributes {
@@ -256,6 +258,8 @@ impl<C: NativeClass> ClassBuilder<C> {
             RpcMode::Puppet => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_SLAVE,
             RpcMode::RemoteSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_SYNC,
             RpcMode::Disabled => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED,
+            RpcMode::MasterSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTERSYNC,
+            RpcMode::PuppetSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPETSYNC,
         };
 
         let attr = sys::godot_method_attributes { rpc_type: rpc };
@@ -284,6 +288,8 @@ impl<C: NativeClass> ClassBuilder<C> {
             "remotesync" => RpcMode::RemoteSync,
             "master" => RpcMode::Master,
             "puppet" => RpcMode::Puppet,
+            "puppetsync" => RpcMode::PuppetSync,
+            "mastersync" => RpcMode::MasterSync,
             _ => RpcMode::Disabled,
         };
 

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -294,15 +294,7 @@ impl<C: NativeClass> ClassBuilder<C> {
 
     #[inline]
     pub fn add_method(&self, name: &str, method: ScriptMethodFn) {
-        self.add_method_advanced(ScriptMethod {
-            name,
-            method_ptr: Some(method),
-            attributes: ScriptMethodAttributes {
-                rpc_mode: RpcMode::Disabled,
-            },
-            method_data: ptr::null_mut(),
-            free_func: None,
-        });
+        self.add_method_with_rpc_mode(name, method, RpcMode::Disabled);
     }
 
     /// Returns a `PropertyBuilder` which can be used to add a property to the class being

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -272,6 +272,14 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                                     rpc = "disabled";
                                                     return false;
                                                 }
+                                                "mastersync" => {
+                                                    rpc = "mastersync";
+                                                    return false;
+                                                }
+                                                "puppetsync" => {
+                                                    rpc = "puppetsync";
+                                                    return false;
+                                                }
                                                 _ => {
                                                     errors.push(syn::Error::new(
                                                         last.span(),


### PR DESCRIPTION
Users can specify RPC modes on exported functions as follows
`[export(rpc = "remotesync")]`

The names of the RPC modes were updated to follow the Godot official documentaion:
https://docs.godotengine.org/en/stable/classes/class_multiplayerapi.html#enumerations