### PR TITLE
Unwrangling the mess that is `godot_wrap_method`, adding generic method support as a side effect

### DIFF
--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -23,6 +23,7 @@ approx = "0.3.2"
 euclid = "0.22.1"
 indexmap = "1.6.0"
 ahash = "0.4.5"
+thiserror = "1.0"
 
 gdnative-impl-proc-macros = { path = "../impl/proc_macros", version = "=0.9.1" }
 

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -23,7 +23,6 @@ approx = "0.3.2"
 euclid = "0.22.1"
 indexmap = "1.6.0"
 ahash = "0.4.5"
-thiserror = "1.0"
 
 gdnative-impl-proc-macros = { path = "../impl/proc_macros", version = "=0.9.1" }
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -41,6 +41,7 @@ mod init;
 #[cfg(feature = "nativescript")]
 pub mod nativescript;
 
+pub mod log;
 mod new_ref;
 pub mod object;
 pub mod ref_kind;

--- a/gdnative-core/src/log.rs
+++ b/gdnative-core/src/log.rs
@@ -1,0 +1,97 @@
+//! Functions for using the engine's logging system in the editor.
+use std::ffi::CStr;
+use std::fmt::{self, Display};
+
+use crate::core_types::GodotString;
+use crate::private;
+
+/// Value representing a call site for errors and warnings. Can be constructed
+/// using the `godot_site!` macro, or manually.
+#[derive(Copy, Clone, Debug)]
+pub struct Site<'a> {
+    file: &'a CStr,
+    func: &'a CStr,
+    line: u32,
+}
+
+impl<'a> Site<'a> {
+    /// Construct a new `Site` value using values provided manually.
+    #[inline]
+    pub const fn new(file: &'a CStr, func: &'a CStr, line: u32) -> Self {
+        Site { file, func, line }
+    }
+}
+
+impl<'a> Default for Site<'a> {
+    #[inline]
+    fn default() -> Self {
+        let unset = unsafe { CStr::from_bytes_with_nul_unchecked(b"<unset>\0") };
+        Site::new(unset, unset, 0)
+    }
+}
+
+impl<'a> Display for Site<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "file {}, {}, line {}",
+            self.file.to_string_lossy(),
+            self.func.to_string_lossy(),
+            self.line
+        )
+    }
+}
+
+/// Print a message to the Godot console.
+///
+/// # Panics
+///
+/// If the API isn't initialized.
+#[inline]
+pub fn print<S: Display>(msg: S) {
+    unsafe {
+        let msg = GodotString::from_str(&msg.to_string());
+        (private::get_api().godot_print)(&msg.to_sys() as *const _);
+    }
+}
+
+/// Print a warning to the Godot console.
+///
+/// # Panics
+///
+/// If the API isn't initialized, or if the message contains any NUL-bytes.
+#[inline]
+pub fn warn<S: Display>(site: Site<'_>, msg: S) {
+    let msg = msg.to_string();
+    let msg = ::std::ffi::CString::new(msg).unwrap();
+
+    unsafe {
+        (private::get_api().godot_print_warning)(
+            msg.as_ptr(),
+            site.func.as_ptr(),
+            site.file.as_ptr(),
+            site.line as libc::c_int,
+        );
+    }
+}
+
+/// Print an error to the Godot console.
+///
+/// # Panics
+///
+/// If the API isn't initialized, or if the message contains any NUL-bytes.
+#[inline]
+pub fn error<S: Display>(site: Site<'_>, msg: S) {
+    let msg = msg.to_string();
+    let msg = ::std::ffi::CString::new(msg).unwrap();
+
+    unsafe {
+        (private::get_api().godot_print_error)(
+            msg.as_ptr(),
+            site.func.as_ptr(),
+            site.file.as_ptr(),
+            site.line as libc::c_int,
+        );
+    }
+}

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -45,6 +45,7 @@ use crate::private::get_api;
 
 use super::emplace;
 
+pub mod method;
 pub mod property;
 
 pub use self::property::{Export, ExportInfo, PropertyBuilder, Usage as PropertyUsage};

--- a/gdnative-core/src/nativescript/init.rs
+++ b/gdnative-core/src/nativescript/init.rs
@@ -31,6 +31,9 @@
 //! For full examples, see [`examples`](https://github.com/godot-rust/godot-rust/tree/master/examples)
 //! in the godot-rust repository.
 
+// Temporary for unsafe method registration
+#![allow(deprecated)]
+
 use crate::*;
 
 use std::ffi::CString;
