### PR TITLE
Try to fix LLVM installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - uses: KyleMayes/install-llvm-action@01144dc97b1e2693196c3056414a44f15180648b
+      - uses: KyleMayes/install-llvm-action@7673c1af8f0ae228f19f5962fc2cd6e3378305a8
         with:
           version: 10.0
           directory: ${{ runner.temp }}/llvm


### PR DESCRIPTION
It seems that some changes in the CI environment stopped clang-sys from
finding the installation on Windows. Let's see if bumping the version of
`install-llvm-action` can resolve this issue.