### PR TITLE
Feature/call error description

### DIFF
--- a/gdnative-core/src/core_types/access.rs
+++ b/gdnative-core/src/core_types/access.rs
@@ -33,7 +33,7 @@ where
 ///
 /// This trait is sealed and has no public members.
 #[allow(clippy::len_without_is_empty)]
-pub unsafe trait Guard: Drop + private::Sealed {
+pub unsafe trait Guard: private::Sealed {
     #[doc(hidden)]
     type Target;
 

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -204,7 +204,7 @@ macro_rules! godot_wrap_method_inner {
                             <$retty as $crate::core_types::OwnedToVariant>::owned_to_variant(ret)
                         })
                         .unwrap_or_else(|err| {
-                            $crate::godot_error!("gdnative-core: method call failed with error: {:?}", err);
+                            $crate::godot_error!("gdnative-core: method call failed with error: {}", err);
                             $crate::godot_error!("gdnative-core: check module level documentation on gdnative::user_data for more information");
                             $crate::core_types::Variant::new()
                         });

--- a/gdnative-core/src/nativescript/user_data.rs
+++ b/gdnative-core/src/nativescript/user_data.rs
@@ -153,6 +153,13 @@ pub type DefaultUserData<T> = LocalCellData<T>;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Infallible {}
 
+impl std::fmt::Display for Infallible {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Operation that can't fail just failed")
+    }
+}
+
 /// Policies to deal with potential deadlocks
 ///
 /// As Godot allows mutable pointer aliasing, doing certain things in exported method bodies may
@@ -526,7 +533,11 @@ mod local_cell {
                     "Accessing from the wrong thread, expected {:?} found {:?}",
                     original, current
                 ),
-                LocalCellError::BorrowFailed => write!(f, "Borrow Failed"),
+                LocalCellError::BorrowFailed => write!(
+                    f,
+                    "Borrow failed; a &mut reference was requested, but one already exists. Cause is likely a re-entrant call \
+                    (e.g. a GDNative Rust method calls to GDScript, which again calls a Rust method on the same object)."
+                ),
             }
         }
     }


### PR DESCRIPTION
Slightly more expressive error message when calls to Rust fail due to `&mut` aliasing.
Looks as follows:
![grafik](https://user-images.githubusercontent.com/708488/103409399-e70bf500-4b66-11eb-97a5-1741e1f58866.png)

I wonder if there's another place where this should be mentioned. Maybe in the `Node::call()` doc, as that's a likely source of re-entrancy?