@@ -48,7 +51,9 @@ use super::emplace;
 pub mod method;
 pub mod property;
 
-pub use self::method::{Method, Varargs, RpcMode, ScriptMethod, MethodBuilder, ScriptMethodAttributes, ScriptMethodFn};
+pub use self::method::{
+    Method, MethodBuilder, RpcMode, ScriptMethod, ScriptMethodAttributes, ScriptMethodFn, Varargs,
+};
 pub use self::property::{Export, ExportInfo, PropertyBuilder, Usage as PropertyUsage};
 
 /// A handle that can register new classes to the engine during initialization.
@@ -223,6 +228,7 @@ pub struct ClassBuilder<C> {
 
 impl<C: NativeClass> ClassBuilder<C> {
     #[inline]
+    #[deprecated(note = "Unsafe registration is deprecated. Use `build_method` instead.")]
     pub fn add_method_advanced(&self, method: ScriptMethod) {
         let method_name = CString::new(method.name).unwrap();
 
@@ -256,6 +262,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     }
 
     #[inline]
+    #[deprecated(note = "Unsafe registration is deprecated. Use `build_method` instead.")]
     pub fn add_method_with_rpc_mode(&self, name: &str, method: ScriptMethodFn, rpc_mode: RpcMode) {
         self.add_method_advanced(ScriptMethod {
             name,
@@ -267,12 +274,32 @@ impl<C: NativeClass> ClassBuilder<C> {
     }
 
     #[inline]
+    #[deprecated(note = "Unsafe registration is deprecated. Use `build_method` instead.")]
     pub fn add_method(&self, name: &str, method: ScriptMethodFn) {
         self.add_method_with_rpc_mode(name, method, RpcMode::Disabled);
     }
 
+    /// Returns a `MethodBuilder` which can be used to add a method to the class being
+    /// registered.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```ignore
+    /// // `Bar` is a stateful method implementing `Method<C>`
+    ///
+    /// builder
+    ///     .build_method("foo", Bar { baz: 42 })
+    ///     .with_rpc_mode(RpcMode::RemoteSync)
+    ///     .done();
+    /// ```
     #[inline]
-    pub fn build_method<'a, F: Method<C>>(&'a self, name: &'a str, method: F) -> MethodBuilder<'a, C, F> {
+    pub fn build_method<'a, F: Method<C>>(
+        &'a self,
+        name: &'a str,
+        method: F,
+    ) -> MethodBuilder<'a, C, F> {
         MethodBuilder::new(self, name, method)
     }
 

--- a/gdnative-core/src/nativescript/init/method.rs
+++ b/gdnative-core/src/nativescript/init/method.rs
@@ -1,0 +1,226 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use crate::core_types::{FromVariant, FromVariantError, Variant};
+
+/// Interface to a list of borrowed method arguments with a convenient interface
+/// for common operations with them. Can also be used as an iterator.
+pub struct Varargs<'a> {
+    idx: usize,
+    iter: std::slice::Iter<'a, &'a Variant>,
+}
+
+impl<'a> Varargs<'a> {
+    /// Returns the amount of arguments left.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.iter.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a builder for reading the next argument, that can be used to refine
+    /// the error message on failure.
+    #[inline]
+    pub fn read<T: FromVariant>(&mut self) -> ArgBuilder<'_, 'a, T> {
+        ArgBuilder {
+            args: self,
+            name: None,
+            ty: None,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the remaining arguments as a slice of `Variant`s.
+    #[inline]
+    pub fn as_slice(&self) -> &'a [&'a Variant] {
+        self.iter.as_slice()
+    }
+
+    /// Discard the rest of the arguments, and return an error if there is any.
+    ///
+    /// # Errors
+    ///
+    /// If there are any excess arguments left.
+    #[inline]
+    pub fn done(self) -> Result<(), ArgumentError<'a>> {
+        if self.is_empty() {
+            Ok(())
+        } else {
+            Err(ArgumentError::ExcessArguments {
+                rest: self.as_slice(),
+            })
+        }
+    }
+
+    /// Create a typed interface from raw pointers. This is an internal interface.
+    ///
+    /// # Safety
+    ///
+    /// `args` must point to an array of valid `godot_variant` pointers of at least `num_args` long.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_sys(num_args: libc::c_int, args: *mut *mut sys::godot_variant) -> Self {
+        let args = std::slice::from_raw_parts(args, num_args as usize);
+        let args = std::mem::transmute::<&[*mut sys::godot_variant], &[&Variant]>(args);
+        Self {
+            idx: 0,
+            iter: args.iter(),
+        }
+    }
+}
+
+impl<'a> Iterator for Varargs<'a> {
+    type Item = &'a Variant;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().copied()
+    }
+}
+
+/// Builder for providing additional argument information for error reporting.
+pub struct ArgBuilder<'r, 'a, T> {
+    args: &'r mut Varargs<'a>,
+    name: Option<&'r str>,
+    ty: Option<&'r str>,
+    _marker: PhantomData<T>,
+}
+
+impl<'r, 'a, T> ArgBuilder<'r, 'a, T> {
+    /// Provides a name for this argument. If an old name is already set, it is
+    /// silently replaced.
+    #[inline]
+    pub fn with_name(mut self, name: &'r str) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// Provides a more readable type name for this argument. If an old name is
+    /// already set, it is silently replaced. If no type name is given, a value
+    /// from `std::any::type_name` is used.
+    #[inline]
+    pub fn with_type_name(mut self, ty: &'r str) -> Self {
+        self.ty = Some(ty);
+        self
+    }
+}
+
+impl<'r, 'a, T: FromVariant> ArgBuilder<'r, 'a, T> {
+    /// Get the converted argument value.
+    ///
+    /// # Errors
+    ///
+    /// If the argument is missing, or cannot be converted to the desired type.
+    #[inline]
+    pub fn get(self) -> Result<T, ArgumentError<'r>> {
+        let name = self.name;
+        let idx = self.args.idx;
+
+        self.get_optional()
+            .and_then(|arg| arg.ok_or(ArgumentError::Missing { idx, name }))
+    }
+
+    /// Get the argument as optional.
+    ///
+    /// # Errors
+    ///
+    /// If the argument is present, but cannot be converted to the desired type.
+    #[inline]
+    pub fn get_optional(self) -> Result<Option<T>, ArgumentError<'r>> {
+        let Self { args, name, ty, .. } = self;
+        let idx = args.idx;
+
+        if let Some(arg) = args.iter.next() {
+            args.idx += 1;
+            T::from_variant(arg)
+                .map(Some)
+                .map_err(|err| ArgumentError::CannotConvert {
+                    idx,
+                    name,
+                    value: arg,
+                    ty: ty.unwrap_or_else(|| std::any::type_name::<T>()),
+                    err,
+                })
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ArgumentError<'a> {
+    Missing {
+        idx: usize,
+        name: Option<&'a str>,
+    },
+    CannotConvert {
+        idx: usize,
+        name: Option<&'a str>,
+        ty: &'a str,
+        value: &'a Variant,
+        err: FromVariantError,
+    },
+    ExcessArguments {
+        rest: &'a [&'a Variant],
+    },
+}
+
+impl<'a> std::error::Error for ArgumentError<'a> {}
+
+impl<'a> fmt::Display for ArgumentError<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ArgumentError as E;
+
+        match self {
+            E::Missing {
+                idx,
+                name: Some(name),
+            } => {
+                write!(f, "missing non-optional parameter `{}` (#{})", name, idx)
+            }
+            E::Missing { idx, name: None } => {
+                write!(f, "missing non-optional parameter #{}", idx)
+            }
+            E::CannotConvert {
+                idx,
+                name: Some(name),
+                value,
+                ty,
+                err,
+            } => {
+                write!(f,
+                    "cannot convert argument `{}` (#{}, {:?}) to {}: {} (non-primitive types may impose structural checks)",
+                    name, idx, value, ty, err
+                )
+            }
+            E::CannotConvert {
+                idx,
+                name: None,
+                value,
+                ty,
+                err,
+            } => {
+                write!(f,
+                    "cannot convert argument #{} ({:?}) to {}: {} (non-primitive types may impose structural checks)",
+                    idx, value, ty, err
+                )
+            }
+            E::ExcessArguments { rest } => {
+                if rest.len() > 1 {
+                    write!(
+                        f,
+                        "{} excessive arguments are given: {:?}",
+                        rest.len(),
+                        rest
+                    )
+                } else {
+                    write!(f, "an excessive argument is given: {:?}", rest[0])
+                }
+            }
+        }
+    }
+}

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -121,7 +121,7 @@ macro_rules! godot_wrap_method_inner {
                                 $($pname,)*
                                 $($opt_pname,)*
                             );
