### PR TITLE
Lower-case error messages without trailing punctuation

### DIFF
--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -1216,7 +1216,7 @@ impl fmt::Display for FromVariantError {
                 write!(f, "invalid value for variant {}: {}", variant, error)
             }
             E::InvalidInstance { expected } => {
-                write!(f, "object is not an instance of NativeClass {}", expected)
+                write!(f, "object is not an instance of `NativeClass` {}", expected)
             }
             E::InvalidField { field_name, error } => {
                 write!(f, "invalid value for field {}", field_name)?;

--- a/gdnative-core/src/nativescript/user_data.rs
+++ b/gdnative-core/src/nativescript/user_data.rs
@@ -170,7 +170,7 @@ pub enum Infallible {}
 impl std::fmt::Display for Infallible {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Operation that can't fail just failed")
+        write!(f, "operation that can't fail just failed")
     }
 }
 
@@ -232,8 +232,8 @@ impl std::fmt::Display for LockFailed {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LockFailed::Timeout(wait) => write!(f, "Failed to acquire lock within {:?}", wait),
-            LockFailed::Pessimistic => write!(f, "Failed to acquire lock, it was already held."),
+            LockFailed::Timeout(wait) => write!(f, "failed to acquire lock within {:?}", wait),
+            LockFailed::Pessimistic => write!(f, "failed to acquire lock, it was already held"),
         }
     }
 }
@@ -559,13 +559,13 @@ mod local_cell {
             match self {
                 LocalCellError::DifferentThread { original, current } => write!(
                     f,
-                    "Accessing from the wrong thread, expected {:?} found {:?}",
+                    "accessing from the wrong thread, expected {:?} found {:?}",
                     original, current
                 ),
                 LocalCellError::BorrowFailed => write!(
                     f,
-                    "Borrow failed; a &mut reference was requested, but one already exists. Cause is likely a re-entrant call \
-                    (e.g. a GDNative Rust method calls to GDScript, which again calls a Rust method on the same object)."
+                    "borrow failed; a &mut reference was requested, but one already exists. The cause is likely a re-entrant call \
+                    (e.g. a GDNative Rust method calls to GDScript, which again calls a Rust method on the same object)"
                 ),
             }
         }


### PR DESCRIPTION
As per Issue #702 changing the format of the errors message to follow the standard listed here: https://rust-lang.github.io/api-guidelines/interoperability.html#error-types-are-meaningful-and-well-behaved-c-good-err

I looked through both the errors and the display impls and these were the only ones that I found that broke the interoperability rules listed in issue#702

Tests still appear to be passing and the changes didn't appear to cause issues with clippy.

If there are any questions with the wording, please let me know.