### PR TITLE
Actually actually set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/gdnative"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/gdnative-bindings"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/gdnative-core"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/gdnative-derive"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/gdnative-sys"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/bindings_generator"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/impl/proc-macros"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/test"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot encountered the following error:

This project is part of a Rust workspace but is not the workspace
root. Please update your settings so Dependabot points at the workspace
root instead of /gdnative-derive

bors r+