### PR TITLE
Impl NodeExt for TRef

### DIFF
--- a/gdnative-bindings/src/utils.rs
+++ b/gdnative-bindings/src/utils.rs
@@ -75,3 +75,12 @@ impl<'n, N: SubClass<Node>> NodeExt for &'n N {
         self.upcast().get_node(path)?.assume_safe().cast()
     }
 }
+
+impl<'n, N: SubClass<Node>> NodeExt for TRef<'n, N> {
+    unsafe fn get_node_as<'a, T>(&self, path: &str) -> Option<TRef<'a, T>>
+    where
+        T: SubClass<Node>,
+    {
+        self.as_ref().get_node_as(path)
+    }
+}


### PR DESCRIPTION
It appears that deref coercion does not cover `TRef`, causing "method not found" errors when calling `get_node_as` directly on `TRef`. Adding an impl should fix the issue.