### PR TITLE
[ci] adding a CI Android target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,8 +119,7 @@ matrix:
       env: CI_STAGE_BUILD_RELEASE=yes CI_ANDROID_TEST=yes JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ANDROID_SDK_ROOT=/opt/android-ndk-r21d
       before_script:
         # aarch64 and armv7 cover most Android phones & tablets.
-        # However armv7 is not yet available for Rust stable.
-        - rustup target add aarch64-linux-android
+        - rustup target add aarch64-linux-android armv7-linux-androideabi
         - sudo apt-get install openjdk-8-jdk
         - sudo apt-get install llvm-dev libclang-dev clang g++-multilib gcc-multilib libc6-dev libc6-dev-arm64-cross
         # Downloading NDK. This file is huge (1Gb) maybe extract only what's needed and repackage.
@@ -136,6 +135,9 @@ matrix:
         - echo >> $HOME/.cargo/config
         - echo "[target.aarch64-linux-android]" >> $HOME/.cargo/config
         - find /opt -name aarch64-linux-android21-clang++ -printf 'linker = "%p"\n' >> $HOME/.cargo/config
+        - echo >> $HOME/.cargo/config
+        - echo "[target.armv7-linux-androideabi]" >> $HOME/.cargo/config
+        - find /opt -name armv7a-linux-androideabi21-clang++ -printf 'linker = "%p"\n' >> $HOME/.cargo/config
         - echo >> $HOME/.cargo/config
 
 script:
@@ -172,6 +174,7 @@ script:
       fi;
       if [[ "$CI_ANDROID_TEST" == "yes" ]]; then
         cargo build --target aarch64-linux-android --release;
+        cargo build --target armv7-linux-androideabi --release;
       fi
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,31 @@ matrix:
        - mkdir -p $HOME/.cargo/bin
        - cp cargo-dinghy-macos/cargo-dinghy $HOME/.cargo/bin
 
+    - name: cargo build --release (stable, android)
+      os: linux
+      rust: stable
+      env: CI_STAGE_BUILD_RELEASE=yes CI_ANDROID_TEST=yes JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ANDROID_SDK_ROOT=/opt/android-ndk-r21d
+      before_script:
+        # aarch64 and armv7 cover most Android phones & tablets.
+        # However armv7 is not yet available for Rust stable.
+        - rustup target add aarch64-linux-android
+        - sudo apt-get install openjdk-8-jdk
+        - sudo apt-get install llvm-dev libclang-dev clang g++-multilib gcc-multilib libc6-dev libc6-dev-arm64-cross
+        # Downloading NDK. This file is huge (1Gb) maybe extract only what's needed and repackage.
+        # See https://developer.android.com/ndk/downloads for updates.
+        # The Android SDK which comes with Android Studio is not required. Only Java + NDK are.
+        - install -d /opt
+        - cd /opt && wget -nc -nv https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && cd $TRAVIS_BUILD_DIR
+        - echo "bcf4023eb8cb6976a4c7cff0a8a8f145f162bf4d  /opt/android-ndk-r21d-linux-x86_64.zip" >> /opt/SHA1SUM.txt
+        - sha1sum --check /opt/SHA1SUM.txt
+        - cd /opt && unzip -q android-ndk-r21d-linux-x86_64.zip && cd $TRAVIS_BUILD_DIR
+        # Using clang linker from NDK when building Android programs.
+        - install -d $HOME/.cargo
+        - echo >> $HOME/.cargo/config
+        - echo "[target.aarch64-linux-android]" >> $HOME/.cargo/config
+        - find /opt -name aarch64-linux-android21-clang++ -printf 'linker = "%p"\n' >> $HOME/.cargo/config
+        - echo >> $HOME/.cargo/config
+
 script:
   - if [[ "$CI_STAGE_CARGO_FMT" == "yes" ]]; then
       cargo fmt --all -- --check;
@@ -144,6 +169,9 @@ script:
       cargo build --release;
       if [[ "$CI_MSVC_TEST" == "yes" ]]; then
         cargo build --target x86_64-pc-windows-msvc --release;
+      fi;
+      if [[ "$CI_ANDROID_TEST" == "yes" ]]; then
+        cargo build --target aarch64-linux-android --release;
       fi
     fi
 


### PR DESCRIPTION
This is a proposal to fix https://github.com/godot-rust/godot-rust/issues/617

It should detect bugs such as https://github.com/godot-rust/godot-rust/issues/571

I have reverted then committed back again the commit https://github.com/godot-rust/godot-rust/pull/599/commits/64c49feb2540c98a83c21ceafad6b1f3344491f6

This resulted in a [broken build #19](https://travis-ci.org/github/ufoot/godot-rust/builds/752135753) then a [successful build #20](https://travis-ci.org/github/ufoot/godot-rust/builds/752136899)

The final [build #22](https://travis-ci.org/github/ufoot/godot-rust/builds/752149489) shows how
the rebased commit should actually be "all green". As I am writing this PR it's not finished yet completely but the [android job](https://travis-ci.org/github/ufoot/godot-rust/jobs/752149498) was successful.

It is only built on stable, adding it to nightly is not hard, but it's yet another build,
and will not speed up the release cycle. Happy to hear feedback on that.

It still has, I think, 2 caveats:

* it downloads a 1Gb (one gigabyte :( ) `.zip` file for the NDK. I don't really know any workaround, it might be just fine to do that on Travis, after all it's reasonably fast. But I'm concerned it consumes so much resources.
* it builds, it does not test. Again, this is hard, and I'd suggest it is done in a second step, to keep this PR simple. Ideally you'd want to run a test program within an Android emulator.
