### PR TITLE
feat: Add 'clamped' to 'Vector2'

### DIFF
--- a/gdnative-core/src/core_types/vector2.rs
+++ b/gdnative-core/src/core_types/vector2.rs
@@ -30,6 +30,8 @@ pub trait Vector2Godot {
     /// This method runs faster than distance_to, so prefer it if you need to compare vectors or
     /// need the squared distance for some formula.
     fn distance_squared_to(self, other: Vector2) -> f32;
+    /// Returns the vector with a maximum length by limiting its length to `length`.
+    fn clamped(self, length: f32) -> Self;
     /// Internal API for converting to `sys` representation. Makes it possible to remove
     /// `transmute`s elsewhere.
     #[doc(hidden)]
@@ -123,6 +125,11 @@ impl Vector2Godot for Vector2 {
     #[inline]
     fn distance_squared_to(self, other: Vector2) -> f32 {
         (other - self).square_length()
+    }
+
+    #[inline]
+    fn clamped(self, length: f32) -> Self {
+        self.clamp_length(0.0, length)
     }
 
     #[inline]


### PR DESCRIPTION
Hiii!!! First and foremost thanks for this project! I am trying to learn Godot, but I want to use Rust instead of GDScript, and this is helping a lot! :blush: :crab: 

So I was following a GDScript tutorial, and was having a lot of trouble to replicate the Godot's `Vector2::clamped` (https://docs.godotengine.org/en/stable/classes/class_vector2.html?highlight=clamped#class-vector2-method-clamped).

After a lot of tries, I've discovered that the `euclid`'s `clamp_length` (https://docs.rs/euclid/0.22.1/euclid/struct.Vector2D.html#method.clamp_length) is actually really similar to the Godot one (https://github.com/godotengine/godot/blob/master/core/math/vector2.cpp#L131).

For it to be the same, you just have to pass `0.0` as the minimum length, so I've added here to ease future people stumbling the same issue/wanting to use the same function :slightly_smiling_face: 
