### PR TITLE
Fix minor mistakes in the Variant macros

### DIFF
--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -87,7 +87,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
                                 #ref_var_ident_string_literals => {
                                     let #var_input_ident_iter = &__dict.get(&__keys.get(0));
                                     (#var_from_variants).map_err(|err| FVE::InvalidEnumVariant {
-                                        variant: "Ok",
+                                        variant: #ref_var_ident_string_literals,
                                         error: Box::new(err),
                                     })
                                 },

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -48,10 +48,12 @@ pub(crate) fn expand_to_variant(
                         let tokens = quote! {
                             #ident::#var_ident #destructure_pattern => {
                                 let __dict = ::gdnative::core_types::Dictionary::new();
-                                let __key = ::gdnative::core_types::GodotString::from(#var_ident_string_literal).to_variant();
+                                let __key = ::gdnative::core_types::ToVariant::to_variant(
+                                    &::gdnative::core_types::GodotString::from(#var_ident_string_literal)
+                                );
                                 let __value = #to_variant;
                                 __dict.insert(&__key, &__value);
-                                __dict.into_shared().to_variant()
+                                ::gdnative::core_types::ToVariant::to_variant(&__dict.into_shared())
                             }
                         };
                         Ok(tokens)


### PR DESCRIPTION
- Add missing import to `derive(ToVariant)` output
- Use the correct variant name instead of `Ok` (leftover from `Result` impl) for `FromVariant` errors

Close #665