### PR TITLE
Parse Godot documentation's BBCode and translate it to RustDoc

### DIFF
--- a/bindings_generator/Cargo.toml
+++ b/bindings_generator/Cargo.toml
@@ -21,3 +21,5 @@ quote = "1.0.9"
 syn = { version = "1.0.74", features = ["full", "extra-traits", "visit"] }
 miniserde = "0.1.14"
 unindent = "0.1.7"
+regex = "1.5.4"
+memchr = "2.4" # to satisfy regex needing memchr >= 2.4

--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -357,6 +357,7 @@ pub enum Ty {
 }
 
 impl Ty {
+    // Note: there is some code duplication with GodotXmlDocs::translate_type() in class_docs.rs
     pub fn from_src(src: &str) -> Self {
         match src {
             "void" => Ty::Void,

--- a/bindings_generator/src/class_docs.rs
+++ b/bindings_generator/src/class_docs.rs
@@ -136,6 +136,7 @@ impl GodotXmlDocs {
             "String" => "GodotString",
             "Error" => "GodotError",
             "RID" => "Rid",
+            // TODO PoolVector3Array etc
             "G6DOFJointAxisParam" => "G6dofJointAxisParam",
             "G6DOFJointAxisFlag" => "G6dofJointAxisFlag",
             _ => godot_type,
@@ -152,11 +153,28 @@ impl GodotXmlDocs {
         };
 
         // TODO reuse regex across classes
+
+        // Covers:
+        // * [url=U]text[/url]
+        // * [url=U][/url]
         let url_regex = Regex::new("\\[url=(.+?)](.*?)\\[/url]").unwrap();
 
-        let type_regex = Regex::new("\\[enum ([A-Za-z0-9_]+?)]").unwrap();
+        // Covers:
+        // * [C]
+        // * [enum C]
+        let type_regex = Regex::new("\\[(enum )?([A-Za-z0-9_]+?)]").unwrap();
+
+        // Covers:
+        // * [member M]
+        // * [method M]
+        // * [constant M]
         let self_member_regex =
             Regex::new("\\[(member|method|constant) ([A-Za-z0-9_]+?)]").unwrap();
+
+        // Covers:
+        // * [member C.M]
+        // * [method C.M]
+        // * [constant C.M]
         let class_member_regex =
             Regex::new("\\[(member|method|constant) ([A-Za-z0-9_]+?)\\.([A-Za-z0-9_]+?)]").unwrap();
 
@@ -183,7 +201,7 @@ impl GodotXmlDocs {
 
         // [Type] style
         let godot_doc = type_regex.replace_all(&godot_doc, |c: &Captures| {
-            let godot_ty = &c[1];
+            let godot_ty = &c[2];
             let rust_ty = Self::to_rust_type(godot_ty);
 
             format!(

--- a/bindings_generator/src/class_docs.rs
+++ b/bindings_generator/src/class_docs.rs
@@ -211,13 +211,16 @@ impl GodotXmlDocs {
             format!("[`{member}`][Self::{member}]", member = &c[2])
         });
 
+        // Note: maybe some of the following can be expressed as regex, but if text-replace does the job reliably enough, it's even faster
         let translated = godot_doc
             .replace("[code]", "`")
             .replace("[/code]", "`")
             .replace("[codeblock]", "```gdscript")
             .replace("[/codeblock]", "```")
             .replace("[b]", "**")
-            .replace("[/b]", "**");
+            .replace("[/b]", "**")
+            .replace("[i]", "_")
+            .replace("[/i]", "_");
 
         format!("{}{}", gdscript_note, translated)
     }

--- a/bindings_generator/src/class_docs.rs
+++ b/bindings_generator/src/class_docs.rs
@@ -187,6 +187,12 @@ impl GodotXmlDocs {
         let class_member_regex =
             Regex::new("\\[(member|method|constant) ([A-Za-z0-9_]+?)\\.([A-Za-z0-9_]+?)]").unwrap();
 
+        // Covers:
+        // * [code]C[/code]
+        // * [signal C]
+        let no_link_regex =
+            Regex::new("\\[code]([^.]+?)\\[/code]|\\[signal ([A-Za-z0-9_]+?)]").unwrap();
+
         // URLs
         let godot_doc = url_regex.replace_all(&godot_doc, |c: &Captures| {
             let url = &c[1];
@@ -238,10 +244,13 @@ impl GodotXmlDocs {
             format!("[`{member}`][Self::{member}]", member = &c[2])
         });
 
+        // `member` style (no link)
+        let godot_doc = no_link_regex.replace_all(&godot_doc, |c: &Captures| {
+            format!("`{member}`", member = &c[1])
+        });
+
         // Note: maybe some of the following can be expressed as regex, but if text-replace does the job reliably enough, it's even faster
         let translated = godot_doc
-            .replace("[code]", "`")
-            .replace("[/code]", "`")
             .replace("[codeblock]", "```gdscript")
             .replace("[/codeblock]", "```")
             .replace("[b]", "**")

--- a/bindings_generator/src/class_docs.rs
+++ b/bindings_generator/src/class_docs.rs
@@ -131,12 +131,21 @@ impl GodotXmlDocs {
         );
     }
 
-    fn to_rust_type(godot_type: &str) -> &str {
+    fn translate_type(godot_type: &str) -> &str {
+        // Note: there is some code duplication with Ty::from_src() in api.rs
         match godot_type {
             "String" => "GodotString",
             "Error" => "GodotError",
             "RID" => "Rid",
-            // TODO PoolVector3Array etc
+            "AABB" => "Aabb",
+            "Array" => "VariantArray",
+            "PoolByteArray" => "ByteArray",
+            "PoolStringArray" => "StringArray",
+            "PoolVector2Array" => "Vector2Array",
+            "PoolVector3Array" => "Vector3Array",
+            "PoolColorArray" => "ColorArray",
+            "PoolIntArray" => "Int32Array",
+            "PoolRealArray" => "Float32Array",
             "G6DOFJointAxisParam" => "G6dofJointAxisParam",
             "G6DOFJointAxisFlag" => "G6dofJointAxisFlag",
             _ => godot_type,
@@ -202,7 +211,7 @@ impl GodotXmlDocs {
         // [Type] style
         let godot_doc = type_regex.replace_all(&godot_doc, |c: &Captures| {
             let godot_ty = &c[2];
-            let rust_ty = Self::to_rust_type(godot_ty);
+            let rust_ty = Self::translate_type(godot_ty);
 
             format!(
                 "[`{godot_ty}`][{rust_ty}]",
@@ -214,7 +223,7 @@ impl GodotXmlDocs {
         // [Type::member] style
         let godot_doc = class_member_regex.replace_all(&godot_doc, |c: &Captures| {
             let godot_ty = &c[2];
-            let rust_ty = Self::to_rust_type(godot_ty);
+            let rust_ty = Self::translate_type(godot_ty);
 
             format!(
                 "[`{godot_ty}.{member}`][{rust_ty}::{member}]",


### PR DESCRIPTION
Closes #590.

Parse Godot documentation's BBCode and translate it to RustDoc, so that our API doc looks nicer. In particular, many intra-doc links are now recognized. As a result, it's now much easier to navigate through the GDNative bindings' doc.

The parser is not perfect, there are also some missing parts, but it should already be a big improvement over weird BBCode syntax.

bors try