### PR TITLE
Fix `Dictionary::get` unsoundness and add a few convenience functions

### DIFF
--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -1753,7 +1753,7 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
 
         match key.as_str() {
             "Ok" => {
-                let val = T::from_variant(&dict.get(key_variant)).map_err(|err| {
+                let val = T::from_variant(&dict.get_or_nil(key_variant)).map_err(|err| {
                     FVE::InvalidEnumVariant {
                         variant: "Ok",
                         error: Box::new(err),
@@ -1762,7 +1762,7 @@ impl<T: FromVariant, E: FromVariant> FromVariant for Result<T, E> {
                 Ok(Ok(val))
             }
             "Err" => {
-                let err = E::from_variant(&dict.get(key_variant)).map_err(|err| {
+                let err = E::from_variant(&dict.get_or_nil(key_variant)).map_err(|err| {
                     FVE::InvalidEnumVariant {
                         variant: "Err",
                         error: Box::new(err),
@@ -1912,11 +1912,11 @@ godot_test!(
     test_variant_result {
         let variant = Result::<i64, ()>::Ok(42_i64).to_variant();
         let dict = variant.try_to_dictionary().expect("should be dic");
-        assert_eq!(Some(42), dict.get("Ok").try_to_i64());
+        assert_eq!(Some(42), dict.get("Ok").and_then(|v| v.try_to_i64()));
 
         let variant = Result::<(), i64>::Err(54_i64).to_variant();
         let dict = variant.try_to_dictionary().expect("should be dic");
-        assert_eq!(Some(54), dict.get("Err").try_to_i64());
+        assert_eq!(Some(54), dict.get("Err").and_then(|v| v.try_to_i64()));
 
         let variant = Variant::from_bool(true);
         assert_eq!(

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -87,7 +87,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
                         match __key.as_str() {
                             #(
                                 #ref_var_ident_string_literals => {
-                                    let #var_input_ident_iter = &__dict.get(&__keys.get(0));
+                                    let #var_input_ident_iter = &__dict.get_or_nil(&__keys.get(0));
                                     (#var_from_variants).map_err(|err| FVE::InvalidEnumVariant {
                                         variant: #ref_var_ident_string_literals,
                                         error: Box::new(err),

--- a/gdnative-derive/src/variant/repr.rs
+++ b/gdnative-derive/src/variant/repr.rs
@@ -280,7 +280,7 @@ impl VariantRepr {
                 let name_string_literals =
                     name_strings.iter().map(|string| Literal::string(&string));
 
-                let expr_variant = &quote!(&__dict.get(&__key));
+                let expr_variant = &quote!(&__dict.get_or_nil(&__key));
                 let exprs = non_skipped_fields
                     .iter()
                     .map(|f| f.from_variant(expr_variant));

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -83,19 +83,25 @@ fn test_derive_to_variant() -> bool {
 
         let variant = data.to_variant();
         let dictionary = variant.try_to_dictionary().expect("should be dictionary");
-        assert_eq!(Some(42), dictionary.get("foo").try_to_i64());
-        assert_eq!(Some(54.0), dictionary.get("bar").try_to_f64());
+        assert_eq!(Some(42), dictionary.get("foo").and_then(|v| v.try_to_i64()));
+        assert_eq!(
+            Some(54.0),
+            dictionary.get("bar").and_then(|v| v.try_to_f64())
+        );
         assert_eq!(
             Some("*mut ()".into()),
-            dictionary.get("ptr").try_to_string()
+            dictionary.get("ptr").and_then(|v| v.try_to_string())
         );
         assert!(!dictionary.contains("skipped"));
 
         let enum_dict = dictionary
             .get("baz")
-            .try_to_dictionary()
+            .and_then(|v| v.try_to_dictionary())
             .expect("should be dictionary");
-        assert_eq!(Some(true), enum_dict.get("Foo").try_to_bool());
+        assert_eq!(
+            Some(true),
+            enum_dict.get("Foo").and_then(|v| v.try_to_bool())
+        );
 
         assert_eq!(
             Ok(ToVar::<f64, i128> {
@@ -146,7 +152,7 @@ fn test_derive_owned_to_variant() -> bool {
         let dictionary = variant.try_to_dictionary().expect("should be dictionary");
         let array = dictionary
             .get("arr")
-            .try_to_array()
+            .and_then(|v| v.try_to_array())
             .expect("should be array");
         assert_eq!(3, array.len());
         assert_eq!(


### PR DESCRIPTION
For some strange reason `godot_dictionary_get` calls `Dictionary::operator[]` instead of `Dictionary::get`, which ends up inserting `Nil` if the key doesn't already exist in the dictionary.
https://github.com/godotengine/godot/blame/3.3/modules/gdnative/gdnative/dictionary.cpp#L126
This means it is unsound to call `godot_dictionary_get` on a `Dictionary<Shared>`. This PR re-implements godot-rust's `Dictionary::get` in terms of `godot_dictionary_get_with_default` (the behavior originally intended and likely expected by most Rust users), and adds `Dictionary::get_or_insert_nil` to provide the original behavior if it is indeed desired, but only on `Dictionary<T: LocalThreadAccess>` and an `unsafe` counterpart for `Dictionary<Shared>`, like the other mutating functions on `Dictionary`. 

I also updated the documentation of `get_ref` and `get_mut_ref` since they call `operator[]`. Perhaps they should also be moved to non-shared access, but I figured that's less important since they're unsafe anyway?

I also added `try_get` and `get_non_nil` while I was at it, to simplify checking if a key exists and checking that its corresponding value is not `Nil` respectively.