-                            <$retty as $crate::core_types::OwnedToVariant>::owned_to_variant(ret)
+                            OwnedToVariant::owned_to_variant(ret)
                         })
                         .unwrap_or_else(|err| {
                             $crate::godot_error!("gdnative-core: method call failed with error: {}", err);

--- a/gdnative-derive/src/extend_bounds.rs
+++ b/gdnative-derive/src/extend_bounds.rs
@@ -1,0 +1,88 @@
+use std::collections::HashSet;
+
+use syn::visit::{self, Visit};
+use syn::{Generics, Ident, Type, TypePath};
+
+// recursively visit all the field types to find what types should be bounded
+pub struct BoundsVisitor<'ast> {
+    all_type_params: HashSet<Ident>,
+    used: HashSet<&'ast TypePath>,
+}
+
+impl<'ast> Visit<'ast> for BoundsVisitor<'ast> {
+    fn visit_type_path(&mut self, type_path: &'ast TypePath) {
+        let path = &type_path.path;
+        if let Some(seg) = path.segments.last() {
+            if seg.ident == "PhantomData" {
+                // things inside PhantomDatas doesn't need to be bounded, so stopping
+                // recursive visit here
+                return;
+            }
+        }
+        if let Some(seg) = path.segments.first() {
+            if self.all_type_params.contains(&seg.ident) {
+                // if the first segment of the type path is a known type variable, then this
+                // is likely an associated type
+                // TODO: what about cases like <Foo<T> as Trait>::A? Maybe too fringe to be
+                // useful? serde_derive can't seem to parse these either. Probably good enough.
+                self.used.insert(type_path);
+            }
+        }
+        visit::visit_path(self, &type_path.path);
+    }
+}
+
+impl<'ast> BoundsVisitor<'ast> {
+    fn new(generics: &Generics) -> Self {
+        let all_type_params = generics
+            .type_params()
+            .map(|param| param.ident.clone())
+            .collect();
+
+        BoundsVisitor {
+            all_type_params,
+            used: HashSet::new(),
+        }
+    }
+}
+
+pub fn with_visitor<'ast, F>(generics: Generics, bound: &syn::Path, op: F) -> Generics
+where
+    F: FnOnce(&mut BoundsVisitor<'ast>),
+{
+    let mut visitor = BoundsVisitor::new(&generics);
+
+    op(&mut visitor);
+
+    // where thing: is_trait
+    fn where_predicate(thing: Type, is_trait: syn::Path) -> syn::WherePredicate {
+        syn::WherePredicate::Type(syn::PredicateType {
+            lifetimes: None,
+            bounded_ty: thing,
+            colon_token: <Token![:]>::default(),
+            bounds: vec![syn::TypeParamBound::Trait(syn::TraitBound {
+                paren_token: None,
+                modifier: syn::TraitBoundModifier::None,
+                lifetimes: None,
+                path: is_trait,
+            })]
+            .into_iter()
+            .collect(),
+        })
+    }
+
+    // place bounds on all used type parameters and associated types
+    let new_predicates = visitor
+        .used
+        .into_iter()
+        .cloned()
+        .map(|bounded_ty| where_predicate(syn::Type::Path(bounded_ty), bound.clone()));
+
+    let mut generics = generics;
+    generics
+        .make_where_clause()
+        .predicates
+        .extend(new_predicates);
+
+    generics
+}

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -131,7 +131,9 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
                         fn #name ( #( #args )* ) -> #ret_ty
                     );
 
