### PR TITLE
Fixing bug of fn rotated in Vector3

### DIFF
--- a/gdnative-core/src/core_types/geom/basis.rs
+++ b/gdnative-core/src/core_types/geom/basis.rs
@@ -571,8 +571,9 @@ impl Basis {
     }
 }
 
-impl core::ops::Mul<Basis> for Basis {
+impl Mul<Basis> for Basis {
     type Output = Self;
+
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         Basis::from_elements([
@@ -600,7 +601,7 @@ impl Mul<Vector3> for Basis {
 
     #[inline]
     fn mul(self, rhs: Self::Output) -> Self::Output {
-        Self::Output::new(self.tdotx(rhs), self.tdoty(rhs), self.tdotz(rhs))
+        self.xform(rhs)
     }
 }
 

--- a/gdnative-core/src/core_types/vector3.rs
+++ b/gdnative-core/src/core_types/vector3.rs
@@ -534,6 +534,23 @@ godot_test!(
 mod tests {
     use crate::core_types::Vector3;
 
+    /*
+     * Test introduced due to bug in Basis * Vector3 operator
+     *
+     * matching result in GDScript:
+     * var v1 = Vector3(37.51756, 20.39467, 49.96816)
+     * var phi = -0.4927880786382844
+     * var v2 = v1.rotated(Vector3.UP, r)
+     * print(c)
+     */
+    #[test]
+    fn rotated() {
+        let v = Vector3::new(37.51756, 20.39467, 49.96816);
+        let phi = -0.4927880786382844;
+        let r = v.rotated(Vector3::UP, phi);
+        assert!(r.is_equal_approx(Vector3::new(9.414476, 20.39467, 61.77177)));
+    }
+
     #[test]
     fn it_is_copy() {
         fn copy<T: Copy>() {}

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -1017,8 +1017,10 @@ pub trait AsVariant: AsArg<<Self as AsVariant>::Target> {
 pub struct Null<T>(PhantomData<T>);
 
 impl<T: GodotObject> Null<T> {
-    /// Creates an explicitly null reference that can be used as a method argument.
+    /// Creates an explicit null reference that can be used as a method argument.
+    // TODO consider something more idiomatic, like module::null::<T>(), similar to std::ptr::null()
     #[inline]
+    #[allow(clippy::self_named_constructors)]
     pub fn null() -> Self {
         Null(PhantomData)
     }


### PR DESCRIPTION
based on related code in godot: https://github.com/godotengine/godot/blob/554c776e08c9ee35fa9e2677e02f4005c11ddbc0/core/math/vector3.cpp#L36