### PR TITLE
Allow the use of the new Android ndk paths

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -195,35 +195,18 @@ jobs:
         #  rust: ${{ matrix.rust.toolchain }}
       - name: "Install Java + NDK"
         run: |
-          export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64;
-          export ANDROID_SDK_ROOT=/opt/ndk/android-ndk-r21d;
           # aarch64 and armv7 cover most Android phones & tablets.;
           rustup target add aarch64-linux-android armv7-linux-androideabi;
           sudo apt-get update;
-          sudo apt-get install openjdk-8-jdk;
           sudo apt-get install llvm-dev libclang-dev clang g++-multilib gcc-multilib libc6-dev libc6-dev-arm64-cross;
-          # Downloading NDK. This file is huge (1Gb) maybe extract only what's needed and repackage.;
-          # See https://developer.android.com/ndk/downloads for updates.;
-          # The Android SDK which comes with Android Studio is not required. Only Java + NDK are.;
-          mkdir /opt/ndk
-          install -d /opt/ndk;
-          cd /opt/ndk && wget -nc -nv https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip && cd $GITHUB_WORKSPACE;
-          echo "bcf4023eb8cb6976a4c7cff0a8a8f145f162bf4d  /opt/ndk/android-ndk-r21d-linux-x86_64.zip" >> /opt/ndk/SHA1SUM.txt;
-          sha1sum --check /opt/ndk/SHA1SUM.txt;
-          cd /opt/ndk && unzip -q android-ndk-r21d-linux-x86_64.zip && cd $GITHUB_WORKSPACE;
-          # Using clang linker from NDK when building Android programs.;
-          install -d $HOME/.cargo;
-          echo >> $HOME/.cargo/config;
-          echo "[target.aarch64-linux-android]" >> $HOME/.cargo/config;
-          find /opt/ndk -name aarch64-linux-android21-clang++ -printf 'linker = "%p"\n' >> $HOME/.cargo/config;
-          echo >> $HOME/.cargo/config;
-          echo "[target.armv7-linux-androideabi]" >> $HOME/.cargo/config;
-          find /opt/ndk -name armv7a-linux-androideabi21-clang++ -printf 'linker = "%p"\n' >> $HOME/.cargo/config;
-          echo >> $HOME/.cargo/config;
       - name: "Build Rust for targets: aarch64-linux-android, armv7-linux-androideabi"
         run: |
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++
+          export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang++
           cargo build --target aarch64-linux-android --release;
           cargo build --target armv7-linux-androideabi --release;
+        env:
+          ANDROID_NDK_VERSION: 21.4.7075529
 
   integration-test-godot:
     name: itest-godot-${{ matrix.godot }}${{ matrix.postfix }}

--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -19,3 +19,4 @@ bindgen = { version = "0.59.1", default-features = false, features = ["runtime"]
 proc-macro2 = "1.0.30"
 quote = "1.0.10"
 miniserde = "0.1.15"
+semver = "1.0.4"


### PR DESCRIPTION
Hi,

As said in #345 comments, ndk is now installed in the `ndk` folder and the `ndk-bundle` folder installation is obsolete (as shown in the SDK Manager of Android studio).
![image](https://user-images.githubusercontent.com/8122888/123173493-fbc6a700-d47e-11eb-9528-20b49f30b0e9.png)

The new way allow multiple ndk to be installed in parallel.
If there is only one available, the build script pick this one.
If multiple NDK versions are installed, you can specify one with the `ANDROID_NDK_VERSION` env var.

It still fallbacks to the `ndk-bundle` folder just to maintain old behaviour.

I added a check that the ndk is present too, and panic if absent, as it's needed for the headers.

Feel free to ask for any modifications, I'm clearly not a rust expert.
I manually tested all the code paths on my install, but I don't know where the tests for this are written (as they are not present in #345 PR).