### PR TITLE
Minimal async-await foundations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "gdnative",
+    "gdnative-async",
     "gdnative-bindings",
     "gdnative-core",
     "gdnative-derive",

--- a/gdnative-async/Cargo.toml
+++ b/gdnative-async/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gdnative-async"
+authors = ["The godot-rust developers"]
+description = "Runtime async support for godot-rust."
+documentation = "https://docs.rs/crate/gdnative-async"
+repository = "https://github.com/godot-rust/godot-rust"
+homepage = "https://godot-rust.github.io/"
+version = "0.9.3"
+license = "MIT"
+workspace = ".."
+edition = "2018"
+
+[features]
+
+[dependencies]
+gdnative-derive = { path = "../gdnative-derive", version = "=0.9.3" }
+gdnative-core = { path = "../gdnative-core", version = "=0.9.3" }
+gdnative-bindings = { path = "../gdnative-bindings", version = "=0.9.3" }
+futures-task = "0.3.13"
+once_cell = "1.7.2"
+thiserror = "1.0"
+parking_lot = "0.11.0"
+crossbeam-channel = "0.5.0"
+
+[build-dependencies]

--- a/gdnative-async/src/executor.rs
+++ b/gdnative-async/src/executor.rs
@@ -1,0 +1,45 @@
+use futures_task::LocalSpawn;
+use once_cell::unsync::OnceCell as UnsyncCell;
+use thiserror::Error;
+
+thread_local!(
+    static LOCAL_SPAWN: UnsyncCell<&'static dyn LocalSpawn> = UnsyncCell::new();
+);
+
+/// Error returned by `set_*_executor` if an executor of the kind has already been set.
+#[derive(Error, Debug)]
+#[error("an executor is already set")]
+pub struct SetExecutorError {
+    _private: (),
+}
+
+impl SetExecutorError {
+    fn new() -> Self {
+        SetExecutorError { _private: () }
+    }
+}
+
+pub(crate) fn local_spawn() -> Option<&'static dyn LocalSpawn> {
+    LOCAL_SPAWN.with(|cell| cell.get().copied())
+}
+
+/// Sets the global executor for the current thread to a `Box<dyn LocalSpawn>`. This value is leaked.
+pub fn set_boxed_executor(sp: Box<dyn LocalSpawn>) -> Result<(), SetExecutorError> {
+    set_executor(Box::leak(sp))
+}
+
+/// Sets the global executor for the current thread to a `&'static dyn LocalSpawn`.
+pub fn set_executor(sp: &'static dyn LocalSpawn) -> Result<(), SetExecutorError> {
+    LOCAL_SPAWN.with(|cell| cell.set(sp).map_err(|_| SetExecutorError::new()))
+}
+
+/// Sets the global executor for the current thread with a function that will only be called
+/// if an executor isn't set yet.
+pub fn ensure_executor_with<F>(f: F)
+where
+    F: FnOnce() -> &'static dyn LocalSpawn,
+{
+    LOCAL_SPAWN.with(|cell| {
+        cell.get_or_init(f);
+    });
+}

