### PR TITLE
add Default implementation to NodePath

### DIFF
--- a/gdnative-core/src/core_types/node_path.rs
+++ b/gdnative-core/src/core_types/node_path.rs
@@ -117,6 +117,13 @@ impl NodePath {
     }
 }
 
+impl Default for NodePath {
+    #[inline]
+    fn default() -> Self {
+        NodePath::new(&GodotString::default())
+    }
+}
+
 impl ToString for NodePath {
     #[inline]
     fn to_string(&self) -> String {


### PR DESCRIPTION
The `Default` implementation will construct a `NodePath` from a
default `GodotString`.