### PR TITLE
#[inherit] defaults to Reference if unspecified

### DIFF
--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -83,9 +83,10 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Makes it possible to use a type as a NativeScript.
 ///
-/// ## Required attributes
+/// ## Type attributes
 ///
-/// The following attributes are required on the type deriving `NativeClass`:
+/// The behavior of the derive macro can be customized using attributes on the type
+/// deriving `NativeClass`. All type attributes are optional.
 ///
 /// ### `#[inherit(gdnative::api::BaseClass)]`
 ///
@@ -97,9 +98,10 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 /// Inheritance from other scripts, either in Rust or other languages, is
 /// not supported.
 ///
-/// ## Optional type attributes
+/// If no `#[inherit(...)]` is provided, [`gdnative::api::Reference`](../gdnative/api/struct.Reference.html)
+/// is used as a base class. This behavior is consistent with GDScript: omitting the
+/// `extends` keyword will inherit `Reference`.
 ///
-/// Behavior of the derive macro can be customized using attribute on the type:
 ///
 /// ### `#[user_data(gdnative::user_data::SomeWrapper<Self>)]`
 ///
@@ -134,7 +136,10 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// See documentation on `Instance::emplace` for an example on how this can be used.
 ///
-/// ## Optional field attributes
+///
+/// ## Field attributes
+///
+/// All field attributes are optional.
 ///
 /// ### `#[property]`
 ///

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -144,14 +144,14 @@ fn parse_derive_input(input: &DeriveInput) -> Result<DeriveData, syn::Error> {
 
     let ident = input.ident.clone();
 
-    let inherit_attr = input
-        .attrs
-        .iter()
-        .find(|a| a.path.is_ident("inherit"))
-        .ok_or_else(|| syn::Error::new(span, "No \"inherit\" attribute found"))?;
+    let inherit_attr = input.attrs.iter().find(|a| a.path.is_ident("inherit"));
 
     // read base class
-    let base = inherit_attr.parse_args::<Type>()?;
+    let base = if let Some(attr) = inherit_attr {
+        attr.parse_args::<Type>()?
+    } else {
+        syn::parse2::<Type>(quote! { ::gdnative::api::Reference }).unwrap()
+    };
 
     let register_callback = input
         .attrs

--- a/gdnative/tests/ui.rs
+++ b/gdnative/tests/ui.rs
@@ -5,8 +5,8 @@ fn ui_tests() {
     // NativeClass
     t.pass("tests/ui/derive_pass.rs");
     t.pass("tests/ui/derive_property_basic.rs");
+    t.pass("tests/ui/derive_no_inherit.rs");
     t.compile_fail("tests/ui/derive_fail_property_hint.rs");
-    t.compile_fail("tests/ui/derive_fail_inherit.rs");
     t.compile_fail("tests/ui/derive_fail_inherit_param.rs");
     t.compile_fail("tests/ui/derive_fail_methods.rs");
     t.compile_fail("tests/ui/derive_fail_methods_param.rs");

--- a/gdnative/tests/ui/derive_fail_inherit.stderr
+++ b/gdnative/tests/ui/derive_fail_inherit.stderr
@@ -1,7 +1,0 @@
-error: No "inherit" attribute found
- --> $DIR/derive_fail_inherit.rs:3:10
-  |
-3 | #[derive(NativeClass)]
-  |          ^^^^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gdnative/tests/ui/derive_no_inherit.rs
+++ b/gdnative/tests/ui/derive_no_inherit.rs
@@ -5,7 +5,7 @@ struct Foo {}
 
 #[methods]
 impl Foo {
-    fn new(_owner: &Node) -> Self {
+    fn new(_owner: &Reference) -> Self {
         Foo {}
     }
 }


### PR DESCRIPTION
Allows to omit the `#[inherit]` attribute in the `NativeClass` derive. In that case, `Reference` is chosen as a base class.

This behavior is consistent with omitting the `extends` keyword in GDScript.