### PR TITLE
Re-organize Variant conversion methods

### DIFF
--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -628,11 +628,6 @@ mod varargs_call {
                             let #name: Variant = Variant::from_object_ptr(#name);
                         }
                     }
-                    Ty::String => {
-                        quote! {
-                            let #name: Variant = Variant::from_godot_string(&#name);
-                        }
-                    }
                     _ => {
                         quote! {
                            let #name: Variant = (&#name).to_variant();
@@ -704,11 +699,6 @@ mod varcall {
                 Ty::Object(_) => {
                     quote! {
                         let #name: Variant = Variant::from_object_ptr(#name);
-                    }
-                }
-                Ty::String => {
-                    quote! {
-                        let #name: Variant = Variant::from_godot_string(&#name);
                     }
                 }
                 _ => {

--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -46,7 +46,7 @@ impl ServerPuppet {
 
     #[export]
     fn on_connected_to_server(&mut self, owner: TRef<Node>) {
-        owner.rpc("greet_server", &[Variant::from_str("hello")]);
+        owner.rpc("greet_server", &[Variant::new("hello")]);
     }
 
     #[export(rpc = "puppet")]

--- a/examples/rpc/src/server.rs
+++ b/examples/rpc/src/server.rs
@@ -38,7 +38,7 @@ impl Server {
         owner.rpc_id(
             tree.get_rpc_sender_id(),
             "return_greeting",
-            &[Variant::from_str("hello")],
+            &[Variant::new("hello")],
         );
     }
 }

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -140,13 +140,9 @@ fn update_panel(owner: &Spatial, num_children: i64) {
         let panel_node = unsafe { panel_node.assume_safe() };
 
         // Put the Node
-        let mut as_variant = Variant::from_object(panel_node);
-        let result = unsafe {
-            as_variant.call(
-                "set_num_children",
-                &[Variant::from_u64(num_children as u64)],
-            )
-        };
+        let mut as_variant = Variant::new(panel_node);
+        let result =
+            unsafe { as_variant.call("set_num_children", &[Variant::new(num_children as u64)]) };
 
         match result {
             Ok(_) => godot_print!("Called Panel OK."),

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -22,7 +22,7 @@ impl SignalEmitter {
             // Argument list used by the editor for GUI and generation of GDScript handlers. It can be omitted if the signal is only used from code.
             args: &[SignalArgument {
                 name: "data",
-                default: Variant::from_i64(100),
+                default: Variant::new(100),
                 export_info: ExportInfo::new(VariantType::I64),
                 usage: PropertyUsage::DEFAULT,
             }],
@@ -48,7 +48,7 @@ impl SignalEmitter {
         if self.data % 2 == 0 {
             owner.emit_signal("tick", &[]);
         } else {
-            owner.emit_signal("tick_with_data", &[Variant::from_i64(self.data)]);
+            owner.emit_signal("tick_with_data", &[Variant::new(self.data)]);
         }
     }
 }
@@ -96,7 +96,7 @@ impl SignalSubscriber {
     fn notify_with_data(&mut self, owner: &Label, data: Variant) {
         let msg = format!(
             "Received signal \"tick_with_data\" with data {}",
-            data.try_to_u64().unwrap()
+            data.try_to::<u64>().unwrap()
         );
 
         owner.set_text(msg);

--- a/gdnative-async/src/method.rs
+++ b/gdnative-async/src/method.rs
@@ -106,14 +106,14 @@ impl<C: NativeClass, F: AsyncMethod<C>> Method<C> for Async<F> {
                         Self::site().unwrap_or_default(),
                         format_args!("unable to spawn future: {}", err),
                     );
-                    Variant::new()
+                    Variant::nil()
                 }
                 None => {
                     log::error(
                         Self::site().unwrap_or_default(),
                         format_args!("implementation did not spawn a future"),
                     );
-                    Variant::new()
+                    Variant::nil()
                 }
             }
         } else {
@@ -121,7 +121,7 @@ impl<C: NativeClass, F: AsyncMethod<C>> Method<C> for Async<F> {
                 Self::site().unwrap_or_default(),
                 "a global executor must be set before any async methods can be called on this thread",
             );
-            Variant::new()
+            Variant::nil()
         }
     }
 }

--- a/gdnative-async/src/rt/bridge.rs
+++ b/gdnative-async/src/rt/bridge.rs
@@ -125,7 +125,7 @@ impl Method<SignalBridge> for OnSignalFn {
             })
             .unwrap();
 
-        Variant::new()
+        Variant::nil()
     }
 
     fn site() -> Option<gdnative_core::log::Site<'static>> {

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -36,7 +36,7 @@ impl NativeClass for FuncState {
             name: "completed",
             args: &[SignalArgument {
                 name: "value",
-                default: Variant::new(),
+                default: Variant::nil(),
                 export_info: ExportInfo::new(VariantType::Nil),
                 usage: PropertyUsage::DEFAULT,
             }],

--- a/gdnative-core/src/core_types/dictionary.rs
+++ b/gdnative-core/src/core_types/dictionary.rs
@@ -95,13 +95,13 @@ impl<Own: Ownership> Dictionary<Own> {
     }
 
     /// Returns a copy of the element corresponding to the key, or `Nil` if it doesn't exist.
-    /// Shorthand for `self.get_or(key, Variant::new())`.
+    /// Shorthand for `self.get_or(key, Variant::nil())`.
     #[inline]
     pub fn get_or_nil<K>(&self, key: K) -> Variant
     where
         K: OwnedToVariant + ToVariantEq,
     {
-        self.get_or(key, Variant::new())
+        self.get_or(key, Variant::nil())
     }
 
     /// Update an existing element corresponding to the key.
@@ -534,12 +534,12 @@ godot_test!(test_dictionary {
     use std::collections::HashSet;
 
     use crate::core_types::VariantType;
-    let foo = Variant::from_str("foo");
-    let bar = Variant::from_str("bar");
-    let nope = Variant::from_str("nope");
+    let foo = Variant::new("foo");
+    let bar = Variant::new("bar");
+    let nope = Variant::new("nope");
 
-    let x = Variant::from_i64(42);
-    let y = Variant::from_i64(1337);
+    let x = Variant::new(42);
+    let y = Variant::new(1337);
 
     let dict = Dictionary::new();
 
@@ -551,7 +551,7 @@ godot_test!(test_dictionary {
     assert!(!dict.contains(&nope));
 
     let keys_array = dict.keys();
-    let baz = Variant::from_str("baz");
+    let baz = Variant::new("baz");
     keys_array.push(&baz);
     dict.insert(&baz, &x);
 
@@ -561,14 +561,14 @@ godot_test!(test_dictionary {
 
     assert!(!dict.contains_all(&keys_array));
 
-    let variant = Variant::from_dictionary(&dict.duplicate().into_shared());
+    let variant = Variant::new(&dict.duplicate().into_shared());
     assert!(variant.get_type() == VariantType::Dictionary);
 
     let dict2 = dict.duplicate();
     assert!(dict2.contains(&foo));
     assert!(dict2.contains(&bar));
 
-    if let Some(dic_variant) = variant.try_to_dictionary() {
+    if let Ok(dic_variant) = variant.try_to::<Dictionary>() {
         assert!(dic_variant.len() == dict.len());
     } else {
         panic!("variant should be a Dictionary");

--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -695,13 +695,13 @@ godot_test!(test_string {
     assert_eq!(index_string[1], 'a');
     assert_eq!(index_string[2], 'r');
 
-    let variant = Variant::from_godot_string(&foo);
+    let variant = Variant::new(&foo);
     assert!(variant.get_type() == VariantType::GodotString);
 
     let variant2: Variant = "foo".to_variant();
     assert!(variant == variant2);
 
-    if let Some(foo_variant) = variant.try_to_godot_string() {
+    if let Ok(foo_variant) = variant.try_to::<GodotString>() {
         assert!(foo_variant == foo);
     } else {
         panic!("variant should be a GodotString");

--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -616,6 +616,9 @@ godot_test!(
     test_array_debug {
         use std::panic::catch_unwind;
 
+        println!("  -- expected 4 'Index 3 out of bounds (len 3)' error messages for edge cases");
+        println!("  -- the test is successful when and only when these errors are shown");
+
         let arr = VariantArray::new(); // []
         arr.push(&Variant::new("hello world"));
         arr.push(&Variant::new(true));

--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -528,9 +528,9 @@ impl<T: ToVariant, Own: LocalThreadOwnership> Extend<T> for VariantArray<Own> {
 }
 
 godot_test!(test_array {
-    let foo = Variant::from_str("foo");
-    let bar = Variant::from_str("bar");
-    let nope = Variant::from_str("nope");
+    let foo = Variant::new("foo");
+    let bar = Variant::new("bar");
+    let nope = Variant::new("nope");
 
     let array = VariantArray::new(); // []
 
@@ -555,9 +555,9 @@ godot_test!(test_array {
     array.pop(); // [&bar]
     array.pop(); // []
 
-    let x = Variant::from_i64(42);
-    let y = Variant::from_i64(1337);
-    let z = Variant::from_i64(512);
+    let x = Variant::new(42);
+    let y = Variant::new(1337);
+    let z = Variant::new(512);
 
     array.insert(0, &x); // [&x]
     array.insert(0, &y); // [&y, &x]
@@ -590,13 +590,13 @@ godot_test!(test_array {
 
     let array3 = VariantArray::new(); // []
 
-    array3.push(&Variant::from_i64(42));
-    array3.push(&Variant::from_i64(1337));
-    array3.push(&Variant::from_i64(512));
+    array3.push(&Variant::new(42));
+    array3.push(&Variant::new(1337));
+    array3.push(&Variant::new(512));
 
     assert_eq!(
         &[42, 1337, 512],
-        array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
+        array3.iter().map(|v| v.try_to::<i64>().unwrap()).collect::<Vec<_>>().as_slice(),
     );
 
     let array4 = VariantArray::new(); // []
@@ -606,10 +606,10 @@ godot_test!(test_array {
     array5.push(array4); // [[&foo, &bar]]
 
     let array6 = array5.duplicate_deep(); // [[&foo, &bar]]
-    unsafe { array5.get(0).to_array().assume_unique().pop(); } // [[&foo]]
+    unsafe { array5.get(0).coerce_to::<VariantArray>().assume_unique().pop(); } // [[&foo]]
 
-    assert!(!array5.get(0).to_array().contains(&bar));
-    assert!(array6.get(0).to_array().contains(&bar));
+    assert!(!array5.get(0).coerce_to::<VariantArray>().contains(&bar));
+    assert!(array6.get(0).coerce_to::<VariantArray>().contains(&bar));
 });
 
 godot_test!(
@@ -617,9 +617,9 @@ godot_test!(
         use std::panic::catch_unwind;
 
         let arr = VariantArray::new(); // []
-        arr.push(&Variant::from_str("hello world"));
-        arr.push(&Variant::from_bool(true));
-        arr.push(&Variant::from_i64(42));
+        arr.push(&Variant::new("hello world"));
+        arr.push(&Variant::new(true));
+        arr.push(&Variant::new(42));
 
         assert_eq!(format!("{:?}", arr), "[GodotString(hello world), Bool(True), I64(42)]");
 
@@ -637,7 +637,7 @@ godot_test!(
 
 // TODO: clear arrays without affecting clones
 //godot_test!(test_array_clone_clear {
-//    let foo = Variant::from_str("foo");
+//    let foo = Variant::new("foo");
 //    let mut array = VariantArray::new();
 //
 //    array.push(&foo);

--- a/gdnative-core/src/export/class_builder.rs
+++ b/gdnative-core/src/export/class_builder.rs
@@ -143,7 +143,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     ///     fn call(&self, this: TInstance<'_, MyType, Shared>, _args: Varargs<'_>) -> Variant {
     ///         this.map(|obj: &MyType, _| {
     ///             let result = obj.my_method();
-    ///             Variant::from_i64(result)
+    ///             Variant::new(result)
     ///         }).expect("method call succeeds")
     ///     }
     /// }

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -62,7 +62,7 @@ macro_rules! godot_wrap_method_inner {
                         .unwrap_or_else(|err| {
                             $crate::godot_error!("gdnative-core: method call failed with error: {}", err);
                             $crate::godot_error!("gdnative-core: check module level documentation on gdnative::user_data for more information");
-                            $crate::core_types::Variant::new()
+                            $crate::core_types::Variant::nil()
                         })
                 }
 

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -200,7 +200,7 @@ impl<C: NativeClass, F: StaticArgsMethod<C>> Method<C> for StaticArgs<F> {
             Ok(parsed) => {
                 if let Err(err) = args.done() {
                     err.with_site(F::site().unwrap_or_default()).log_error();
-                    return Variant::new();
+                    return Variant::nil();
                 }
                 F::call(&self.f, this, parsed)
             }
@@ -208,7 +208,7 @@ impl<C: NativeClass, F: StaticArgsMethod<C>> Method<C> for StaticArgs<F> {
                 for err in errors {
                     err.with_site(F::site().unwrap_or_default()).log_error();
                 }
-                Variant::new()
+                Variant::nil()
             }
         }
     }
@@ -561,7 +561,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
                 C::class_name(),
             ),
         );
-        return Variant::new().forget();
+        return Variant::nil().forget();
     }
 
     let this = match std::ptr::NonNull::new(this) {
@@ -574,7 +574,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
                     C::class_name(),
                 ),
             );
-            return Variant::new().forget();
+            return Variant::nil().forget();
         }
     };
 
@@ -596,7 +596,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
                 F::site().unwrap_or_default(),
                 "gdnative-core: method panicked (check stderr for output)",
             );
-            Variant::new()
+            Variant::nil()
         })
         .forget()
 }

--- a/gdnative-core/src/export/property/accessor.rs
+++ b/gdnative-core/src/export/property/accessor.rs
@@ -296,7 +296,7 @@ where
                     "gdnative-core: user data pointer for {} is null (did the constructor fail?)",
                     C::class_name(),
                 );
-                return Variant::new().forget();
+                return Variant::nil().forget();
             }
 
             let this = match NonNull::new(this) {
@@ -306,7 +306,7 @@ where
                         "gdnative-core: owner pointer for {} is null",
                         C::class_name(),
                     );
-                    return Variant::new().forget();
+                    return Variant::nil().forget();
                 }
             };
 
@@ -319,14 +319,14 @@ where
                     Ok(variant) => variant.forget(),
                     Err(err) => {
                         godot_error!("gdnative-core: cannot call property getter: {:?}", err);
-                        Variant::new().forget()
+                        Variant::nil().forget()
                     }
                 }
             });
 
             result.unwrap_or_else(|_| {
                 godot_error!("gdnative-core: property getter panicked (check stderr for output)");
-                Variant::new().forget()
+                Variant::nil().forget()
             })
         }
         get.get_func = Some(invoke::<SelfArg, RetKind, C, F, T>);

--- a/gdnative-core/src/export/property/invalid_accessor.rs
+++ b/gdnative-core/src/export/property/invalid_accessor.rs
@@ -70,7 +70,7 @@ extern "C" fn invalid_getter(
         property_name,
         class_name
     );
-    Variant::new().forget()
+    Variant::nil().forget()
 }
 
 extern "C" fn invalid_free_func(data: *mut libc::c_void) {

--- a/gdnative-core/src/object/instance.rs
+++ b/gdnative-core/src/object/instance.rs
@@ -177,7 +177,7 @@ impl<T: NativeClass> Instance<T, Unique> {
             let variant = Variant::from_sys(variant);
 
             let owner = variant
-                .try_to_object::<T::Base>()
+                .to_object::<T::Base>()
                 .expect("the engine should return a base object of the correct type")
                 .assume_unique();
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -75,7 +75,7 @@ pub extern "C" fn run_tests(
     status &= test_variant_ops::run_tests();
     status &= test_vararray_return::run_tests();
 
-    gdnative::core_types::Variant::from_bool(status).forget()
+    gdnative::core_types::Variant::new(status).forget()
 }
 
 fn test_underscore_method_binding() -> bool {
@@ -84,7 +84,7 @@ fn test_underscore_method_binding() -> bool {
     let ok = std::panic::catch_unwind(|| {
         let script = gdnative::api::NativeScript::new();
         let result = script._new(&[]);
-        assert_eq!(Variant::new(), result);
+        assert_eq!(Variant::nil(), result);
     })
     .is_ok();
 
@@ -139,7 +139,7 @@ impl Foo {
 
     #[export]
     fn choose_variant(&self, _owner: &Reference, a: i32, what: Variant, b: f64) -> Variant {
-        let what = what.try_to_string().expect("should be string");
+        let what = what.try_to::<String>().expect("should be string");
         match what.as_str() {
             "int" => a.to_variant(),
             "float" => b.to_variant(),
@@ -157,7 +157,7 @@ fn test_rust_class_construction() -> bool {
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));
 
         let base = foo.into_base();
-        assert_eq!(Some(42), unsafe { base.call("answer", &[]).try_to_i64() });
+        assert_eq!(Some(42), unsafe { base.call("answer", &[]).to() });
 
         let foo = Instance::<Foo, _>::try_from_base(base).expect("should be able to downcast");
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(&*owner) }));

--- a/test/src/test_free_ub.rs
+++ b/test/src/test_free_ub.rs
@@ -55,7 +55,7 @@ fn test_owner_free_ub() -> bool {
             let bar = Bar(42, Arc::clone(&drop_counter)).emplace();
 
             assert_eq!(Some(true), unsafe {
-                bar.base().call("set_script_is_not_ub", &[]).try_to_bool()
+                bar.base().call("set_script_is_not_ub", &[]).to()
             });
 
             bar.into_base().free();
@@ -65,7 +65,7 @@ fn test_owner_free_ub() -> bool {
             let bar = Bar(42, Arc::clone(&drop_counter)).emplace();
 
             assert_eq!(Some(true), unsafe {
-                bar.base().call("free_is_not_ub", &[]).try_to_bool()
+                bar.base().call("free_is_not_ub", &[]).to()
             });
         }
 

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -35,7 +35,7 @@ impl NativeClass for RegisterSignal {
             name: "progress",
             args: &[SignalArgument {
                 name: "amount",
-                default: Variant::new(),
+                default: Variant::nil(),
                 export_info: ExportInfo::new(VariantType::I64),
                 usage: PropertyUsage::DEFAULT,
             }],
@@ -90,21 +90,15 @@ fn test_register_property() -> bool {
 
         let base = obj.into_base();
 
-        assert_eq!(Some(42), unsafe {
-            base.call("get_value", &[]).try_to_i64()
-        });
+        assert_eq!(Some(42), unsafe { base.call("get_value", &[]).to() });
 
         base.set("value", 54.to_variant());
 
-        assert_eq!(Some(54), unsafe {
-            base.call("get_value", &[]).try_to_i64()
-        });
+        assert_eq!(Some(54), unsafe { base.call("get_value", &[]).to() });
 
         unsafe { base.call("set_value", &[4242.to_variant()]) };
 
-        assert_eq!(Some(4242), unsafe {
-            base.call("get_value", &[]).try_to_i64()
-        });
+        assert_eq!(Some(4242), unsafe { base.call("get_value", &[]).to() });
     })
     .is_ok();
 
@@ -190,7 +184,7 @@ fn test_advanced_methods() -> bool {
             i32::from_variant(unsafe {
                 &thing.call(
                     "add_ints",
-                    &[1.to_variant(), 2.to_variant(), Variant::new()],
+                    &[1.to_variant(), 2.to_variant(), Variant::nil()],
                 )
             })
             .unwrap()
@@ -212,7 +206,7 @@ fn test_advanced_methods() -> bool {
             f32::from_variant(unsafe {
                 &thing.call(
                     "add_floats",
-                    &[(5.0).to_variant(), (-2.5).to_variant(), Variant::new()],
+                    &[(5.0).to_variant(), (-2.5).to_variant(), Variant::nil()],
                 )
             })
             .unwrap()
@@ -224,7 +218,7 @@ fn test_advanced_methods() -> bool {
                 &[
                     Vector2::new(5.0, -5.0).to_variant(),
                     Vector2::new(-2.5, 2.5).to_variant(),
-                    Variant::new(),
+                    Variant::nil(),
                 ],
             )
         })

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -59,18 +59,11 @@ fn test_variant_call_args() -> bool {
 
         assert_eq!(Some(42), call_i64(&mut base, "zero", &[]));
 
-        assert_eq!(
-            Some(126),
-            call_i64(&mut base, "one", &[Variant::from_i64(3)])
-        );
+        assert_eq!(Some(126), call_i64(&mut base, "one", &[Variant::new(3)]));
 
         assert_eq!(
             Some(-10),
-            call_i64(
-                &mut base,
-                "two",
-                &[Variant::from_i64(-1), Variant::from_i64(32)]
-            )
+            call_i64(&mut base, "two", &[Variant::new(-1), Variant::new(32)])
         );
 
         assert_eq!(
@@ -78,11 +71,7 @@ fn test_variant_call_args() -> bool {
             call_i64(
                 &mut base,
                 "three",
-                &[
-                    Variant::from_i64(-2),
-                    Variant::from_i64(4),
-                    Variant::from_i64(8),
-                ]
+                &[Variant::new(-2), Variant::new(4), Variant::new(8),]
             )
         );
     })
@@ -98,5 +87,5 @@ fn test_variant_call_args() -> bool {
 fn call_i64(variant: &mut Variant, method: &str, args: &[Variant]) -> Option<i64> {
     let result = unsafe { variant.call(method, args) };
 
-    result.unwrap().try_to_i64()
+    result.unwrap().to()
 }


### PR DESCRIPTION
Inherent conversion methods are now genericized into `new`, `to`, `try_to`, and `coerce_to`, to reduce the clutter and make other `Variant` methods more discoverable in docs.

- `new` replaces the `from_*` methods. The original version that returns nil variants is renamed to `Variant::nil`, to better reflect its behavior.
- `to` and `try_to` replaces the `try_to_*` methods, with naming more consistent with the rest of the Rust ecosystem.
- `to_object` and `try_to_object` are kept for convenience around `Ref`.
- `coerce_to` replaces the `to_*` methods. A new trait `CoerceFromVariant` is introduced and implemented for all GDScript built-in types.
- Documentation is updated around convertion methods/traits to highlight what is used for exported methods.

Close #774

Rare PR with negative LoC
