### PR TITLE
Fix tests with Godot 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   RUST_BACKTRACE: 1
-  GODOT_VER: 3.2
+  GODOT_VER: 3.3
   GODOT_REL: stable
 
 on:

--- a/test/project/gdnative.gdnlib
+++ b/test/project/gdnative.gdnlib
@@ -16,4 +16,4 @@ X11.64=[  ]
 singleton=false
 load_once=true
 symbol_prefix="godot_"
-reloadable=true
+reloadable=false


### PR DESCRIPTION
The most important change here is the first commit making the `.gdnlib` file not-reloadable. Godot 3.3 apparently added hot-reloading support for gdnative, but did so by terminating the library when no `NativeScript`s reference it: https://github.com/godotengine/godot/blame/3.3/modules/gdnative/nativescript/nativescript.cpp#L1550

This probably makes sense for most users, but for the specific case of keeping a `GDNative` object alive while `NativeScript`s are created and freed, this causes the library to be terminated out from under the `GDNative` object This is actually supposed to be prevented, but is not due to a bug in the engine. However even fixing that bug upstream would still cause panics in the tests due to the godot-rust class registry thinking all classes have already been registered when `godot_nativescript_init` is called again. Therefore, I also included a commit that refactors the `init` code a bit to only panic if a class is registered *with the same init handle* more than once, just in case users have a use case where making the library not-relodable is not an option for some reason. This adds a lifetime parameter to `InitHandle` in order to keep it `Copy`, but that does not seem to break any of my code or the tests. 

There was also a superfluous error in the `test_vararray_return_crash` test due to the camera not being in the world. This may not matter for the test, but I figured it was somewhat confusing that it was not included in the "expected error messages" list.

These changes were kept as separate commits so you can let me know if you want to forego or modify any of them.