--- a/gdnative-async/src/future.rs
+++ b/gdnative-async/src/future.rs
@@ -1,0 +1,59 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+
+use crossbeam_channel::{Receiver, Sender};
+use parking_lot::Mutex;
+
+pub(crate) fn make<T>() -> (Yield<T>, Resume<T>) {
+    let (arg_send, arg_recv) = crossbeam_channel::bounded(1);
+    let waker = Arc::default();
+
+    let future = Yield {
+        waker: Arc::clone(&waker),
+        arg_recv,
+    };
+
+    let resume = Resume { waker, arg_send };
+
+    (future, resume)
+}
+
+/// Signal
+pub struct Yield<T> {
+    waker: Arc<Mutex<Option<Waker>>>,
+    arg_recv: Receiver<T>,
+}
+
+impl<T: Send> Future for Yield<T> {
+    type Output = T;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.arg_recv.try_recv() {
+            Ok(arg) => Poll::Ready(arg),
+            Err(_) => {
+                let mut waker = self.waker.lock();
+                *waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+pub(crate) struct Resume<T> {
+    waker: Arc<Mutex<Option<Waker>>>,
+    arg_send: Sender<T>,
+}
+
+impl<T: Send> Resume<T> {
+    /// Resume the task with a given argument from GDScript.
+    pub fn resume(self, arg: T) {
+        self.arg_send
+            .send(arg)
+            .expect("sender should not become disconnected");
+
+        if let Some(waker) = self.waker.lock().take() {
+            waker.wake();
+        }
+    }
+}

--- a/gdnative-async/src/lib.rs
+++ b/gdnative-async/src/lib.rs
@@ -1,0 +1,19 @@
+//! Runtime async support for godot-rust.
+//!
+//! This crate contains types and functions that enable using async code with godot-rust.
+//!
+//! # Safety assumptions
+//!
+//! This crate assumes that all user non-Rust code follow the official threading guidelines.
+
+// Workaround for macros that expect the `gdnative` crate.
+extern crate gdnative_core as gdnative;
+
+mod executor;
+mod future;
+mod method;
+mod rt;
+
+pub use executor::{ensure_executor_with, set_boxed_executor, set_executor, SetExecutorError};
+pub use method::{Async, AsyncMethod, Spawner};
+pub use rt::{register_runtime, terminate_runtime, Context, InitError};

--- a/gdnative-async/src/method.rs
+++ b/gdnative-async/src/method.rs
@@ -1,0 +1,123 @@
+use std::future::Future;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use futures_task::{LocalFutureObj, LocalSpawn, SpawnError};
+
+use gdnative_core::core_types::{ToVariant, Variant};
+use gdnative_core::log::{self, Site};
+use gdnative_core::nativescript::init::{Method, Varargs};
+use gdnative_core::nativescript::{NativeClass, RefInstance};
+use gdnative_core::thread_access::Shared;
+
+use crate::rt::Context;
+
+/// Trait for async methods. When exported, such methods return `FunctionState`-like
+/// objects that can be manually resumed or yielded to completion.
+///
+/// Async methods are always spawned locally on the thread where they were created,
+/// and never sent to another thread. This is so that we can ensure the safety of
+/// emitting signals from the `FunctionState`-like object. If you need to off-load
+/// some task to another thread, consider using something like
+/// `futures::future::Remote` to spawn it remotely on a thread pool.
+pub trait AsyncMethod<C: NativeClass>: Send + Sync + 'static {
+    /// Spawns the future for result of this method with `spawner`. This is done so
+    /// that implementors of this trait do not have to name their future types.
+    ///
+    /// If the `spawner` object is not used, the method call will fail, output an error,
+    /// and return a `Nil` variant.
+    fn spawn_with(&self, spawner: Spawner<'_, C>);
+
+    /// Returns an optional site where this method is defined. Used for logging errors in FFI wrappers.
+    ///
+    /// Default implementation returns `None`.
+    #[inline]
+    fn site() -> Option<Site<'static>> {
+        None
+    }
+}
+
+pub struct Spawner<'a, C: NativeClass> {
+    sp: &'static dyn LocalSpawn,
+    ctx: Context,
+    this: RefInstance<'a, C, Shared>,
+    args: Varargs<'a>,
+    result: &'a mut Option<Result<(), SpawnError>>,
+    _marker: PhantomData<*const ()>,
+}
+
+impl<'a, C: NativeClass> Spawner<'a, C> {
+    /// Consumes this `Spawner` and spawns a future returned by the closure. This indirection
+    /// is necessary so that implementors of the `AsyncMethod` trait do not have to name their
+    /// future types.
+    pub fn spawn<F, R>(self, f: F)
+    where
+        F: FnOnce(Arc<Context>, RefInstance<'_, C, Shared>, Varargs<'_>) -> R,
+        R: Future<Output = Variant> + 'static,
+    {
+        let ctx = Arc::new(self.ctx);
+        let future = f(Arc::clone(&ctx), self.this, self.args);
+        *self.result = Some(self.sp.spawn_local_obj(LocalFutureObj::new(Box::new(async {
+            let value = future.await;
+            ctx.resolve(value);
+            drop(ctx);
+        }))));
+    }
+}
+
+/// Adapter for async methods that implements `Method` and can be registered.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Async<F> {
+    f: F,
+}
+
+impl<F> Async<F> {
+    /// Wrap `f` in an adapter that implements `Method`.
+    #[inline]
+    pub fn new(f: F) -> Self {
+        Async { f }
+    }
+}
+
+impl<C: NativeClass, F: AsyncMethod<C>> Method<C> for Async<F> {
+    fn call(&self, this: RefInstance<'_, C, Shared>, args: Varargs<'_>) -> Variant {
+        if let Some(sp) = crate::executor::local_spawn() {
+            let ctx = Context::new();
+            let func_state = ctx.func_state();
+
+            let mut result = None;
+            self.f.spawn_with(Spawner {
+                sp,
+                ctx,
+                this,
+                args,
+                result: &mut result,
+                _marker: PhantomData,
+            });
+
+            match result {
+                Some(Ok(())) => func_state.to_variant(),
+                Some(Err(err)) => {
+                    log::error(
+                        Self::site().unwrap_or_default(),
+                        format_args!("unable to spawn future: {}", err),
+                    );
+                    Variant::new()
+                }
+                None => {
+                    log::error(
+                        Self::site().unwrap_or_default(),
+                        format_args!("implementation did not spawn a future"),
+                    );
+                    Variant::new()
+                }
+            }
+        } else {
+            log::error(
+                Self::site().unwrap_or_default(),
+                "a global executor must be set before any async methods can be called on this thread",
+            );
+            Variant::new()
+        }
+    }
+}

