### PR TITLE
Connect to server from client in RPC example

### DIFF
--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -31,7 +31,7 @@ impl ServerPuppet {
 
         let tree = owner.get_tree().expect("could not retreive SceneTree");
         let tree = unsafe { tree.assume_safe() };
-        
+
         tree.set_network_peer(peer);
 
         tree.connect(

--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -31,6 +31,8 @@ impl ServerPuppet {
 
         let tree = owner.get_tree().expect("could not retreive SceneTree");
         let tree = unsafe { tree.assume_safe() };
+        
+        tree.set_network_peer(peer);
 
         tree.connect(
             "connected_to_server",


### PR DESCRIPTION
Without this the client doesn't actually connect to the server.