### PR TITLE
Fix bounds in RefKindSpec trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,17 @@ jobs:
         if: ${{ matrix.is_windows }}
         run: cargo build --target x86_64-pc-windows-msvc --release;
 
+  rustc-1-46:
+    needs: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
+        with:
+          toolchain: 1.46.0
+      - name: Checking on 1.46.0
+        run: cargo +1.46.0 check --all --all-features;
+
   test_ios:
     continue-on-error: ${{ matrix.experimental }}
     needs: rustfmt
@@ -260,6 +271,7 @@ jobs:
       - clippy
       - rustfmt
       - test
+      - rustc-1-46
       - test_ios
       - test_android
       - godot_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2020-02-02
+
+### Fixed
+
+- **The code now compiles on rustc versions not affected by https://github.com/rust-lang/rust/issues/79904**
+
 ## [0.9.2] - 2020-02-01
 
 ### Added

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -1156,7 +1156,9 @@ pub trait RefKindSpec: Sized {
     #[doc(hidden)]
     unsafe fn impl_from_maybe_ref_counted<T: GodotObject<RefKind = Self>>(
         ptr: NonNull<sys::godot_object>,
-    ) -> Option<Ref<T, Unique>>;
+    ) -> Option<Ref<T, Unique>>
+    where
+        Self: RefKind;
 
     #[doc(hidden)]
     unsafe fn impl_assume_safe<'a, T: GodotObject<RefKind = Self>>(


### PR DESCRIPTION
A [rustc regression](https://github.com/rust-lang/rust/issues/79904) in the latest stable version as of writing (1.49.0) caused this to sneak past CI. This should let the library compile again. A test using rustc 1.46.0 is added, but this is not a commitment of minimum compiler version.