### PR TITLE
Implement owner argument inference

### DIFF
--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -16,12 +16,12 @@ impl HUD {
         });
     }
 
-    fn new(_owner: &CanvasLayer) -> Self {
+    fn new(_owner: _) -> Self {
         HUD
     }
 
     #[export]
-    pub fn show_message(&self, owner: &CanvasLayer, text: String) {
+    pub fn show_message(&self, owner: _, text: String) {
         let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
         message_label.set_text(text);
         message_label.show();
@@ -30,7 +30,7 @@ impl HUD {
         timer.start(0.0);
     }
 
-    pub fn show_game_over(&self, owner: &CanvasLayer) {
+    pub fn show_game_over(&self, owner: TRef<CanvasLayer>) {
         self.show_message(owner, "Game Over".into());
 
         let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
@@ -42,20 +42,20 @@ impl HUD {
     }
 
     #[export]
-    pub fn update_score(&self, owner: &CanvasLayer, score: i64) {
+    pub fn update_score(&self, owner: _, score: i64) {
         let label = unsafe { owner.get_typed_node::<Label, _>("score_label") };
         label.set_text(score.to_string());
     }
 
     #[export]
-    fn on_start_button_pressed(&self, owner: &CanvasLayer) {
+    fn on_start_button_pressed(&self, owner: _) {
         let button = unsafe { owner.get_typed_node::<Button, _>("start_button") };
         button.hide();
         owner.emit_signal("start_game", &[]);
     }
 
     #[export]
-    fn on_message_timer_timeout(&self, owner: &CanvasLayer) {
+    fn on_message_timer_timeout(&self, owner: _) {
         let message_label = unsafe { owner.get_typed_node::<Label, _>("message_label") };
         message_label.hide()
     }

--- a/examples/dodge_the_creeps/src/main_scene.rs
+++ b/examples/dodge_the_creeps/src/main_scene.rs
@@ -18,7 +18,7 @@ pub struct Main {
 
 #[methods]
 impl Main {
-    fn new(_owner: &Node) -> Self {
+    fn new(_owner: _) -> Self {
         Main {
             mob: PackedScene::new().into_shared(),
             score: 0,
@@ -26,7 +26,7 @@ impl Main {
     }
 
     #[export]
-    fn game_over(&self, owner: &Node) {
+    fn game_over(&self, owner: _) {
         let score_timer = unsafe { owner.get_typed_node::<Timer, _>("score_timer") };
         let mob_timer = unsafe { owner.get_typed_node::<Timer, _>("mob_timer") };
 
@@ -36,12 +36,12 @@ impl Main {
         let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
         hud_node
             .cast_instance::<hud::HUD>()
-            .and_then(|hud| hud.map(|x, o| x.show_game_over(&*o)).ok())
+            .and_then(|hud| hud.map(|x, o| x.show_game_over(o)).ok())
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
     #[export]
-    fn new_game(&mut self, owner: &Node) {
+    fn new_game(&mut self, owner: _) {
         let start_position = unsafe { owner.get_typed_node::<Position2D, _>("start_position") };
         let player = unsafe { owner.get_typed_node::<Area2D, _>("player") };
         let start_timer = unsafe { owner.get_typed_node::<Timer, _>("start_timer") };
@@ -52,7 +52,7 @@ impl Main {
             .cast_instance::<player::Player>()
             .and_then(|player| {
                 player
-                    .map(|x, o| x.start(&*o, start_position.position()))
+                    .map(|x, o| x.start(o, start_position.position()))
                     .ok()
             })
             .unwrap_or_else(|| godot_print!("Unable to get player"));
@@ -64,8 +64,8 @@ impl Main {
             .cast_instance::<hud::HUD>()
             .and_then(|hud| {
                 hud.map(|x, o| {
-                    x.update_score(&*o, self.score);
-                    x.show_message(&*o, "Get Ready".into());
+                    x.update_score(o, self.score);
+                    x.show_message(o, "Get Ready".into());
                 })
                 .ok()
             })
@@ -73,7 +73,7 @@ impl Main {
     }
 
     #[export]
-    fn on_start_timer_timeout(&self, owner: &Node) {
+    fn on_start_timer_timeout(&self, owner: _) {
         let mob_timer = unsafe { owner.get_typed_node::<Timer, _>("mob_timer") };
         let score_timer = unsafe { owner.get_typed_node::<Timer, _>("score_timer") };
         mob_timer.start(0.0);
@@ -81,18 +81,18 @@ impl Main {
     }
 
     #[export]
-    fn on_score_timer_timeout(&mut self, owner: &Node) {
+    fn on_score_timer_timeout(&mut self, owner: _) {
         self.score += 1;
 
         let hud_node = unsafe { owner.get_typed_node::<CanvasLayer, _>("hud") };
         hud_node
             .cast_instance::<hud::HUD>()
-            .and_then(|hud| hud.map(|x, o| x.update_score(&*o, self.score)).ok())
+            .and_then(|hud| hud.map(|x, o| x.update_score(o, self.score)).ok())
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
     #[export]
-    fn on_mob_timer_timeout(&self, owner: &Node) {
+    fn on_mob_timer_timeout(&self, owner: _) {
         let mob_spawn_location =
             unsafe { owner.get_typed_node::<PathFollow2D, _>("mob_path/mob_spawn_locations") };
 

--- a/examples/dodge_the_creeps/src/mob.rs
+++ b/examples/dodge_the_creeps/src/mob.rs
@@ -34,7 +34,7 @@ const MOB_TYPES: [MobType; 3] = [MobType::Walk, MobType::Swim, MobType::Fly];
 
 #[methods]
 impl Mob {
-    fn new(_owner: &RigidBody2D) -> Self {
+    fn new(_owner: _) -> Self {
         Mob {
             min_speed: 150.0,
             max_speed: 250.0,
@@ -42,7 +42,7 @@ impl Mob {
     }
 
     #[export]
-    fn _ready(&mut self, owner: &RigidBody2D) {
+    fn _ready(&mut self, owner: _) {
         let mut rng = rand::thread_rng();
         let animated_sprite =
             unsafe { owner.get_typed_node::<AnimatedSprite, _>("animated_sprite") };
@@ -50,14 +50,14 @@ impl Mob {
     }
 
     #[export]
-    fn on_visibility_screen_exited(&self, owner: &RigidBody2D) {
+    fn on_visibility_screen_exited(&self, owner: _) {
         unsafe {
             owner.assume_unique().queue_free();
         }
     }
 
     #[export]
-    fn on_start_game(&self, owner: &RigidBody2D) {
+    fn on_start_game(&self, owner: _) {
         unsafe {
             owner.assume_unique().queue_free();
         }

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -23,7 +23,7 @@ impl Player {
         });
     }
 
-    fn new(_owner: &Area2D) -> Self {
+    fn new(_owner: _) -> Self {
         Player {
             speed: 400.0,
             screen_size: Vector2::new(0.0, 0.0),
@@ -31,14 +31,14 @@ impl Player {
     }
 
     #[export]
-    fn _ready(&mut self, owner: &Area2D) {
+    fn _ready(&mut self, owner: _) {
         let viewport = unsafe { owner.get_viewport().unwrap().assume_safe() };
         self.screen_size = viewport.size();
         owner.hide();
     }
 
     #[export]
-    fn _process(&mut self, owner: &Area2D, delta: f32) {
+    fn _process(&mut self, owner: _, delta: f32) {
         let animated_sprite =
             unsafe { owner.get_typed_node::<AnimatedSprite, _>("animated_sprite") };
 
@@ -86,7 +86,7 @@ impl Player {
     }
 
     #[export]
-    fn on_player_body_entered(&self, owner: &Area2D, _body: Ref<PhysicsBody2D>) {
+    fn on_player_body_entered(&self, owner: _, _body: Ref<PhysicsBody2D>) {
         owner.hide();
         owner.emit_signal("hit", &[]);
 
@@ -97,7 +97,7 @@ impl Player {
     }
 
     #[export]
-    pub fn start(&self, owner: &Area2D, pos: Vector2) {
+    pub fn start(&self, owner: _, pos: Vector2) {
         owner.set_global_position(pos);
         owner.show();
 

--- a/examples/resource/src/lib.rs
+++ b/examples/resource/src/lib.rs
@@ -10,11 +10,11 @@ struct GreetingResource {
 
 #[gdnative::methods]
 impl GreetingResource {
-    fn new(_owner: &Resource) -> Self {
+    fn new(_owner: _) -> Self {
         Self { name: "".into() }
     }
 
-    fn say_hello(&self, _owner: &Reference) {
+    fn say_hello(&self, _owner: _) {
         godot_print!("Hello {}!", self.name);
     }
 }
@@ -31,17 +31,17 @@ struct Greeter {
 
 #[gdnative::methods]
 impl Greeter {
-    fn new(_owner: &Node) -> Self {
+    fn new(_owner: _) -> Self {
         Greeter {
             greeting_resource: None,
         }
     }
 
     #[export]
-    fn _ready(&self, _owner: &Node) {
+    fn _ready(&self, _owner: _) {
         if let Some(greeting_resource) = self.greeting_resource.as_ref() {
             let greeting_resource = unsafe { greeting_resource.assume_safe() };
-            greeting_resource.map(|s, o| s.say_hello(&*o)).unwrap();
+            greeting_resource.map(|s, o| s.say_hello(o)).unwrap();
         }
     }
 }

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -29,7 +29,7 @@ impl SignalEmitter {
         });
     }
 
-    fn new(_owner: &Node) -> Self {
+    fn new(_owner: _) -> Self {
         SignalEmitter {
             timer: 0.0,
             data: 100,
@@ -37,7 +37,7 @@ impl SignalEmitter {
     }
 
     #[export]
-    fn _process(&mut self, owner: &Node, delta: f64) {
+    fn _process(&mut self, owner: _, delta: f64) {
         if self.timer < 1.0 {
             self.timer += delta;
             return;
@@ -61,12 +61,12 @@ struct SignalSubscriber {
 
 #[methods]
 impl SignalSubscriber {
-    fn new(_owner: &Label) -> Self {
+    fn new(_owner: _) -> Self {
         SignalSubscriber { times_received: 0 }
     }
 
     #[export]
-    fn _ready(&mut self, owner: TRef<Label>) {
+    fn _ready(&mut self, owner: _) {
         let emitter = &mut owner.get_node("../SignalEmitter").unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
@@ -85,7 +85,7 @@ impl SignalSubscriber {
     }
 
     #[export]
-    fn notify(&mut self, owner: &Label) {
+    fn notify(&mut self, owner: _) {
         self.times_received += 1;
         let msg = format!("Received signal \"tick\" {} times", self.times_received);
 
@@ -93,7 +93,7 @@ impl SignalSubscriber {
     }
 
     #[export]
-    fn notify_with_data(&mut self, owner: &Label, data: Variant) {
+    fn notify_with_data(&mut self, owner: _, data: Variant) {
         let msg = format!(
             "Received signal \"tick_with_data\" with data {}",
             data.try_to_u64().unwrap()

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -38,7 +38,7 @@ fn register_properties(builder: &ClassBuilder<RustTest>) {
 
 #[gdnative::methods]
 impl RustTest {
-    fn new(_owner: &MeshInstance) -> Self {
+    fn new(_owner: _) -> Self {
         RustTest {
             start: Vector3::new(0.0, 0.0, 0.0),
             time: 0.0,
@@ -47,12 +47,12 @@ impl RustTest {
     }
 
     #[export]
-    fn _ready(&mut self, owner: &MeshInstance) {
+    fn _ready(&mut self, owner: _) {
         owner.set_physics_process(true);
     }
 
     #[export]
-    fn _physics_process(&mut self, owner: &MeshInstance, delta: f64) {
+    fn _physics_process(&mut self, owner: _, delta: f64) {
         use gdnative::api::SpatialMaterial;
 
         self.time += delta as f32;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -105,37 +105,30 @@ fn test_underscore_method_binding() -> bool {
 #[inherit(Reference)]
 struct Foo(i64);
 
-impl Foo {
-    fn new(_owner: TRef<Reference>) -> Foo {
-        Foo(42)
-    }
-}
-
 #[derive(NativeClass)]
 #[inherit(Reference)]
 struct NotFoo;
 
+#[methods]
 impl NotFoo {
-    fn new(_owner: &Reference) -> NotFoo {
+    fn new(_owner: _) -> NotFoo {
         NotFoo
     }
 }
 
 #[methods]
 impl Foo {
+    fn new(_owner: TRef<Reference>) -> Foo {
+        Foo(42)
+    }
+
     #[export]
     fn answer(&self, _owner: &Reference) -> i64 {
         self.0
     }
 
     #[export]
-    fn choose(
-        &self,
-        _owner: &Reference,
-        a: GodotString,
-        which: bool,
-        b: GodotString,
-    ) -> GodotString {
+    fn choose(&self, _owner: _, a: GodotString, which: bool, b: GodotString) -> GodotString {
         if which {
             a
         } else {
@@ -144,7 +137,7 @@ impl Foo {
     }
 
     #[export]
-    fn choose_variant(&self, _owner: &Reference, a: i32, what: Variant, b: f64) -> Variant {
+    fn choose_variant(&self, _owner: _, a: i32, what: Variant, b: f64) -> Variant {
         let what = what.try_to_string().expect("should be string");
         match what.as_str() {
             "int" => a.to_variant(),
@@ -184,19 +177,17 @@ fn test_rust_class_construction() -> bool {
 #[inherit(Reference)]
 struct OptionalArgs;
 
-impl OptionalArgs {
-    fn new(_owner: &Reference) -> Self {
-        OptionalArgs
-    }
-}
-
 #[methods]
 impl OptionalArgs {
+    fn new(_owner: _) -> Self {
+        OptionalArgs
+    }
+
     #[export]
     #[allow(clippy::many_single_char_names)]
     fn opt_sum(
         &self,
-        _owner: &Reference,
+        _owner: _,
         a: i64,
         b: i64,
         #[opt] c: i64,

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -22,7 +22,7 @@ struct Bar(i64, Arc<AtomicUsize>);
 #[methods]
 impl Bar {
     #[export]
-    fn free_is_not_ub(&mut self, owner: &Node) -> bool {
+    fn free_is_not_ub(&mut self, owner: _) -> bool {
         unsafe {
             owner.assume_unique().free();
         }
@@ -31,7 +31,7 @@ impl Bar {
     }
 
     #[export]
-    fn set_script_is_not_ub(&mut self, owner: &Node) -> bool {
+    fn set_script_is_not_ub(&mut self, owner: _) -> bool {
         owner.set_script(Null::null());
         assert_eq!(42, self.0, "self should not point to garbage");
         true

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -67,12 +67,12 @@ impl NativeClass for RegisterProperty {
 #[methods]
 impl RegisterProperty {
     #[export]
-    fn set_value(&mut self, _owner: TRef<Reference>, value: i64) {
+    fn set_value(&mut self, _owner: _, value: i64) {
         self.value = value;
     }
 
     #[export]
-    fn get_value(&self, _owner: TRef<Reference>) -> i64 {
+    fn get_value(&self, _owner: _) -> i64 {
         self.value
     }
 }

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -29,22 +29,22 @@ impl NativeClass for VariantCallArgs {
 #[methods]
 impl VariantCallArgs {
     #[export]
-    fn zero(&mut self, _owner: &Reference) -> i32 {
+    fn zero(&mut self, _owner: _) -> i32 {
         42
     }
 
     #[export]
-    fn one(&mut self, _owner: &Reference, a: i32) -> i32 {
+    fn one(&mut self, _owner: _, a: i32) -> i32 {
         a * 42
     }
 
     #[export]
-    fn two(&mut self, _owner: &Reference, a: i32, b: i32) -> i32 {
+    fn two(&mut self, _owner: _, a: i32, b: i32) -> i32 {
         a * 42 + b
     }
 
     #[export]
-    fn three(&mut self, _owner: &Reference, a: i32, b: i32, c: i32) -> i32 {
+    fn three(&mut self, _owner: _, a: i32, b: i32, c: i32) -> i32 {
         a * 42 + b * c
     }
 }


### PR DESCRIPTION
This allows the use of `_` as types of arguments named `owner` or `_owner` within `#[methods]` blocks. Such placeholders will be automatically replaced with `TRef<'_, Self::Base, Shared>` for convenience.

This should make typing function signatures less tedious, and give new users a sufficiently sane default owner argument type that just works in common use cases: calling methods and passing as arguments. This should also help with the rather frequent confusion new users face when they try to write something that don't extend `Node`.

The downside is that it makes more things implicit, although it can be argued that `owner` in godot-rust is close enough to `self` to make this acceptable. Documentation is added to the `#[methods]` attribute macro to explain the exact behavior for advanced users.

Draft status: The change itself is simple enough and not really expected to impact #609 a lot, but some opinions on whether this is a good feature would be really helpful.