### PR TITLE
TypedArray: mention use cases and limitations in doc

### DIFF
--- a/gdnative-core/src/core_types/typed_array.rs
+++ b/gdnative-core/src/core_types/typed_array.rs
@@ -14,6 +14,13 @@ use crate::NewRef;
 /// A reference-counted CoW typed vector using Godot's pool allocator, generic over possible
 /// element types.
 ///
+/// `TypedArray` unifies all the different `Pool*Array` types exported by Godot. It can be used
+/// in exported Rust methods as parameter and return types, as well as in exported properties.
+/// However, it is limited to the element types, for which a `Pool*Array` exists in GDScript,
+/// i.e. it cannot contain user-defined types.
+/// If you need other types, look into [`VariantArray`](struct.VariantArray.html) or directly use
+/// `Vec<T>` for type safety.
+///
 /// This type is CoW. The `Clone` implementation of this type creates a new reference without
 /// copying the contents.
 ///


### PR DESCRIPTION
Adds a short paragraph to the `TypedArray` documentation:
![grafik](https://user-images.githubusercontent.com/708488/111084207-7d6a7880-8511-11eb-8167-d7ab26459fc1.png)
