### PR TITLE
Method converting Variants to primitives by type

### DIFF
--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -2,8 +2,8 @@ pub use gdnative_core::core_types::{
     self, error::GodotError, Aabb, Angle, Basis, ByteArray, Color, ColorArray, Dictionary,
     Float32Array, GodotString, Int32Array, NodePath, Plane, Point2, Point3, Quat, Rect2, Rid,
     Rotation2D, Rotation3D, Size2, StringArray, StringName, Transform, Transform2D, TypedArray,
-    Variant, VariantArray, VariantOperator, VariantType, Vector2, Vector2Array, Vector3,
-    Vector3Array,
+    Variant, VariantArray, VariantDispatch, VariantOperator, VariantType, Vector2, Vector2Array,
+    Vector3, Vector3Array,
 };
 pub use gdnative_core::core_types::{
     FromVariant, FromVariantError, OwnedToVariant, ToVariant, ToVariantEq, Vector2Godot,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -39,6 +39,7 @@ pub extern "C" fn run_tests(
     status &= gdnative::core_types::test_variant_result();
     status &= gdnative::core_types::test_to_variant_iter();
     status &= gdnative::core_types::test_variant_tuple();
+    status &= gdnative::core_types::test_variant_dispatch();
 
     status &= gdnative::core_types::test_byte_array_access();
     status &= gdnative::core_types::test_byte_array_debug();


### PR DESCRIPTION
Adds `Variant::dispatch`, a method that converts the variant to a primitive value depending on its type, and returns that result as a Rust enum the user can then conveniently `match` on.