### PR TITLE
Silence UB warnings caused by bindgen

### DIFF
--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -1,8 +1,11 @@
-#![allow(non_snake_case)] // because of the generated bindings.
+// For silenced lints/warnings, see also gdnative-sys/src/lib.rs
+
+// Generated bindings don't follow some conventions
+#![allow(non_snake_case)]
 #![allow(unused_unsafe)]
 // False positives on generated drops that enforce lifetime
 #![allow(clippy::drop_copy)]
-// Disable non-critical lints for generated code.
+// Disable non-critical lints for generated code
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 mod generated;

--- a/gdnative-sys/src/lib.rs
+++ b/gdnative-sys/src/lib.rs
@@ -1,8 +1,14 @@
+// For silenced lints/warnings, see also gdnative-bindings/src/lib.rs
+
+// Notes:
+// * deref_nullptr: since rustc 1.53, bindgen causes UB warnings -- see https://github.com/rust-lang/rust-bindgen/issues/1651
+//   remove this once bindgen has fixed the issue (currently at version 1.59.1)
 #![allow(
     non_upper_case_globals,
     non_camel_case_types,
     non_snake_case,
     improper_ctypes,
+    deref_nullptr,
     clippy::style
 )]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Since the update to rustc 1.53, bindgen using UB causes warnings.
See https://github.com/rust-lang/rust-bindgen/issues/1651 for detail.

Warnings all in the style of:
```
warning: dereferencing a null pointer
  --> ../godot-rust/target/<toolchain>/debug/build/gdnative-sys-7023d0a45a684438/out/bindings.rs:98:19
   |
98 |         unsafe { &(*(::std::ptr::null::<godot_string>()))._dont_touch_that as *const _ as usize },
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
   |
   = note: `#[warn(deref_nullptr)]` on by default
```