### PR TITLE
Fix pointer type for class name to *const c_char

### DIFF
--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -198,10 +198,10 @@ macro_rules! make_method_table {
 
             #[inline(never)]
             fn init(table: &mut Self, api: &sys::GodotApi) {
-                const CLASS_NAME: *const i8 = concat!(stringify!($class), "\0").as_ptr() as *const i8;
+                const CLASS_NAME: *const libc::c_char = concat!(stringify!($class), "\0").as_ptr() as *const libc::c_char;
 
                 unsafe {
-                    $(table.$methods = (api.godot_method_bind_get_method)(CLASS_NAME, concat!(stringify!($methods), "\0").as_ptr() as *const i8);)*
+                    $(table.$methods = (api.godot_method_bind_get_method)(CLASS_NAME, concat!(stringify!($methods), "\0").as_ptr() as *const libc::c_char);)*
                 }
             }
         }


### PR DESCRIPTION
The type of c_char is different depending on the target platform. On most platforms this is `i8`, but on Android it's `u8` instead. This caused type mismatch errors when building for Android. Using the `libc` type alias should fix this.

Close #571