### PR TITLE
Add the MapOwned trait and the `Once<T>` userdata type

### DIFF
--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -28,3 +28,4 @@ gdnative-impl-proc-macros = { path = "../impl/proc_macros", version = "=0.9.3" }
 
 bitflags = { version = "1.2", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
+atomic-take = "1.0.0"

--- a/gdnative-core/src/nativescript/class.rs
+++ b/gdnative-core/src/nativescript/class.rs
@@ -4,9 +4,7 @@ use crate::core_types::{
     FromVariant, FromVariantError, GodotString, OwnedToVariant, ToVariant, Variant,
 };
 use crate::nativescript::init::ClassBuilder;
-use crate::nativescript::Map;
-use crate::nativescript::MapMut;
-use crate::nativescript::UserData;
+use crate::nativescript::{Map, MapMut, MapOwned, UserData};
 use crate::object::{
     AssumeSafeLifetime, LifetimeConstraint, QueueFree, RawObject, Ref, RefImplBound, SafeAsRaw,
     SafeDeref, TRef,
@@ -441,6 +439,18 @@ where
         self.script
             .map_mut(|script| op(script, self.owner.as_ref()))
     }
+
+    /// Calls a function with a NativeClass instance and its owner, and returns its return
+    /// value. Can be used on reference counted types for multiple times.
+    #[inline]
+    pub fn map_owned<F, U>(&self, op: F) -> Result<U, <T::UserData as MapOwned>::Err>
+    where
+        T::UserData: MapOwned,
+        F: FnOnce(T, TRef<'_, T::Base, Access>) -> U,
+    {
+        self.script
+            .map_owned(|script| op(script, self.owner.as_ref()))
+    }
 }
 
 /// Methods for instances with manually-managed base classes.
@@ -647,6 +657,17 @@ where
         F: FnOnce(&mut T, TRef<'_, T::Base, Access>) -> U,
     {
         self.script.map_mut(|script| op(script, self.owner))
+    }
+
+    /// Calls a function with a NativeClass instance and its owner, and returns its return
+    /// value.
+    #[inline]
+    pub fn map_owned<F, U>(&self, op: F) -> Result<U, <T::UserData as MapOwned>::Err>
+    where
+        T::UserData: MapOwned,
+        F: FnOnce(T, TRef<'_, T::Base, Access>) -> U,
+    {
+        self.script.map_owned(|script| op(script, self.owner))
     }
 }
 

--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -188,6 +188,50 @@ macro_rules! godot_wrap_method {
             ) -> $retty
         )
     };