-                    #builder.add_method_with_rpc_mode(#name_string, method, #rpc);
+                    #builder.build_method(#name_string, method)
+                        .with_rpc_mode(#rpc)
+                        .done_stateless();
                 }
             )
         })

--- a/gdnative-derive/src/varargs.rs
+++ b/gdnative-derive/src/varargs.rs
@@ -1,0 +1,160 @@
+use proc_macro2::Span;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::ToTokens;
+
+use syn::visit::Visit;
+use syn::Fields;
+use syn::{spanned::Spanned, Data, DeriveInput, Ident};
+
+use crate::extend_bounds::with_visitor;
+
+pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, syn::Error> {
+    if let Data::Struct(struct_data) = input.data {
+        let ident = input.ident;
+
+        let mut generics = with_visitor(
+            input.generics,
+            &syn::parse_quote! { ::gdnative::core_types::FromVariant },
+            |visitor| {
+                visitor.visit_data_struct(&struct_data);
+            },
+        );
+
+        for param in generics.type_params_mut() {
+            param.default = None;
+        }
+
+        let input_ident = Ident::new("__args", Span::call_site());
+        let where_clause = &generics.where_clause;
+
+        let fields = match &struct_data.fields {
+            Fields::Named(fields) => &fields.named,
+            Fields::Unnamed(fields) => &fields.unnamed,
+            Fields::Unit => {
+                return Ok(quote! {
+                    impl #generics ::gdnative::nativescript::init::method::FromVarargs for #ident #generics #where_clause {
+                        fn read<'a>(
+                            #input_ident: &mut ::gdnative::nativescript::init::method::Varargs<'a>,
+                        ) -> Result<Self, Vec<::gdnative::nativescript::init::method::ArgumentError<'a>>> {
+                            Ok(#ident)
+                        }
+                    }
+                })
+            }
+        };
+
+        let mut required = Vec::new();
+        let mut optional = Vec::new();
+        for field in fields.iter() {
+            let is_optional = field.attrs.iter().any(|attr| attr.path.is_ident("opt"));
+            if !is_optional && !optional.is_empty() {
+                return Err(syn::Error::new(
+                    field.ident.span(),
+                    "cannot add required arguments after optional ones",
+                ));
+            }
+            if is_optional {
+                optional.push(field);
+            } else {
+                required.push(field);
+            }
+        }
+
+        let req_var_idents = required
+            .iter()
+            .enumerate()
+            .map(|(n, field)| {
+                field
+                    .ident
+                    .clone()
+                    .unwrap_or_else(|| Ident::new(&format!("__req_arg_{}", n), Span::call_site()))
+            })
+            .collect::<Vec<_>>();
+        let req_var_names = required
+            .iter()
+            .map(|field| {
+                field.ident.as_ref().map(|id| {
+                    let s = id.to_string();
+                    quote!(.with_name(#s))
+                })
+            })
+            .collect::<Vec<_>>();
+        let req_var_tys = required
+            .iter()
+            .map(|field| format!("{}", field.ty.to_token_stream()))
+            .collect::<Vec<_>>();
+
+        let opt_var_idents = optional
+            .iter()
+            .enumerate()
+            .map(|(n, field)| {
+                field
+                    .ident
+                    .clone()
+                    .unwrap_or_else(|| Ident::new(&format!("__opt_arg_{}", n), Span::call_site()))
+            })
+            .collect::<Vec<_>>();
+        let opt_var_names = optional
+            .iter()
+            .map(|field| {
+                field.ident.as_ref().map(|id| {
+                    let s = id.to_string();
+                    quote!(.with_name(#s))
+                })
+            })
+            .collect::<Vec<_>>();
+        let opt_var_tys = optional
+            .iter()
+            .map(|field| format!("{}", field.ty.to_token_stream()))
+            .collect::<Vec<_>>();
+
+        Ok(quote! {
+            #[allow(unused_variables)]
+            impl #generics ::gdnative::nativescript::init::method::FromVarargs for #ident #generics #where_clause {
+                fn read<'a>(
+                    #input_ident: &mut ::gdnative::nativescript::init::method::Varargs<'a>,
+                ) -> Result<Self, Vec<::gdnative::nativescript::init::method::ArgumentError<'a>>> {
+                    let mut __errors = Vec::new();
+
+                    #(
+                        let #req_var_idents = #input_ident.read()
+                            #req_var_names
+                            .with_type_name(stringify!(#req_var_tys))
+                            .get()
+                            .map_err(|err| __errors.push(err))
+                            .ok();
+                    )*
+
+                    #(
+                        let #opt_var_idents = #input_ident.read()
+                            #opt_var_names
+                            .with_type_name(stringify!(#opt_var_tys))
+                            .get_optional()
+                            .map_err(|err| __errors.push(err))
+                            .ok()
+                            .flatten()
+                            .unwrap_or_default();
+                    )*
+
+                    if !__errors.is_empty() {
+                        return Err(__errors);
+                    }
+
+                    #(
+                        let #req_var_idents = #req_var_idents.unwrap();
+                    )*
+
+                    Ok(#ident {
+                        #(#req_var_idents,)*
+                        #(#opt_var_idents,)*
+                    })
+                }
+            }
+        })
+    } else {
+        Err(syn::Error::new(
+            input.span(),
+            "`FromVarargs` can only be derived for structs",
+        ))
+    }
+}

