### PR TITLE
Fix/suppress clippy lints on nightly

### DIFF
--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -5,6 +5,8 @@
 #![allow(unused_unsafe)]
 // False positives on generated drops that enforce lifetime
 #![allow(clippy::drop_copy)]
+// False positives on thread-safe singletons
+#![allow(clippy::non_send_fields_in_send_ty)]
 // Disable non-critical lints for generated code
 #![allow(clippy::style, clippy::complexity, clippy::perf)]
 

--- a/gdnative-core/src/core_types/transform2d.rs
+++ b/gdnative-core/src/core_types/transform2d.rs
@@ -360,10 +360,7 @@ fn test_transform2d_behavior_impl() {
     let rotation_rust = new_transform_rust.rotation();
     let rotation_godot = unsafe { (api.godot_transform2d_get_rotation)(new_transform_rust.sys()) };
 
-    assert!(
-        (rotation_rust - rotation_godot) < f32::EPSILON,
-        "Rotation getters should return equal results"
-    );
+    approx::assert_relative_eq!(rotation_rust, rotation_godot);
 
     let scale_rust = new_transform_rust.scale();
     let scale_godot =

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -623,7 +623,7 @@ impl Default for Variant {
 impl fmt::Debug for Variant {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{:?}({})", self.get_type(), self.to_string())
+        write!(f, "{:?}({})", self.get_type(), self)
     }
 }
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -23,7 +23,7 @@
 #![allow(
     clippy::transmute_ptr_to_ptr,
     clippy::missing_safety_doc,
-    clippy::if_then_panic
+    clippy::non_send_fields_in_send_ty
 )]
 #![cfg_attr(feature = "gd_test", allow(clippy::blacklisted_name))]
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::blacklisted_name, clippy::if_then_panic)]
+#![allow(clippy::blacklisted_name)]
 
 use gdnative::prelude::*;
 


### PR DESCRIPTION
- Modified `LocalCell<T>` so the destructor is not called on a different thread. Allowed `clippy::non_send_fields_in_send_ty` otherwise.
- Removed mentions of `if_then_panic` which is no longer a thing (`https://github.com/rust-lang/rust-clippy/pull/7810`).
- A few other minor fixes.