### PR TITLE
Add automatically_derived and allow lints in macros

### DIFF
--- a/gdnative-core/src/nativescript/macros.rs
+++ b/gdnative-core/src/nativescript/macros.rs
@@ -101,6 +101,7 @@ macro_rules! godot_wrap_method_inner {
             use ::gdnative::FromVarargs;
 
             #[derive(FromVarargs)]
+            #[allow(clippy::used_underscore_binding)]
             struct Args {
                 $($pname: $pty,)*
                 $(#[opt] $opt_pname: $opt_pty,)*

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -238,3 +238,18 @@ pub fn derive_from_varargs(input: TokenStream) -> TokenStream {
         Err(err) => err.to_compile_error().into(),
     }
 }
+
+/// Returns a standard header for derived implementations.
+///
+/// Adds the `automatically_derived` attribute and prevents common lints from triggering
+/// in user code. See:
+///
+/// - https://doc.rust-lang.org/reference/attributes/derive.html
+/// - https://doc.rust-lang.org/rustc/lints/groups.html
+/// - https://github.com/rust-lang/rust-clippy#clippy
+fn automatically_derived() -> proc_macro2::TokenStream {
+    quote! {
+        #[automatically_derived]
+        #[allow(nonstandard_style, unused, clippy::style, clippy::complexity, clippy::perf, clippy::pedantic)]
+    }
+}

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -68,6 +68,7 @@ pub(crate) struct ExportArgs {
 }
 
 pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
+    let derived = crate::automatically_derived();
     let (impl_block, export) = impl_gdnative_expose(item_impl);
 
     let class_name = export.class_ty;
@@ -140,9 +141,9 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
         .collect::<Vec<_>>();
 
     quote::quote!(
-
         #impl_block
 
+        #derived
         impl gdnative::nativescript::NativeClassMethods for #class_name {
             fn register(#builder: &::gdnative::nativescript::init::ClassBuilder<Self>) {
                 use gdnative::nativescript::init::*;

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -18,9 +18,11 @@ pub(crate) struct DeriveData {
 }
 
 pub(crate) fn impl_empty_nativeclass(derive_input: &DeriveInput) -> TokenStream2 {
+    let derived = crate::automatically_derived();
     let name = &derive_input.ident;
 
     quote! {
+        #derived
         impl ::gdnative::prelude::NativeClass for #name {
             type Base = ::gdnative::api::Object;
             type UserData = ::gdnative::prelude::LocalCellData<Self>;
@@ -36,6 +38,7 @@ pub(crate) fn impl_empty_nativeclass(derive_input: &DeriveInput) -> TokenStream2
 }
 
 pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStream, syn::Error> {
+    let derived = crate::automatically_derived();
     let data = parse_derive_input(&derive_input)?;
 
     // generate NativeClass impl
@@ -117,6 +120,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
         };
 
         quote!(
+            #derived
             impl ::gdnative::nativescript::NativeClass for #name {
                 type Base = #base;
                 type UserData = #user_data;

--- a/gdnative-derive/src/varargs.rs
+++ b/gdnative-derive/src/varargs.rs
@@ -9,6 +9,8 @@ use syn::{spanned::Spanned, Data, DeriveInput, Ident};
 use crate::extend_bounds::with_visitor;
 
 pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, syn::Error> {
+    let derived = crate::automatically_derived();
+
     if let Data::Struct(struct_data) = input.data {
         let ident = input.ident;
 
@@ -32,6 +34,7 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
             Fields::Unnamed(fields) => &fields.unnamed,
             Fields::Unit => {
                 return Ok(quote! {
+                    #derived
                     impl #generics ::gdnative::nativescript::init::method::FromVarargs for #ident #generics #where_clause {
                         fn read<'a>(
                             #input_ident: &mut ::gdnative::nativescript::init::method::Varargs<'a>,
@@ -109,7 +112,7 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
             .collect::<Vec<_>>();
 
         Ok(quote! {
-            #[allow(unused_variables)]
+            #derived
             impl #generics ::gdnative::nativescript::init::method::FromVarargs for #ident #generics #where_clause {
                 fn read<'a>(
                     #input_ident: &mut ::gdnative::nativescript::init::method::Varargs<'a>,

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -12,6 +12,8 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
         mut generics,
     } = derive_data;
 
+    let derived = crate::automatically_derived();
+
     for param in generics.type_params_mut() {
         param.default = None;
     }
@@ -106,7 +108,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
     let where_clause = &generics.where_clause;
 
     let result = quote! {
-        #[allow(unused_variables)]
+        #derived
         impl #generics ::gdnative::core_types::FromVariant for #ident #generics #where_clause {
             fn from_variant(
                 #input_ident: &::gdnative::core_types::Variant

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -16,6 +16,7 @@ pub(crate) fn expand_to_variant(
     let trait_path = trait_kind.trait_path();
     let to_variant_fn = trait_kind.to_variant_fn();
     let to_variant_receiver = trait_kind.to_variant_receiver();
+    let derived = crate::automatically_derived();
 
     for param in generics.type_params_mut() {
         param.default = None;
@@ -71,7 +72,7 @@ pub(crate) fn expand_to_variant(
     let where_clause = &generics.where_clause;
 
     let result = quote! {
-        #[allow(unused_variables)]
+        #derived
         impl #generics #trait_path for #ident #generics #where_clause {
             fn #to_variant_fn(#to_variant_receiver) -> ::gdnative::core_types::Variant {
                 use #trait_path;


### PR DESCRIPTION
This should prevent clippy lints from showing up in user code in the future. See:

- https://doc.rust-lang.org/reference/attributes/derive.html
- https://doc.rust-lang.org/rustc/lints/groups.html
- https://github.com/rust-lang/rust-clippy#clippy