--- a/gdnative-derive/src/variant/bounds.rs
+++ b/gdnative-derive/src/variant/bounds.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
+use syn::visit::Visit;
+use syn::Generics;
 
-use syn::visit::{self, Visit};
-use syn::{Generics, Ident, Type, TypePath};
+use crate::extend_bounds::{with_visitor, BoundsVisitor};
 
 use super::repr::{Field, Repr, VariantRepr};
 use super::Direction;
@@ -12,106 +12,41 @@ pub(crate) fn extend_bounds(
     bound: &syn::Path,
     dir: Direction,
 ) -> Generics {
-    // recursively visit all the field types to find what types should be bounded
-    struct Visitor<'ast> {
-        all_type_params: HashSet<Ident>,
-        used: HashSet<&'ast TypePath>,
-    }
-
-    impl<'ast> Visit<'ast> for Visitor<'ast> {
-        fn visit_type_path(&mut self, type_path: &'ast TypePath) {
-            let path = &type_path.path;
-            if let Some(seg) = path.segments.last() {
-                if seg.ident == "PhantomData" {
-                    // things inside PhantomDatas doesn't need to be bounded, so stopping
-                    // recursive visit here
-                    return;
+    with_visitor(generics, bound, |visitor| {
+        // iterate through parsed variant representations and visit the types of each field
+        fn visit_var_repr<'ast>(
+            visitor: &mut BoundsVisitor<'ast>,
+            repr: &'ast VariantRepr,
+            dir: Direction,
+        ) {
+            match repr {
+                VariantRepr::Unit => {}
+                VariantRepr::Tuple(tys) => {
+                    for Field { ty, attr, .. } in tys.iter() {
+                        if !attr.skip_bounds(dir) {
+                            visitor.visit_type(ty);
+                        }
+                    }
+                }
+                VariantRepr::Struct(fields) => {
+                    for Field { ty, attr, .. } in fields.iter() {
+                        if !attr.skip_bounds(dir) {
+                            visitor.visit_type(ty);
+                        }
+                    }
                 }
             }
-            if let Some(seg) = path.segments.first() {
-                if self.all_type_params.contains(&seg.ident) {
-                    // if the first segment of the type path is a known type variable, then this
-                    // is likely an associated type
-                    // TODO: what about cases like <Foo<T> as Trait>::A? Maybe too fringe to be
-                    // useful? serde_derive can't seem to parse these either. Probably good enough.
-                    self.used.insert(type_path);
-                }
-            }
-            visit::visit_path(self, &type_path.path);
         }
-    }
 
-    let all_type_params = generics
-        .type_params()
-        .map(|param| param.ident.clone())
-        .collect();
-
-    let mut visitor = Visitor {
-        all_type_params,
-        used: HashSet::new(),
-    };
-
-    // iterate through parsed variant representations and visit the types of each field
-    fn visit_var_repr<'ast>(visitor: &mut Visitor<'ast>, repr: &'ast VariantRepr, dir: Direction) {
         match repr {
-            VariantRepr::Unit => {}
-            VariantRepr::Tuple(tys) => {
-                for Field { ty, attr, .. } in tys.iter() {
-                    if !attr.skip_bounds(dir) {
-                        visitor.visit_type(ty);
-                    }
+            Repr::Enum(ref variants) => {
+                for (_, var_repr) in variants.iter() {
+                    visit_var_repr(visitor, var_repr, dir);
                 }
             }
-            VariantRepr::Struct(fields) => {
-                for Field { ty, attr, .. } in fields.iter() {
-                    if !attr.skip_bounds(dir) {
-                        visitor.visit_type(ty);
-                    }
-                }
+            Repr::Struct(var_repr) => {
+                visit_var_repr(visitor, var_repr, dir);
             }
         }
-    }
-
-    match repr {
-        Repr::Enum(ref variants) => {
-            for (_, var_repr) in variants.iter() {
-                visit_var_repr(&mut visitor, var_repr, dir);
-            }
-        }
-        Repr::Struct(var_repr) => {
-            visit_var_repr(&mut visitor, var_repr, dir);
-        }
-    }
-
-    // where thing: is_trait
-    fn where_predicate(thing: Type, is_trait: syn::Path) -> syn::WherePredicate {
-        syn::WherePredicate::Type(syn::PredicateType {
-            lifetimes: None,
-            bounded_ty: thing,
-            colon_token: <Token![:]>::default(),
-            bounds: vec![syn::TypeParamBound::Trait(syn::TraitBound {
-                paren_token: None,
-                modifier: syn::TraitBoundModifier::None,
-                lifetimes: None,
-                path: is_trait,
-            })]
-            .into_iter()
-            .collect(),
-        })
-    }
-
-    // place bounds on all used type parameters and associated types
-    let new_predicates = visitor
-        .used
-        .into_iter()
-        .cloned()
-        .map(|bounded_ty| where_predicate(syn::Type::Path(bounded_ty), bound.clone()));
-
-    let mut generics = generics;
-    generics
-        .make_where_clause()
-        .predicates
-        .extend(new_predicates);
-
-    generics
+    })
 }

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -20,7 +20,7 @@ pub use gdnative_core::NewRef;
 pub use gdnative_core::nativescript::{
     self,
     class::{Instance, RefInstance},
-    init::{ClassBuilder, InitHandle, Signal, SignalArgument},
+    init::{ClassBuilder, InitHandle, Method, MethodBuilder, Signal, SignalArgument},
     user_data::{self, Aether, ArcData, LocalCellData, MutexData, RwLockData},
     ExportInfo, NativeClass, NativeClassMethods, PropertyUsage,
 };

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -27,7 +27,7 @@ pub use gdnative_core::nativescript::{
 
 pub use gdnative_core::{
     godot_dbg, godot_error, godot_gdnative_init, godot_gdnative_terminate, godot_init,
-    godot_nativescript_init, godot_print, godot_warn,
+    godot_nativescript_init, godot_print, godot_site, godot_warn,
 };
 
 pub use gdnative_derive::*;

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -15,3 +15,4 @@ type_tag_fallback = ["gdnative/type_tag_fallback"]
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd_test"] }
 gdnative-derive = { path = "../gdnative-derive" }
+approx = "0.3.2"

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -65,8 +65,8 @@ func _assert_choose(expected, foo, fun, a, which, b):
 func _test_optional_args():
     print(" -- _test_optional_args")
     print("   -- expected error messages for edge cases:")
-    print("     -- Incorrect number of parameters: required 2 but got 1")
-    print("     -- Incorrect number of parameters: expected at most 5 but got 6")
+    print("     -- missing non-optional parameter `b` (#1)")
+    print("     -- 1 excessive argument is given: [I64(6)]")
     print("   -- the test is successful when and only when these errors are shown")
 
     var script = NativeScript.new()

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -1,9 +1,13 @@
+use std::ops::Add;
+
+use gdnative::nativescript::init::method::{StaticArgs, StaticArgsMethod};
 use gdnative::prelude::*;
 
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
 
     status &= test_register_property();
+    status &= test_advanced_methods();
 
     status
 }
@@ -11,6 +15,7 @@ pub(crate) fn run_tests() -> bool {
 pub(crate) fn register(handle: InitHandle) {
     handle.add_class::<RegisterSignal>();
     handle.add_class::<RegisterProperty>();
+    handle.add_class::<AdvancedMethods>();
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -105,6 +110,133 @@ fn test_register_property() -> bool {
 
     if !ok {
         gdnative::godot_error!("   !! Test test_register_property failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+#[register_with(register_methods)]
+struct AdvancedMethods;
+
+#[methods]
+impl AdvancedMethods {
+    fn new(_owner: TRef<Reference>) -> Self {
+        AdvancedMethods
+    }
+}
+
+#[derive(FromVarargs)]
+struct AddArgs<T> {
+    a: T,
+    b: T,
+    #[opt]
+    c: Option<T>,
+}
+
+struct StatefulMixin<T> {
+    d: T,
+}
+
+impl<T, C> StaticArgsMethod<C> for StatefulMixin<T>
+where
+    T: Copy + Add<Output = T> + Send + Sync + ToVariant + FromVariant + 'static,
+    C: NativeClass,
+{
+    type Args = AddArgs<T>;
+    fn call(&self, _this: RefInstance<'_, C, Shared>, args: AddArgs<T>) -> Variant {
+        let AddArgs { a, b, c } = args;
+
+        let mut acc = a;
+        acc = acc + b;
+        if let Some(c) = c {
+            acc = acc + c;
+        }
+        acc = acc + self.d;
+
+        acc.to_variant()
+    }
+}
+
+fn register_methods(builder: &ClassBuilder<AdvancedMethods>) {
+    builder
+        .build_method("add_ints", StaticArgs::new(StatefulMixin { d: 42 }))
+        .done();
+
+    builder
+        .build_method("add_floats", StaticArgs::new(StatefulMixin { d: 4.0 }))
+        .done();
+
+    builder
+        .build_method(
+            "add_vectors",
+            StaticArgs::new(StatefulMixin {
+                d: Vector2::new(1.0, 2.0),
+            }),
+        )
+        .done();
+}
+
+fn test_advanced_methods() -> bool {
+    println!(" -- test_advanced_methods");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<AdvancedMethods, _>::new();
+        let thing = thing.base();
+
+        assert_eq!(
+            45,
+            i32::from_variant(unsafe {
+                &thing.call(
+                    "add_ints",
+                    &[1.to_variant(), 2.to_variant(), Variant::new()],
+                )
+            })
+            .unwrap()
+        );
+
+        assert_eq!(
+            48,
+            i32::from_variant(unsafe {
+                &thing.call(
+                    "add_ints",
+                    &[1.to_variant(), 2.to_variant(), 3.to_variant()],
+                )
+            })
+            .unwrap()
+        );
+
+        approx::assert_relative_eq!(
+            6.5,
+            f32::from_variant(unsafe {
+                &thing.call(
+                    "add_floats",
+                    &[(5.0).to_variant(), (-2.5).to_variant(), Variant::new()],
+                )
+            })
+            .unwrap()
+        );
+
+        let v = Vector2::from_variant(unsafe {
+            &thing.call(
+                "add_vectors",
+                &[
+                    Vector2::new(5.0, -5.0).to_variant(),
+                    Vector2::new(-2.5, 2.5).to_variant(),
+                    Variant::new(),
+                ],
+            )
+        })
+        .unwrap();
+
+        approx::assert_relative_eq!(3.5, v.x);
+        approx::assert_relative_eq!(-0.5, v.y);
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_advanced_methods failed");
     }
 
     ok


### PR DESCRIPTION
Due to repeated past additions to `godot_wrap_method_inner`, the implementation has become a total mess of unsafe macro code that is very hard to follow. Meanwhile, the manual interface for method registration has largely been neglected, lagging behind the rest of the crate, exposing `sys` types and unsafe FFI signatures. Recently, I've found myself in need to register a few methods manually and having to deal with this entire situation, so I've taken the chance to make some improvements to this part of the codebase, with all the hindsight that we now have. This has resulted in satisfactory results:

- All the unsafe FFI code previously in `godot_wrap_method_inner` is extracted to the library proper, and can no longer be touched by obscure import/inference problems that come from delayed type checking.
- Argument errors are now represented with a proper error type with a `Display` implementation. The library can report multiple argument errors at once. "Missing/excessive argument" errors are also more informative.
- It's possible to manually register one method for many classes that it may apply to, or many specializations of a generic method to one class by different names.
- Safe, straightforward support for stateful methods.

This is not in itself a breaking change, but it's expected that the older unsafe interface will be removed at the next possibility.

- - -

As a curiosity, the syntax for manually registering generic methods currently looks like this, and I find it already fairly usable even without further macro goodness:

```rust
#[derive(Copy, Clone, Default)]
struct Mixin<T> {
    _marker: PhantomData<T>,
}

#[derive(FromVarargs)]
struct Args<T> {
    a: T,
    b: T,
}

impl<T, C> StaticArgsMethod<C> for Mixin<T>
where
    T: Add<Output = T> + Send + Sync + ToVariant + FromVariant + 'static,
    C: NativeClass,
{
    type Args = Args<T>;
    fn call(&self, _this: RefInstance<'_, C, Shared>, Args { a, b }: Args<T>) -> Variant {
        (a + b).to_variant()
    }
}

fn register_methods(builder: &ClassBuilder<SomeClass>) {
    builder
        .build_method("add_i", StaticArgs::<Mixin::<i32>>::default())
        .done_stateless();
    builder
        .build_method("add_f", StaticArgs::<Mixin::<f32>>::default())
        .done_stateless();
    builder
        .build_method("add_v", StaticArgs::<Mixin::<Vector2>>::default())
        .done_stateless();
}
```

## Unresolved questions

~~As a side effect of moving the error handling to the library side, error sites all point to the library now. This should be fixable with something on the macro side that provides borrow-able site information, like how `profiling::Signature` is handled? This would mean moving the FFI call out of `godot_error` into some interface as well.~~ Resolved.

## Future development

If desired, it should be fairly easy to add a higher-level, derivable `Mixin` interface based on this. It should also be possible to add support for generic methods directly in `#[export]`.