--- a/gdnative-async/src/rt.rs
+++ b/gdnative-async/src/rt.rs
@@ -1,0 +1,128 @@
+use std::marker::PhantomData;
+
+use gdnative_bindings::Object;
+use gdnative_core::object::SubClass;
+use once_cell::sync::OnceCell;
+use thiserror::Error;
+
+use gdnative_core::core_types::{GodotError, Variant};
+use gdnative_core::nativescript::{InitHandle, Instance, RefInstance};
+use gdnative_core::thread_access::Shared;
+use gdnative_core::TRef;
+
+use crate::future;
+
+mod bridge;
+mod func_state;
+
+use func_state::FuncState;
+
+static REGISTRATION: OnceCell<()> = OnceCell::new();
+
+#[derive(Debug, Error)]
+#[error("async runtime must only be initialized once")]
+pub struct InitError {
+    _private: (),
+}
+
+impl InitError {
+    fn new() -> Self {
+        InitError { _private: () }
+    }
+}
+
+/// Context for creating `yield`-like futures in async methods.
+pub struct Context {
+    func_state: Instance<FuncState, Shared>,
+    /// Remove Send and Sync
+    _marker: PhantomData<*const ()>,
+}
+
+impl Context {
+    pub(crate) fn new() -> Self {
+        Context {
+            func_state: FuncState::new().into_shared(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn func_state(&self) -> Instance<FuncState, Shared> {
+        self.func_state.clone()
+    }
+
+    fn safe_func_state(&self) -> RefInstance<'_, FuncState, Shared> {
+        // SAFETY: FuncState objects are bound to their origin threads in Rust, and
+        // Context is !Send, so this is safe to call within this type.
+        // Non-Rust code is expected to be following the official guidelines as per
+        // the global safety assumptions. Since a reference of `FuncState` is held by
+        // Rust, it voids the assumption to send the reference to any thread aside from
+        // the one where it's created.
+        unsafe { self.func_state.assume_safe() }
+    }
+
+    pub(crate) fn resolve(&self, value: Variant) {
+        func_state::resolve(self.safe_func_state(), value);
+    }
+
+    /// Returns a future that waits until the corresponding `FunctionState` object
+    /// is manually resumed from GDScript, and yields the argument to `resume` or `Nil`
+    /// if nothing is passed.
+    ///
+    /// Calling this function will put the associated `FunctionState`-like object in
+    /// resumable state, and will make it emit a `resumable` signal if it isn't in that
+    /// state already.
+    ///
+    /// Only the most recent future created from this `Context` is guaranteed to resolve
+    /// upon a `resume` call. If any previous futures weren't `await`ed to completion, they
+    /// are no longer guaranteed to resolve, and have unspecified, but safe behavior
+    /// when polled.
+    pub fn until_resume(&self) -> future::Yield<Variant> {
+        let (future, resume) = future::make();
+        func_state::make_resumable(self.safe_func_state(), resume);
+        future
+    }
+
+    /// Returns a future that waits until the specified signal is emitted, if connection succeeds.
+    /// Yields any arguments emitted with the signal.
+    ///
+    /// Only the most recent future created from this `Context` is guaranteed to resolve
+    /// when the signal is emitted. If any previous futures weren't `await`ed to completion, they
+    /// are no longer guaranteed to resolve, and have unspecified, but safe behavior
+    /// when polled.
+    ///
+    /// # Errors
+    ///
+    /// If connection to the signal failed.
+    pub fn signal<C>(
+        &self,
+        obj: TRef<'_, C>,
+        signal: &str,
+    ) -> Result<future::Yield<Vec<Variant>>, GodotError>
+    where
+        C: SubClass<Object>,
+    {
+        let (future, resume) = future::make();
+        bridge::SignalBridge::connect(obj.upcast(), signal, resume)?;
+        Ok(future)
+    }
+}
+
+pub fn register_runtime(handle: &InitHandle) -> Result<(), InitError> {
+    let mut called = false;
+
+    REGISTRATION.get_or_init(|| {
+        handle.add_class::<bridge::SignalBridge>();
+        handle.add_class::<func_state::FuncState>();
+        called = true;
+    });
+
+    if called {
+        Ok(())
+    } else {
+        Err(InitError::new())
+    }
+}
+
+pub fn terminate_runtime() {
+    bridge::terminate();
+}

--- a/gdnative-async/src/rt/bridge.rs
+++ b/gdnative-async/src/rt/bridge.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+
+use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
+
+use gdnative_bindings::{Object, Reference};
+use gdnative_core::core_types::{GodotError, Variant, VariantArray};
+use gdnative_core::nativescript::init::ClassBuilder;
+use gdnative_core::nativescript::method::{Method, Varargs};
+use gdnative_core::nativescript::user_data::ArcData;
+use gdnative_core::nativescript::{Instance, Map, NativeClass, NativeClassMethods, RefInstance};
+use gdnative_core::thread_access::Shared;
+use gdnative_core::{godot_site, TRef};
+
+use crate::future::Resume;
+
+// We need to keep our observers alive since `Object::connect` won't
+static BRIDGES: OnceCell<Mutex<Pool>> = OnceCell::new();
+
+pub(super) fn terminate() {
+    if let Some(pool) = BRIDGES.get() {
+        let mut pool = pool.lock();
+        std::mem::take(&mut *pool);
+    }
+}
+
+#[derive(Default)]
+struct Pool {
+    busy: HashMap<i64, Entry>,
+    free: Vec<(i64, Instance<SignalBridge, Shared>)>,
+    next_id: i64,
+}
+
+struct Entry {
+    resume: Resume<Vec<Variant>>,
+
+    // Just need to keep this alive.
+    #[allow(dead_code)]
+    obj: Instance<SignalBridge, Shared>,
+}
+
+pub(super) struct SignalBridge {
+    id: i64,
+}
+
+impl NativeClass for SignalBridge {
+    type Base = Reference;
+    type UserData = ArcData<SignalBridge>;
+
+    fn class_name() -> &'static str {
+        // Sort of just praying that there will be no duplicates of this.
+        "__GDNATIVE_ASYNC_INTERNAL__SignalBridge"
+    }
+
+    fn register_properties(_builder: &ClassBuilder<Self>) {}
+}
+
+impl SignalBridge {
+    pub(crate) fn connect(
+        source: TRef<Object>,
+        signal: &str,
+        resume: Resume<Vec<Variant>>,
+    ) -> Result<(), GodotError> {
+        assert!(
+            super::REGISTRATION.get().is_some(),
+            "async API must be registered before any async methods can be called"
+        );
+
+        let mut pool = BRIDGES.get_or_init(Mutex::default).lock();
+        let (id, bridge) = pool.free.pop().unwrap_or_else(|| {
+            let id = pool.next_id;
+            pool.next_id += 1;
+            let bridge = Instance::emplace(SignalBridge { id }).into_shared();
+            (id, bridge)
+        });
+
+        source.connect(
+            signal,
+            bridge.base(),
+            "_on_signal",
+            VariantArray::new_shared(),
+            Object::CONNECT_ONESHOT,
+        )?;
+
+        let entry = Entry {
+            obj: bridge,
+            resume,
+        };
+
+        assert!(pool.busy.insert(id, entry).is_none());
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct OnSignalFn;
+
+impl Method<SignalBridge> for OnSignalFn {
+    fn call(&self, this: RefInstance<'_, SignalBridge, Shared>, args: Varargs<'_>) -> Variant {
+        let args = args.cloned().collect();
+
+        let this_persist = this.clone().claim();
+
+        this.script()
+            .map(|s| {
+                let (resume, args) = {
+                    let mut pool = BRIDGES.get().unwrap().lock();
+                    match pool.busy.remove(&s.id) {
+                        Some(entry) => {
+                            pool.free.push((s.id, this_persist));
+                            (entry.resume, args)
+                        }
+                        None => {
+                            gdnative_core::log::warn(
+                                Self::site().unwrap(),
+                                "`_on_signal` should only be called once per bridge object",
+                            );
+                            return;
+                        }
+                    }
+                };
+
+                resume.resume(args);
+            })
+            .unwrap();
+
+        Variant::new()
+    }
+
+    fn site() -> Option<gdnative_core::log::Site<'static>> {
+        Some(godot_site!(SignalBridge::_on_signal))
+    }
+}
+
+impl NativeClassMethods for SignalBridge {
+    fn register(builder: &ClassBuilder<Self>) {
+        builder
+            .build_method("_on_signal", OnSignalFn)
+            .done_stateless();
+    }
+}

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -1,0 +1,186 @@
+use gdnative_bindings::Reference;
+use gdnative_core::core_types::{ToVariant, Variant, VariantType};
+use gdnative_core::godot_site;
+use gdnative_core::nativescript::init::method::StaticArgs;
+use gdnative_core::nativescript::init::{
+    ClassBuilder, ExportInfo, PropertyUsage, Signal, SignalArgument,
+};
+use gdnative_core::nativescript::method::StaticArgsMethod;
+use gdnative_core::nativescript::user_data::LocalCellData;
+use gdnative_core::nativescript::{
+    Instance, Map, MapMut, NativeClass, NativeClassMethods, RefInstance,
+};
+use gdnative_core::thread_access::{Shared, Unique};
+use gdnative_derive::FromVarargs;
+
+use crate::future::Resume;
+
+pub(crate) struct FuncState {
+    kind: Kind,
+}
+
+enum Kind {
+    Resolved(Variant),
+    Resumable(Resume<Variant>),
+    Pending,
+}
+
+impl NativeClass for FuncState {
+    type Base = Reference;
+    type UserData = LocalCellData<FuncState>;
+
+    fn class_name() -> &'static str {
+        // Sort of just praying that there will be no duplicates of this.
+        "__GDNATIVE_ASYNC_INTERNAL__FuncState"
+    }
+
+    fn register_properties(builder: &ClassBuilder<Self>) {
+        builder.add_signal(Signal {
+            name: "completed",
+            args: &[SignalArgument {
+                name: "value",
+                default: Variant::new(),
+                export_info: ExportInfo::new(VariantType::Nil),
+                usage: PropertyUsage::DEFAULT,
+            }],
+        });
+
+        builder.add_signal(Signal {
+            name: "resumable",
+            args: &[],
+        });
+    }
+}
+
+impl FuncState {
+    pub fn new() -> Instance<Self, Unique> {
+        assert!(
+            super::REGISTRATION.get().is_some(),
+            "async API must be registered before any async methods can be called"
+        );
+
+        Instance::emplace(FuncState {
+            kind: Kind::Pending,
+        })
+    }
+}
+
+pub(super) fn resolve(this: RefInstance<'_, FuncState, Shared>, value: Variant) {
+    this.script()
+        .map_mut(|s| {
+            match s.kind {
+                Kind::Resolved(_) => {
+                    panic!("`resolve` should only be called once for each FuncState")
+                }
+                Kind::Pending => {}
+                Kind::Resumable(_) => {
+                    gdnative_core::log::warn(
+                        Default::default(),
+                        "async function resolved while waiting for a `resume` call",
+                    );
+                }
+            }
+
+            s.kind = Kind::Resolved(value.clone());
+        })
+        .expect("no reentrancy");
+
+    this.base().emit_signal("completed", &[value]);
+}
+
+pub(super) fn make_resumable(this: RefInstance<'_, FuncState, Shared>, resume: Resume<Variant>) {
+    let kind = this
+        .script()
+        .map_mut(|s| std::mem::replace(&mut s.kind, Kind::Resumable(resume)))
+        .expect("no reentrancy");
+
+    match kind {
+        Kind::Resolved(_) => {
+            panic!("`make_resumable` should not be called after resolution")
+        }
+        Kind::Resumable(_) => {
+            gdnative_core::log::warn(
+                Default::default(),
+                "`make_resumable` called when there is a previous pending future",
+            );
+        }
+        Kind::Pending => {
+            this.base().emit_signal("resumable", &[]);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct IsValidFn;
+
+#[derive(FromVarargs)]
+struct IsValidArgs {
+    #[opt]
+    extended_check: Option<bool>,
+}
+
+impl StaticArgsMethod<FuncState> for IsValidFn {
+    type Args = IsValidArgs;
+    fn call(&self, this: RefInstance<'_, FuncState, Shared>, args: Self::Args) -> Variant {
+        if args.extended_check.is_some() {
+            gdnative_core::log::warn(
+                Self::site().unwrap(),
+                "`extended_check` is set, but it has no effect on Rust function state objects",
+            )
+        }
+
+        this.script()
+            .map(|s| match &s.kind {
+                Kind::Resumable(_) => true,
+                Kind::Resolved(_) | Kind::Pending => false,
+            })
+            .unwrap()
+            .to_variant()
+    }
+    fn site() -> Option<gdnative_core::log::Site<'static>> {
+        Some(godot_site!(FunctionState::is_valid))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ResumeFn;
+
+#[derive(FromVarargs)]
+struct ResumeArgs {
+    #[opt]
+    arg: Variant,
+}
+
+impl StaticArgsMethod<FuncState> for ResumeFn {
+    type Args = ResumeArgs;
+    fn call(&self, this: RefInstance<'_, FuncState, Shared>, args: Self::Args) -> Variant {
+        this.map_mut(
+            |s, owner| match std::mem::replace(&mut s.kind, Kind::Pending) {
+                Kind::Resumable(resume) => {
+                    resume.resume(args.arg);
+                    owner.to_variant()
+                }
+                Kind::Pending => owner.to_variant(),
+                Kind::Resolved(result) => {
+                    s.kind = Kind::Resolved(result.clone());
+                    result
+                }
+            },
+        )
+        .expect("no reentrancy")
+    }
+    fn site() -> Option<gdnative_core::log::Site<'static>> {
+        Some(godot_site!(FunctionState::is_valid))
+    }
+}
+
+impl NativeClassMethods for FuncState {
+    fn register(builder: &ClassBuilder<Self>) {
+        builder
+            .build_method("is_valid", StaticArgs::new(IsValidFn))
+            .done_stateless();
+        builder
+            .build_method("resume", StaticArgs::new(ResumeFn))
+            .done_stateless();
+    }
+}

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -12,17 +12,19 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["bindings"]
+default = ["bindings", "async"]
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one_class_one_file"]
 
 gd_test = ["gdnative-core/gd_test"]
 type_tag_fallback = ["gdnative-core/type_tag_fallback"]
 bindings = ["gdnative-bindings"]
+async = ["gdnative-async", "bindings"]
 
 [dependencies]
 gdnative-derive = { path = "../gdnative-derive", version = "=0.9.3" }
 gdnative-core = { path = "../gdnative-core", version = "=0.9.3" }
 gdnative-bindings = { optional = true, path = "../gdnative-bindings", version = "=0.9.3" }
+gdnative-async = { optional = true, path = "../gdnative-async", version = "=0.9.3" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -73,3 +73,8 @@ pub mod prelude;
 #[cfg(feature = "bindings")]
 /// Bindings for the Godot Class API.
 pub use gdnative_bindings as api;
+
+#[doc(inline)]
+#[cfg(feature = "async")]
+/// Support for async code
+pub use gdnative_async as asn;

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -16,3 +16,5 @@ type_tag_fallback = ["gdnative/type_tag_fallback"]
 gdnative = { path = "../gdnative", features = ["gd_test"] }
 gdnative-derive = { path = "../gdnative-derive" }
 approx = "0.3.2"
+futures = "0.3.13"
+once_cell = "1.7.2"

--- a/test/project/Scene.tscn
+++ b/test/project/Scene.tscn
@@ -2,8 +2,5 @@
 
 [ext_resource path="res://main.gd" type="Script" id=1]
 
-[node name="Node" type="Node" index="0"]
-
+[node name="Node" type="Node"]
 script = ExtResource( 1 )
-
-

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -3,95 +3,165 @@ extends Node
 var gdn
 
 func _ready():
-    print(" -- Rust gdnative test suite:")
-    gdn = GDNative.new()
-    var status = false;
+	print(" -- Rust gdnative test suite:")
+	_timeout()
 
-    gdn.library = load("res://gdnative.gdnlib")
+	gdn = GDNative.new()
+	var status = false;
 
-    if gdn.initialize():
-        status = gdn.call_native("standard_varcall", "run_tests", [])
+	gdn.library = load("res://gdnative.gdnlib")
 
-        status = status && _test_argument_passing_sanity()
-        status = status && _test_optional_args()
+	if gdn.initialize():
+		status = gdn.call_native("standard_varcall", "run_tests", [])
 
-        gdn.terminate()
-    else:
-        print(" -- Could not load the gdnative library.")
+		status = status && _test_argument_passing_sanity()
+		status = status && _test_optional_args()
+		status = status && yield(_test_async_resume(), "completed")
 
-    if status:
-        print(" -- Test run completed successfully.")
-    else:
-        print(" -- Test run completed with errors.")
-        OS.exit_code = 1
+		# Godot needs another frame to dispose the executor driver node. Otherwise the process
+		# aborts due to `_process` being called after `terminate` (`get_api` fail, not UB).
+		yield(get_tree().create_timer(0.1), "timeout")
 
-    print(" -- exiting.")
-    get_tree().quit()
+		gdn.terminate()
+	else:
+		print(" -- Could not load the gdnative library.")
+
+	if status:
+		print(" -- Test run completed successfully.")
+	else:
+		print(" -- Test run completed with errors.")
+		OS.exit_code = 1
+
+	print(" -- exiting.")
+	get_tree().quit()
+
+func _timeout():
+	yield(get_tree().create_timer(10.0), "timeout")
+	print(" -- Test run is taking too long.")
+	OS.exit_code = 1
+
+	print(" -- exiting.")
+	get_tree().quit()
 
 func _test_argument_passing_sanity():
-    print(" -- test_argument_passing_sanity")
+	print(" -- test_argument_passing_sanity")
 
-    var script = NativeScript.new()
-    script.set_library(gdn.library)
-    script.set_class_name("Foo")
-    var foo = Reference.new()
-    foo.set_script(script)
-    
-    var status = true
+	var script = NativeScript.new()
+	script.set_library(gdn.library)
+	script.set_class_name("Foo")
+	var foo = Reference.new()
+	foo.set_script(script)
+	
+	var status = true
 
-    status = status && _assert_choose("foo", foo, "choose", "foo", true, "bar")
-    status = status && _assert_choose("night", foo, "choose", "day", false, "night")
-    status = status && _assert_choose(42, foo, "choose_variant", 42, "int", 54.0)
-    status = status && _assert_choose(9.0, foo, "choose_variant", 6, "float", 9.0)
+	status = status && _assert_choose("foo", foo, "choose", "foo", true, "bar")
+	status = status && _assert_choose("night", foo, "choose", "day", false, "night")
+	status = status && _assert_choose(42, foo, "choose_variant", 42, "int", 54.0)
+	status = status && _assert_choose(9.0, foo, "choose_variant", 6, "float", 9.0)
 
-    if status:
-        assert("foo" == foo.choose("foo", true, "bar"))
-        assert("night" == foo.choose("day", false, "night"))
-        assert(42 == foo.choose_variant(42, "int", 54.0))
-        assert(9.0 == foo.choose_variant(6, "float", 9.0))
+	if status:
+		assert("foo" == foo.choose("foo", true, "bar"))
+		assert("night" == foo.choose("day", false, "night"))
+		assert(42 == foo.choose_variant(42, "int", 54.0))
+		assert(9.0 == foo.choose_variant(6, "float", 9.0))
 
-    if !status:
-        printerr("   !! test_argument_passing_sanity failed")
+	if !status:
+		printerr("   !! test_argument_passing_sanity failed")
 
-    return status
+	return status
 
 func _assert_choose(expected, foo, fun, a, which, b):
-    var got_value = foo.call(fun, a, which, b)
-    if got_value == expected:
-        return true
-    printerr("   !! expected ", expected, ", got ", got_value)
-    return false
+	var got_value = foo.call(fun, a, which, b)
+	if got_value == expected:
+		return true
+	printerr("   !! expected ", expected, ", got ", got_value)
+	return false
 
 func _test_optional_args():
-    print(" -- _test_optional_args")
-    print("   -- expected error messages for edge cases:")
-    print("     -- missing non-optional parameter `b` (#1)")
-    print("     -- 1 excessive argument is given: [I64(6)]")
-    print("   -- the test is successful when and only when these errors are shown")
+	print(" -- _test_optional_args")
+	print("   -- expected error messages for edge cases:")
+	print("     -- missing non-optional parameter `b` (#1)")
+	print("     -- 1 excessive argument is given: [I64(6)]")
+	print("   -- the test is successful when and only when these errors are shown")
 
-    var script = NativeScript.new()
-    script.set_library(gdn.library)
-    script.set_class_name("OptionalArgs")
-    var opt_args = Reference.new()
-    opt_args.set_script(script)
+	var script = NativeScript.new()
+	script.set_library(gdn.library)
+	script.set_class_name("OptionalArgs")
+	var opt_args = Reference.new()
+	opt_args.set_script(script)
 
-    var status = true
+	var status = true
 
-    status = status && _assert_opt_args(null, opt_args, [1])
-    status = status && _assert_opt_args(2, opt_args, [1, 1])
-    status = status && _assert_opt_args(6, opt_args, [1, 3, 2])
-    status = status && _assert_opt_args(13, opt_args, [5, 1, 3, 4])
-    status = status && _assert_opt_args(42, opt_args, [4, 1, 20, 4, 13])
-    status = status && _assert_opt_args(null, opt_args, [1, 2, 3, 4, 5, 6])
+	status = status && _assert_opt_args(null, opt_args, [1])
+	status = status && _assert_opt_args(2, opt_args, [1, 1])
+	status = status && _assert_opt_args(6, opt_args, [1, 3, 2])
+	status = status && _assert_opt_args(13, opt_args, [5, 1, 3, 4])
+	status = status && _assert_opt_args(42, opt_args, [4, 1, 20, 4, 13])
+	status = status && _assert_opt_args(null, opt_args, [1, 2, 3, 4, 5, 6])
 
-    if !status:
-        printerr("   !! _test_optional_args failed")
+	if !status:
+		printerr("   !! _test_optional_args failed")
 
-    return status
+	return status
 
 func _assert_opt_args(expected, opt_args, args):
-    var got_value = opt_args.callv("opt_sum", args);
-    if got_value == expected:
-        return true
-    printerr("   !! expected ", expected, ", got ", got_value)
-    return false
+	var got_value = opt_args.callv("opt_sum", args);
+	if got_value == expected:
+		return true
+	printerr("   !! expected ", expected, ", got ", got_value)
+	return false
+
+
+func _test_async_resume():
+	print(" -- _test_async_resume")
+
+	var driver_script = NativeScript.new()
+	driver_script.set_library(gdn.library)
+	driver_script.set_class_name("AsyncExecutorDriver")
+	var driver = Node.new()
+	driver.set_script(driver_script)
+	add_child(driver)
+
+	var script = NativeScript.new()
+	script.set_library(gdn.library)
+	script.set_class_name("AsyncMethods")
+	var resume = Reference.new()
+	resume.set_script(script)
+
+	var status = true
+
+	# Force this to return a FunctionState for convenience
+	yield(get_tree().create_timer(0.1), "timeout")
+
+	var fn_state = resume.resume_add(1, self, "_get_async_number")
+	if !fn_state:
+		printerr("   !! _test_async_resume failed")
+		remove_child(driver)
+		driver.queue_free()
+		return false
+
+	yield(fn_state, "resumable")
+	status = status && fn_state.is_valid()
+	
+	fn_state = fn_state.resume(2)
+	if !fn_state:
+		printerr("   !! _test_async_resume failed")
+		remove_child(driver)
+		driver.queue_free()
+		return false
+
+	var result = yield(fn_state, "completed")
+	
+	status = status && (result == 42)
+
+	if !status:
+		printerr("   !! _test_async_resume failed")
+
+	remove_child(driver)
+	driver.queue_free()
+
+	return status
+
+func _get_async_number():
+	yield(get_tree().create_timer(0.1), "timeout")
+	return 39

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -2,6 +2,7 @@
 
 use gdnative::prelude::*;
 
+mod test_async;
 mod test_constructor;
 mod test_derive;
 mod test_free_ub;
@@ -59,6 +60,7 @@ pub extern "C" fn run_tests(
     status &= test_rust_class_construction();
     status &= test_from_instance_id();
 
+    status &= test_async::run_tests();
     status &= test_derive::run_tests();
     status &= test_free_ub::run_tests();
     status &= test_constructor::run_tests();
@@ -254,6 +256,7 @@ fn init(handle: InitHandle) {
     handle.add_class::<Foo>();
     handle.add_class::<OptionalArgs>();
 
+    test_async::register(handle);
     test_derive::register(handle);
     test_free_ub::register(handle);
     test_constructor::register(handle);
@@ -265,4 +268,10 @@ fn init(handle: InitHandle) {
     test_vararray_return::register(handle);
 }
 
-gdnative::godot_init!(init);
+fn terminate(_term_info: &gdnative::TerminateInfo) {
+    gdnative::asn::terminate_runtime();
+}
+
+gdnative::godot_gdnative_init!();
+gdnative::godot_nativescript_init!(init);
+gdnative::godot_gdnative_terminate!(terminate);

--- a/test/src/test_async.rs
+++ b/test/src/test_async.rs
@@ -1,0 +1,99 @@
+use std::cell::RefCell;
+
+use gdnative::asn::{Async, AsyncMethod, Spawner};
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    // Relevant tests in GDScript
+    true
+}
+
+thread_local! {
+    static EXECUTOR: &'static SharedLocalPool = {
+        Box::leak(Box::new(SharedLocalPool::default()))
+    };
+}
+
+pub(crate) fn register(handle: InitHandle) {
+    gdnative::asn::register_runtime(&handle).unwrap();
+    gdnative::asn::set_executor(EXECUTOR.with(|e| *e)).unwrap();
+
+    handle.add_class::<AsyncMethods>();
+    handle.add_class::<AsyncExecutorDriver>();
+}
+
+#[derive(Default)]
+struct SharedLocalPool {
+    pool: RefCell<futures::executor::LocalPool>,
+}
+
+impl futures::task::LocalSpawn for SharedLocalPool {
+    fn spawn_local_obj(
+        &self,
+        future: futures::task::LocalFutureObj<'static, ()>,
+    ) -> Result<(), futures::task::SpawnError> {
+        self.pool.borrow_mut().spawner().spawn_local_obj(future)
+    }
+}
+
+#[derive(NativeClass)]
+#[inherit(Node)]
+struct AsyncExecutorDriver;
+
+impl AsyncExecutorDriver {
+    fn new(_owner: &Node) -> Self {
+        AsyncExecutorDriver
+    }
+}
+
+#[methods]
+impl AsyncExecutorDriver {
+    #[export]
+    fn _process(&self, _owner: &Node, _delta: f64) {
+        EXECUTOR.with(|e| e.pool.borrow_mut().run_until_stalled());
+    }
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+#[register_with(register_methods)]
+struct AsyncMethods;
+
+#[methods]
+impl AsyncMethods {
+    fn new(_owner: TRef<Reference>) -> Self {
+        AsyncMethods
+    }
+}
+
+struct ResumeAddFn;
+
+impl AsyncMethod<AsyncMethods> for ResumeAddFn {
+    fn spawn_with(&self, spawner: Spawner<'_, AsyncMethods>) {
+        spawner.spawn(|ctx, _this, mut args| {
+            let a = args.read::<i32>().get().unwrap();
+            let obj = args.read::<Ref<Object>>().get().unwrap();
+            let name = args.read::<GodotString>().get().unwrap();
+
+            async move {
+                let b = ctx.until_resume().await;
+                let b = i32::from_variant(&b).unwrap();
+
+                let c = unsafe { obj.assume_safe().call(name, &[]) };
+                let c = Ref::<Reference>::from_variant(&c).unwrap();
+                let c = unsafe { c.assume_safe() };
+                let c = ctx.signal(c, "completed").unwrap().await;
+                assert_eq!(1, c.len());
+                let c = i32::from_variant(&c[0]).unwrap();
+
+                (a + b + c).to_variant()
+            }
+        });
+    }
+}
+
+fn register_methods(builder: &ClassBuilder<AsyncMethods>) {
+    builder
+        .build_method("resume_add", Async::new(ResumeAddFn))
+        .done();
+}


### PR DESCRIPTION
This sets the foundations for async-await support in godot-rust, based on the original idea in #284. However, although the tests work, this is not a full implementation:

- Async methods can only be registered manually using `build_method`. Macro syntax and implementation are out of the scope of this PR.
- The runtime types aren't registered automatically yet. Users need to manually call `register_runtime` and `terminate_runtime` functions in their library lifecycle hooks. Improving this is out of the scope of this PR for now.
- The crate is currently re-exported as `gdnative::asn`, instead of the much longer `async_yield`. The name is open to discussion -- I don't like it very much.
- Only local spawners are supported, due to issues with thread safety. Users may off-load tasks that don't contain `yield`-likes to thread pool spawners using something like `futures::future::Remote`, however.
- Panics in async methods don't currently behave very well. Their `FunctionState`-likes simply block forever and any outstanding bridge objects for futures can be leaked.

- - -

While the feature is not yet complete, the commit is already pretty big, and I feel that it's in a somewhat usable state. As a result, I'm putting this up as a draft PR to gather some feedback. If you have uses for async-await / "yield" from GDScript, please feel free to try it and tell me what you think!

Registering an async method currently looks like this (excerpt from the tests):

```rust

struct ResumeAddFn;

impl AsyncMethod<AsyncMethods> for ResumeAddFn {
    fn spawn_with(&self, spawner: Spawner<'_, AsyncMethods>) {
        spawner.spawn(|ctx, _this, mut args| {
            let a = args.read::<i32>().get().unwrap();
            let obj = args.read::<Ref<Object>>().get().unwrap();
            let name = args.read::<GodotString>().get().unwrap();

            async move {
                let b = ctx.until_resume().await;
                let b = i32::from_variant(&b).unwrap();

                let c = unsafe { obj.assume_safe().call(name, &[]) };
                let c = Ref::<Reference>::from_variant(&c).unwrap();
                let c = unsafe { c.assume_safe() };
                let c = ctx.signal(c, "completed").unwrap().await;
                assert_eq!(1, c.len());
                let c = i32::from_variant(&c[0]).unwrap();

                (a + b + c).to_variant()
            }
        });
    }
}

fn register_methods(builder: &ClassBuilder<AsyncMethods>) {
    builder
        .build_method("resume_add", Async::new(ResumeAddFn))
        .done();
}
```

Using it is almost like any other GDScript coroutine:

```gdscript
func _async_call(obj):
	var fn_state = obj.resume_add(1, self, "_get_async_number")
	# the "resumable" signal is unique to Rust, since unlike GDScript coroutines,
	# Rust futures aren't guaranteed to be polled up to a yield right after spawning.
	yield(fn_state, "resumable")
	fn_state = fn_state.resume(2)
	# no "resumable" signal when awaiting signals, though
	var result = yield(fn_state, "completed")
	assert(result == 42)

func _get_async_number():
	yield(get_tree().create_timer(0.1), "timeout")
	return 39
```