### PR TITLE
Add into_inner method to ArcData

### DIFF
--- a/gdnative-core/src/nativescript/user_data.rs
+++ b/gdnative-core/src/nativescript/user_data.rs
@@ -440,6 +440,21 @@ impl<T, OPT> Clone for RwLockData<T, OPT> {
 #[derive(Debug)]
 pub struct ArcData<T>(Arc<T>);
 
+impl<T> ArcData<T> {
+    /// Returns the internal `Arc<T>`. Useful for API's that require an `Arc`
+    /// directly, or for coercing it into a trait object.
+    ///
+    /// Note that this removes
+    /// the restriction of only being able to access the `NativeClass` instance
+    /// temporarily through the `Map` trait; however, it should be exactly as safe
+    /// as permanently storing an owned `ArcData` and then calling `.map()` on
+    /// it later.
+    #[inline]
+    pub fn into_inner(self) -> Arc<T> {
+        self.0
+    }
+}
+
 unsafe impl<T> UserData for ArcData<T>
 where
     T: NativeClass + Send + Sync,


### PR DESCRIPTION
As discussed in Discord, this method is especially useful for coercing the `script` of an `Instance` into a trait object, thus being able to benefit from more Rust conveniences within Godot scripts.

This *could* be written as an `impl<T> Into<Arc<T>> for ArcData<T>`, but I feel like this makes it more clear that it's not expected for the user to be able to freely treat `ArcData` as an `Arc` whenever they want to, but rather must be explicit about accessing the internals of this type -- even if it should theoretically be as memory-safe as using the `ArcData` anyway.

I decided to have this method take ownership of `self` because if you have  reference to an `ArcData`, you should still be able to call `clone()` on it to get an owned copy, but the opposite would not be as easy if the user didn't want to increment the ref count.