### PR TITLE
Implement some methods of the Transform API

### DIFF
--- a/gdnative-core/src/core_types/geom/transform.rs
+++ b/gdnative-core/src/core_types/geom/transform.rs
@@ -1,3 +1,5 @@
+use std::ops::Mul;
+
 use crate::core_types::{Basis, Vector3};
 
 /// 3D Transformation (3x4 matrix) Using basis + origin representation.
@@ -11,6 +13,13 @@ pub struct Transform {
     pub basis: Basis,
     /// The translation offset of the transform.
     pub origin: Vector3,
+}
+
+impl Default for Transform {
+    #[inline]
+    fn default() -> Self {
+        Self::IDENTITY
+    }
 }
 
 impl Transform {
@@ -28,11 +37,102 @@ impl Transform {
         unsafe { std::mem::transmute::<sys::godot_transform, Self>(c) }
     }
 
+    pub const IDENTITY: Transform = Transform {
+        basis: Basis::identity(),
+        origin: Vector3::ZERO,
+    };
+
+    /// Creates a new transform from its three basis vectors and origin.
     #[inline]
-    pub fn translate(origin: Vector3) -> Transform {
-        Transform {
-            basis: Basis::identity(),
+    pub fn from_axis_origin(
+        x_axis: Vector3,
+        y_axis: Vector3,
+        z_axis: Vector3,
+        origin: Vector3,
+    ) -> Self {
+        Self {
             origin,
+            basis: Basis::from_elements([x_axis, y_axis, z_axis]),
         }
+    }
+
+    /// Returns this transform, with its origin moved by a certain `translation`
+    #[inline]
+    pub fn translated(&self, translation: Vector3) -> Transform {
+        Self {
+            origin: self.origin + translation,
+            basis: self.basis,
+        }
+    }
+
+    /// Returns a vector transformed (multiplied) by the matrix.
+    #[inline]
+    pub fn xform(&self, v: Vector3) -> Vector3 {
+        self.basis.xform(v) + self.origin
+    }
+
+    /// Returns a vector transformed (multiplied) by the transposed basis
+    /// matrix.
+    ///
+    /// **Note:** This results in a multiplication by the inverse of the matrix
+    /// only if it represents a rotation-reflection.
+    #[inline]
+    pub fn xform_inv(&self, v: Vector3) -> Vector3 {
+        self.basis.xform_inv(v - self.origin)
+    }
+
+    /// Returns the inverse of the transform, under the assumption that the
+    /// transformation is composed of rotation and translation (no scaling, use
+    /// affine_inverse for transforms with scaling).
+    #[inline]
+    pub fn inverse(&self) -> Transform {
+        let basis_inv = self.basis.transposed();
+        let origin_inv = basis_inv.xform(-self.origin);
+        Transform {
+            origin: origin_inv,
+            basis: basis_inv,
+        }
+    }
+
+    /// Returns the inverse of the transform, under the assumption that the
+    /// transformation is composed of rotation, scaling and translation.
+    #[inline]
+    pub fn affine_inverse(&self) -> Transform {
+        let basis_inv = self.basis.inverted();
+        let origin_inv = basis_inv.xform(-self.origin);
+        Transform {
+            origin: origin_inv,
+            basis: basis_inv,
+        }
+    }
+
+    /// Returns a copy of the transform rotated such that its -Z axis points
+    /// towards the target position.
+    ///
+    /// The transform will first be rotated around the given up vector, and then
+    /// fully aligned to the target by a further rotation around an axis
+    /// perpendicular to both the target and up vectors.
+    #[inline]
+    pub fn looking_at(&self, target: Vector3, up: Vector3) -> Transform {
+        let up = up.normalized();
+        let v_z = (self.origin - target).normalized();
+        let v_x = up.cross(v_z);
+        let v_y = v_z.cross(v_x);
+
+        Transform {
+            basis: Basis::from_elements([v_x, v_y, v_z]).transposed(),
+            origin: self.origin,
+        }
+    }
+}
+
+impl Mul<Transform> for Transform {
+    type Output = Transform;
+
+    #[inline]
+    fn mul(self, rhs: Transform) -> Self::Output {
+        let origin = self.xform(rhs.origin);
+        let basis = self.basis * rhs.basis;
+        Transform { origin, basis }
     }
 }


### PR DESCRIPTION
Here are some more Transform methods. I followed the same strategy as for #791, where the implementation was done by translating the C++ code to Rust.

I can also add some tests similar to the ones from the previous PR if you'd like :+1: Although the code for Transform is far simpler, because it delegates most of the implementation to `Vector3` and `Basis`.