### PR TITLE
Fix 'unresolved import syn::export' error in version 0.8.1

### DIFF
--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -2,7 +2,7 @@ use syn::{FnArg, ImplItem, ItemImpl, Pat, PatIdent, Signature, Type};
 
 use proc_macro::TokenStream;
 use std::boxed::Box;
-use syn::export::Span;
+use proc_macro2::Span;
 
 pub(crate) struct ClassMethodExport {
     pub(crate) class_ty: Box<Type>,


### PR DESCRIPTION
Hi
The syn crate has breaking change from 1.0.57 to 1.0.58([related change](https://github.com/dtolnay/syn/blob/5e23a9b9ac13733a56cf55777dc42bb23ee00bbc/src/lib.rs#L789-L791)) and this change cause compilation error in other projects like [qodot-next](https://github.com/Shfty/qodot-next) that still using version 0.8.x.
I create the pull request for master branch because there isn't a branch for 0.8.
If it's possible, please release version 0.8.2 to fix this bug.
Thanks