### PR TITLE
Properties are now registered in order of declaration

### DIFF
--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 
-use std::collections::HashMap;
 use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Fields, Ident, Meta, MetaList, NestedMeta, Path, Stmt, Type};
 
@@ -13,7 +12,7 @@ pub(crate) struct DeriveData {
     pub(crate) base: Type,
     pub(crate) register_callback: Option<Path>,
     pub(crate) user_data: Type,
-    pub(crate) properties: HashMap<Ident, PropertyAttrArgs>,
+    pub(crate) properties: Vec<(Ident, PropertyAttrArgs)>,
     pub(crate) no_constructor: bool,
 }
 
@@ -188,7 +187,7 @@ fn parse_derive_input(input: &DeriveInput) -> Result<DeriveData, syn::Error> {
     };
 
     // Find all fields with a `#[property]` attribute
-    let mut properties = HashMap::new();
+    let mut properties = Vec::new();
 
     if let Fields::Named(names) = &struct_data.fields {
         for field in &names.named {
@@ -232,7 +231,7 @@ fn parse_derive_input(input: &DeriveInput) -> Result<DeriveData, syn::Error> {
                     .ident
                     .clone()
                     .ok_or_else(|| syn::Error::new(field.ident.span(), "Fields should be named"))?;
-                properties.insert(ident, builder.done());
+                properties.push((ident, builder.done()));
             }
         }
     };


### PR DESCRIPTION
Older change, not yet merged.

Properties exported via `#[property]` appear in arbitrary order in the editor, and the order can change on each rustc compilation. This is due to the inner workings of `HashMap`, which orders its element non-deterministically as a [security feature](https://doc.rust-lang.org/std/collections/struct.HashMap.html).

This code:
```rs
#[derive(gd::NativeClass)]
#[no_constructor]
pub struct GodotGraph {
    #[property] first: i32,
    #[property] second: bool,
    #[property] third: Color,
    #[property] fourth: Vector2,
}
```
can lead to any of these variants:

![one](https://user-images.githubusercontent.com/708488/131356360-b6d0fec0-2b51-41b6-aabc-178c4e73aacd.png)
![two](https://user-images.githubusercontent.com/708488/131356850-e53a82ee-006c-4bcf-85fc-1125009f081e.png)
![three](https://user-images.githubusercontent.com/708488/131356416-f13e677a-2f35-4702-9100-e262c34650f0.png)

This PR makes the order follow the declaration order, by using `Vec` instead of `HashMap`.

bors try