### PR TITLE
Add workflow for publishing on crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to crates.io
+
+on:
+  push:
+    branches:
+      - '!*'
+    tags:
+      - '*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: Deploy
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Sanity tests
+        run: |
+          cargo fmt --all -- --check;
+          cargo clippy --all --all-features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
+          cargo test --all --all-features;
+      - name: Publishing to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: |
+          (cd impl/proc_macros && cargo publish);
+          (cd gdnative-sys && cargo publish);
+          (cd gdnative-derive && cargo publish);
+          (cd gdnative-core && cargo publish);
+          (cd bindings_generator && cargo publish);
+          (cd gdnative-bindings && cargo publish);
+          (cd gdnative && cargo publish);


### PR DESCRIPTION
The workflow triggers on tag pushes, and must be approved by an organization member with push access. Once approved, the workflow will try publishing the crates in the correct order to crates.io

@godot-rust/bindings Thoughts? This should make the publishing process a tiny bit easier for future releases. The chances for the token to get compromised *should* be small enough to make this worth the drawback, imo.