### PR TITLE
Construct Godot API objects from class names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,13 +227,25 @@ jobs:
           cd test;
           mkdir -p ./project/lib;
           cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests;
+          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
+          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+            exit 1;
+          fi;
+          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
+          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+            exit 1;
+          fi;
           cargo build --features=type_tag_fallback;
           mkdir -p ./project/lib;
           cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests;
+          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
+          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+            exit 1;
+          fi;
+          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
+          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+            exit 1;
+          fi;
           
   # This job doesn't actually test anything, but they're used to tell bors the
   # build completed, as there is no practical way to detect when a workflow is

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -150,7 +150,7 @@ unsafe impl crate::object::GodotObject for ManuallyManagedClassPlaceholder {
     type RefKind = crate::ref_kind::ManuallyManaged;
 
     fn class_name() -> &'static str {
-        "{placeholder} manually managed object"
+        "Object"
     }
 }
 
@@ -162,7 +162,7 @@ unsafe impl crate::object::GodotObject for ReferenceCountedClassPlaceholder {
     type RefKind = crate::ref_kind::RefCounted;
 
     fn class_name() -> &'static str {
-        "{placeholder} reference counted object"
+        "Reference"
     }
 }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::blacklisted_name)]
 
-use gdnative::api;
 use gdnative::prelude::*;
 
+mod test_constructor;
 mod test_derive;
 mod test_free_ub;
 mod test_register;
@@ -54,13 +54,13 @@ pub extern "C" fn run_tests(
     status &= gdnative::core_types::test_vector3_array_access();
     status &= gdnative::core_types::test_vector3_array_debug();
 
-    status &= test_constructor();
     status &= test_underscore_method_binding();
     status &= test_rust_class_construction();
     status &= test_from_instance_id();
 
     status &= test_derive::run_tests();
     status &= test_free_ub::run_tests();
+    status &= test_constructor::run_tests();
     status &= test_register::run_tests();
     status &= test_return_leak::run_tests();
     status &= test_variant_call_args::run_tests();
@@ -68,21 +68,6 @@ pub extern "C" fn run_tests(
     status &= test_vararray_return::run_tests();
 
     gdnative::core_types::Variant::from_bool(status).forget()
-}
-
-fn test_constructor() -> bool {
-    println!(" -- test_constructor");
-
-    // Just create an object and call a method as a sanity check for the
-    // generated constructors.
-    let lib = api::GDNativeLibrary::new();
-    let _ = lib.is_singleton();
-
-    let path = api::Path2D::new();
-    let _ = path.z_index();
-    path.free();
-
-    true
 }
 
 fn test_underscore_method_binding() -> bool {
@@ -269,6 +254,7 @@ fn init(handle: InitHandle) {
 
     test_derive::register(handle);
     test_free_ub::register(handle);
+    test_constructor::register(handle);
     test_register::register(handle);
     test_return_leak::register(handle);
     test_variant_call_args::register(handle);

--- a/test/src/test_constructor.rs
+++ b/test/src/test_constructor.rs
@@ -1,0 +1,69 @@
+use gdnative::api;
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    let mut status = true;
+
+    status &= test_constructor();
+    status &= test_from_class_name();
+
+    status
+}
+
+pub(crate) fn register(_handle: InitHandle) {}
+
+fn test_constructor() -> bool {
+    println!(" -- test_constructor");
+
+    // Just create an object and call a method as a sanity check for the
+    // generated constructors.
+    let lib = api::GDNativeLibrary::new();
+    let _ = lib.is_singleton();
+
+    let path = api::Path2D::new();
+    let _ = path.z_index();
+    path.free();
+
+    true
+}
+
+fn test_from_class_name() -> bool {
+    println!(" -- test_from_class_name");
+
+    let ok = std::panic::catch_unwind(|| {
+        // Since this method is restricted to Godot types, there is no way we can detect
+        // here whether any invalid objects are leaked. Instead, the CI script is modified
+        // to look at stdout for any reported leaks.
+
+        let node = Ref::<Node, _>::by_class_name("Node2D").unwrap();
+        assert_eq!("Node2D", node.get_class().to_string());
+        let node = node.cast::<Node2D>().unwrap();
+        assert_eq!("Node2D", node.get_class().to_string());
+        let _ = node.position();
+        node.free();
+
+        let shader = Ref::<Reference, _>::by_class_name("Shader").unwrap();
+        assert_eq!("Shader", &shader.get_class().to_string());
+        let shader = shader.cast::<Shader>().unwrap();
+        assert_eq!("Shader", &shader.get_class().to_string());
+
+        let none = Ref::<Object, _>::by_class_name("Shader");
+        assert!(none.is_none());
+
+        let none = Ref::<Node2D, _>::by_class_name("Spatial");
+        assert!(none.is_none());
+
+        let none = Ref::<Shader, _>::by_class_name("AudioEffectReverb");
+        assert!(none.is_none());
+
+        let none = Ref::<Object, _>::by_class_name("ClassThatDoesNotExistProbably");
+        assert!(none.is_none());
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_from_class_name failed");
+    }
+
+    ok
+}


### PR DESCRIPTION
This adds the `Ref::<T>::by_class_name` constructor that instantiates a sub-class of `T` by its name. If the resulting object cannot be casted to `T`, it is correctly freed depending on whether it is a `Reference`, and `None` is returned. As with `Ref::cast`, there is the caveat that reference-counted classes cannot be casted to `Object`s, since memory management is determined statically.