### PR TITLE
Proper fallback in case of TypeId widening

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,4 +154,9 @@ script:
       cp ../target/debug/libgdnative_test.so ./project/lib/;
       "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/;
       "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests;
+      cargo build --features=type_tag_fallback;
+      mkdir ./project/lib;
+      cp ../target/debug/libgdnative_test.so ./project/lib/;
+      "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/;
+      "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests;
     fi

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -14,12 +14,15 @@ edition = "2018"
 default = ["nativescript"]
 gd_test = []
 nativescript = ["bitflags", "parking_lot"]
+type_tag_fallback = []
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.9.0" }
 libc = "0.2"
 approx = "0.3.2"
 euclid = "0.22.1"
+indexmap = "1.6.0"
+ahash = "0.4.5"
 
 gdnative-impl-proc-macros = { path = "../impl/proc_macros", version = "=0.9.0" }
 

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -16,6 +16,7 @@ default = ["bindings"]
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one_class_one_file"]
 
 gd_test = ["gdnative-core/gd_test"]
+type_tag_fallback = ["gdnative-core/type_tag_fallback"]
 bindings = ["gdnative-bindings"]
 
 [dependencies]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = []
+type_tag_fallback = ["gdnative/type_tag_fallback"]
+
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd_test"] }
 gdnative-derive = { path = "../gdnative-derive" }


### PR DESCRIPTION
This adds a proper fallback mechanism using `IndexSet` that should cover all cases where the layout of `TypeId` would not be compatible with that of `usize`.

A `type_tag_fallback` feature is added so both paths can be tested in CI.

Close #608.

Draft status: I would like to test both code paths in CI, but such a change would conflict with #615.