+    // owned
+    (
+        $type_name:ty,
+        fn $method_name:ident(
+            mut $self:ident,
+            $owner:ident : $owner_ty:ty
+            $(,$pname:ident : $pty:ty)*
+            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            $(,)?
+        ) -> $retty:ty
+    ) => {
+        $crate::godot_wrap_method_inner!(
+            $type_name,
+            map_owned,
+            fn $method_name(
+                $self,
+                $owner: $owner_ty
+                $(,$pname : $pty)*
+                $(,#[opt] $opt_pname : $opt_pty)*
+            ) -> $retty
+        )
+    };
+    // owned
+    (
+        $type_name:ty,
+        fn $method_name:ident(
+            $self:ident,
+            $owner:ident : $owner_ty:ty
+            $(,$pname:ident : $pty:ty)*
+            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            $(,)?
+        ) -> $retty:ty
+    ) => {
+        $crate::godot_wrap_method_inner!(
+            $type_name,
+            map_owned,
+            fn $method_name(
+                $self,
+                $owner: $owner_ty
+                $(,$pname : $pty)*
+                $(,#[opt] $opt_pname : $opt_pty)*
+            ) -> $retty
+        )
+    };
     // mutable without return type
     (
         $type_name:ty,
@@ -224,6 +268,48 @@ macro_rules! godot_wrap_method {
             $type_name,
             fn $method_name(
                 & $self,
+                $owner: $owner_ty
+                $(,$pname : $pty)*
+                $(,#[opt] $opt_pname : $opt_pty)*
+            ) -> ()
+        )
+    };
+    // owned without return type
+    (
+        $type_name:ty,
+        fn $method_name:ident(
+            mut $self:ident,
+            $owner:ident : $owner_ty:ty
+            $(,$pname:ident : $pty:ty)*
+            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            $(,)?
+        )
+    ) => {
+        $crate::godot_wrap_method!(
+            $type_name,
+            fn $method_name(
+                $self,
+                $owner: $owner_ty
+                $(,$pname : $pty)*
+                $(,#[opt] $opt_pname : $opt_pty)*
+            ) -> ()
+        )
+    };
+    // owned without return type
+    (
+        $type_name:ty,
+        fn $method_name:ident(
+            $self:ident,
+            $owner:ident : $owner_ty:ty
+            $(,$pname:ident : $pty:ty)*
+            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            $(,)?
+        )
+    ) => {
+        $crate::godot_wrap_method!(
+            $type_name,
+            fn $method_name(
+                $self,
                 $owner: $owner_ty
                 $(,$pname : $pty)*
                 $(,#[opt] $opt_pname : $opt_pty)*

--- a/gdnative-core/src/nativescript/mod.rs
+++ b/gdnative-core/src/nativescript/mod.rs
@@ -11,4 +11,4 @@ pub mod user_data;
 
 pub use class::*;
 pub use init::*;
-pub use user_data::{Map, MapMut, UserData};
+pub use user_data::{Map, MapMut, MapOwned, UserData};

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -5,6 +5,7 @@ use gdnative::prelude::*;
 mod test_constructor;
 mod test_derive;
 mod test_free_ub;
+mod test_map_owned;
 mod test_register;
 mod test_return_leak;
 mod test_vararray_return;
@@ -61,6 +62,7 @@ pub extern "C" fn run_tests(
     status &= test_derive::run_tests();
     status &= test_free_ub::run_tests();
     status &= test_constructor::run_tests();
+    status &= test_map_owned::run_tests();
     status &= test_register::run_tests();
     status &= test_return_leak::run_tests();
     status &= test_variant_call_args::run_tests();
@@ -255,6 +257,7 @@ fn init(handle: InitHandle) {
     test_derive::register(handle);
     test_free_ub::register(handle);
     test_constructor::register(handle);
+    test_map_owned::register(handle);
     test_register::register(handle);
     test_return_leak::register(handle);
     test_variant_call_args::register(handle);

--- a/test/src/test_map_owned.rs
+++ b/test/src/test_map_owned.rs
@@ -1,0 +1,69 @@
+use gdnative::nativescript::user_data::Once;
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    let mut status = true;
+
+    status &= test_map_owned();
+
+    status
+}
+
+pub(crate) fn register(handle: InitHandle) {
+    handle.add_class::<VecBuilder>();
+}
+
+#[derive(NativeClass)]
+#[no_constructor]
+#[inherit(Reference)]
+#[user_data(Once<Self>)]
+struct VecBuilder {
+    v: Vec<i32>,
+}
+
+#[methods]
+impl VecBuilder {
+    #[export]
+    fn append(mut self, _owner: TRef<Reference>, mut numbers: Vec<i32>) -> Instance<Self, Shared> {
+        self.v.append(&mut numbers);
+        Instance::emplace(Self { v: self.v }).into_shared()
+    }
+}
+
+fn test_map_owned() -> bool {
+    println!(" -- test_map_owned");
+
+    let ok = std::panic::catch_unwind(|| {
+        let v1 = Instance::emplace(VecBuilder { v: Vec::new() }).into_shared();
+        let v1 = unsafe { v1.assume_safe() };
+
+        let v2 = v1
+            .map_owned(|s, owner| s.append(owner, vec![1, 2, 3]))
+            .unwrap();
+        let v2 = unsafe { v2.assume_safe() };
+        assert!(v1
+            .map_owned(|_, _| panic!("should never be called"))
+            .is_err());
+
+        let v3 = v2
+            .map_owned(|s, owner| s.append(owner, vec![4, 5, 6]))
+            .unwrap();
+        let v3 = unsafe { v3.assume_safe() };
+        assert!(v2
+            .map_owned(|_, _| panic!("should never be called"))
+            .is_err());
+
+        let v = v3.map_owned(|s, _| s.v).unwrap();
+        assert_eq!(&v, &[1, 2, 3, 4, 5, 6]);
+        assert!(v3
+            .map_owned(|_, _| panic!("should never be called"))
+            .is_err());
+    })
+    .is_ok();
+
+    if !ok {
+        gdnative::godot_error!("   !! Test test_map_owned failed");
+    }
+
+    ok
+}


### PR DESCRIPTION
This adds support for exporting methods that take ownership of `self`. `Once<T>` is a userdata wrapper that uses atomic compare-exchange to allow taking ownership safely once.