### PR TITLE
example/dodge_the_creeps: Godot to control speed

### DIFF
--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -46,16 +46,16 @@ impl Player {
         let mut velocity = Vector2::new(0.0, 0.0);
 
         if Input::is_action_pressed(&input, "ui_right") {
-            velocity.x += 1.0
+            velocity.x += self.speed
         }
         if Input::is_action_pressed(&input, "ui_left") {
-            velocity.x -= 1.0
+            velocity.x -= self.speed
         }
         if Input::is_action_pressed(&input, "ui_down") {
-            velocity.y += 1.0
+            velocity.y += self.speed
         }
         if Input::is_action_pressed(&input, "ui_up") {
-            velocity.y -= 1.0
+            velocity.y -= self.speed
         }
 
         if velocity.length() > 0.0 {


### PR DESCRIPTION
Currently the example is using `velocity.x += 1.0` which doesn't allow
the end-user to control the speed within the engine. This attempts to
resolve that

![image](https://user-images.githubusercontent.com/11302521/103609054-de277480-4f14-11eb-9078-29a81fea0618.png)

Discovered using code quality assurance in https://github.com/RXT0147/unnamedGame/pull/1

Signed-off-by: Jacob Hrbek <kreyren@fsfe.org>