### PR TITLE
Take self by value when deriving OwnedToVariant

### DIFF
--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -58,7 +58,7 @@ pub(crate) fn expand_to_variant(
                     }).collect::<Result<Vec<_>,syn::Error>>()?;
 
                 quote! {
-                    match &self {
+                    match #to_variant_receiver {
                         #( #match_arms ),*
                     }
                 }

--- a/gdnative/tests/ui/variant_pass.rs
+++ b/gdnative/tests/ui/variant_pass.rs
@@ -36,4 +36,12 @@ pub struct Foo {
     skip_from: String,
 }
 
+#[derive(OwnedToVariant)]
+pub struct Owned;
+
+#[derive(OwnedToVariant)]
+pub struct Bar {
+    owned: Owned,
+}
+
 fn main() {}


### PR DESCRIPTION
This was preventing the macro from working on types whose fields actually require OwnedToVariant.