### PR TITLE
Extend safe name filter to support Godot 3.4 API

### DIFF
--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -166,6 +166,7 @@ fn rust_safe_name(name: &str) -> proc_macro2::Ident {
         "in" => format_ident!("_in"),
         "override" => format_ident!("_override"),
         "where" => format_ident!("_where"),
+        "enum" => format_ident!("_enum"),
         name => format_ident!("{}", name),
     }
 }

--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -346,7 +346,7 @@ pub(crate) fn generate_methods(
 
         icalls.insert(icall_name.clone(), method_sig);
 
-        let rusty_name = format_ident!("{}", rusty_method_name);
+        let rusty_name = rust_safe_name(rusty_method_name);
 
         let maybe_unsafe: TokenStream;
         let maybe_unsafe_reason: &str;


### PR DESCRIPTION
This PR adds 'enum' keyword to rust_safe_name filter and also makes use of this filter for rusty_method_name variable in bindings generator. It allows to build godot-rust with latest stable Godot 3.4 API.

A bit of context: when trying to build bindings for latest stable Godot API, the following errors are produced:
```
error: expected expression, found keyword `enum`
1972 | ..., self . this . sys () . as_ptr () , class . into () , enum . into () , no_inheritance) ; StringArray :: from_sys (ret) } } # [doc = "...
     |                                                           ^^^^ expected expression

error: expected identifier, found keyword `type`
2302 | ... } # [doc = ""] # [doc = ""] # [inline] pub fn type (& self) -> GodotString { unsafe { let method_bind : * mut sys :: godot_method_bin...
     |                                                   ^^^^ expected identifier, found keyword
```
It seems that newer API version introduces more keyword collisions which this patch aims to fix.