### PR TITLE
Made Instance::new use NativeScript::new instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,4 +153,5 @@ script:
       mkdir ./project/lib;
       cp ../target/debug/libgdnative_test.so ./project/lib/;
       "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/;
+      "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests;
     fi

--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -137,10 +137,10 @@ impl GodotClass {
 
     pub fn is_singleton_thread_safe(&self) -> bool {
         assert!(self.singleton, "class is not a singleton");
-        match self.name.as_str() {
-            "VisualServer" | "PhysicsServer" | "Physics3DServer" | "Physics2DServer" => false,
-            _ => true,
-        }
+        !matches!(
+            self.name.as_str(),
+            "VisualServer" | "PhysicsServer" | "Physics3DServer" | "Physics2DServer"
+        )
     }
 
     /// Returns the base class from `api` if `base_class` is not empty. Returns `None` otherwise.

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -209,7 +209,6 @@ macro_rules! make_method_table {
 }
 
 make_method_table!(struct ObjectMethodTable for Object {
-    set_script,
     get_class,
     is_class,
 });
@@ -226,4 +225,5 @@ make_method_table!(struct ReferenceMethodTable for Reference {
 make_method_table!(struct NativeScriptMethodTable for NativeScript {
     set_class_name,
     set_library,
+    new,
 });

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -209,12 +209,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
 
                 // only allow the "outer" style, aka #[thing] item.
                 method.attrs.retain(|attr| {
-                    let correct_style = match attr.style {
-                        syn::AttrStyle::Outer => true,
-                        _ => false,
-                    };
-
-                    if correct_style {
+                    if matches!(attr.style, syn::AttrStyle::Outer) {
                         let last_seg = attr
                             .path
                             .segments

--- a/test/project/addons/editor_test_runner/plugin.cfg
+++ b/test/project/addons/editor_test_runner/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="editor_test_runner"
+description=""
+author=""
+version=""
+script="plugin.gd"

--- a/test/project/addons/editor_test_runner/plugin.gd
+++ b/test/project/addons/editor_test_runner/plugin.gd
@@ -1,0 +1,39 @@
+tool
+extends EditorPlugin
+
+var gdn
+
+func _enter_tree():
+	var run_tests = false
+	for arg in OS.get_cmdline_args():
+		if arg == "--run-editor-tests":
+			run_tests = true
+			break
+	if run_tests:
+		_run_tests()
+	else:
+		print("Opening editor normally for the test project. To run tests, pass `--run-editor-tests` to the executable.")
+
+func _run_tests():
+	print(" -- Rust gdnative test suite:")
+	gdn = GDNative.new()
+	var status = false;
+
+	gdn.library = load("res://gdnative.gdnlib")
+
+	if gdn.initialize():
+		status = gdn.call_native("standard_varcall", "run_tests", [])
+
+		gdn.terminate()
+	else:
+		print(" -- Could not load the gdnative library.")
+
+	if status:
+		print(" -- Test run completed successfully.")
+	else:
+		print(" -- Test run completed with errors.")
+		OS.exit_code = 1
+
+	print(" -- exiting.")
+	get_tree().quit()
+

--- a/test/project/project.godot
+++ b/test/project/project.godot
@@ -6,11 +6,18 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=3
+config_version=4
+
+_global_script_classes=[  ]
+_global_script_class_icons={
+
+}
 
 [application]
 
 config/name="GodotRustTests"
 run/main_scene="res://Scene.tscn"
 
-[rendering]
+[editor_plugins]
+
+enabled=PoolStringArray( "editor_test_runner" )


### PR DESCRIPTION
Unlike `Object::set_script`, this will also work in editors even if the script isn't registered as a tool script.

Also modified CI to run tests in editor mode as well.

Close #614