### PR TITLE
Instance and TInstance: Own=Shared by default

### DIFF
--- a/examples/resource/src/lib.rs
+++ b/examples/resource/src/lib.rs
@@ -26,7 +26,7 @@ struct Greeter {
     // All these traits are implemented for `Instance<T, Shared>` where the base class of `T` is reference-counted.
     // `Resource` inherits from `Reference`, so all native scripts extending `Resource` have reference-counted base classes.
     #[property]
-    greeting_resource: Option<Instance<GreetingResource, Shared>>,
+    greeting_resource: Option<Instance<GreetingResource>>,
 }
 
 #[methods]

--- a/gdnative-async/src/rt.rs
+++ b/gdnative-async/src/rt.rs
@@ -4,7 +4,6 @@ use func_state::FuncState;
 use gdnative_bindings::Object;
 use gdnative_core::core_types::{GodotError, Variant};
 use gdnative_core::init::InitHandle;
-use gdnative_core::object::ownership::Shared;
 use gdnative_core::object::{Instance, SubClass, TInstance, TRef};
 
 use crate::future;
@@ -14,7 +13,7 @@ mod func_state;
 
 /// Context for creating `yield`-like futures in async methods.
 pub struct Context {
-    func_state: Instance<FuncState, Shared>,
+    func_state: Instance<FuncState>,
     /// Remove Send and Sync
     _marker: PhantomData<*const ()>,
 }
@@ -27,11 +26,11 @@ impl Context {
         }
     }
 
-    pub(crate) fn func_state(&self) -> Instance<FuncState, Shared> {
+    pub(crate) fn func_state(&self) -> Instance<FuncState> {
         self.func_state.clone()
     }
 
-    fn safe_func_state(&self) -> TInstance<'_, FuncState, Shared> {
+    fn safe_func_state(&self) -> TInstance<'_, FuncState> {
         // SAFETY: FuncState objects are bound to their origin threads in Rust, and
         // Context is !Send, so this is safe to call within this type.
         // Non-Rust code is expected to be following the official guidelines as per

--- a/gdnative-async/src/rt/bridge.rs
+++ b/gdnative-async/src/rt/bridge.rs
@@ -8,7 +8,6 @@ use gdnative_core::core_types::{GodotError, Variant, VariantArray};
 use gdnative_core::export::user_data::{ArcData, Map};
 use gdnative_core::export::{ClassBuilder, Method, NativeClass, NativeClassMethods, Varargs};
 use gdnative_core::godot_site;
-use gdnative_core::object::ownership::Shared;
 use gdnative_core::object::{Instance, TInstance, TRef};
 
 use crate::future::Resume;
@@ -26,7 +25,7 @@ pub(super) fn terminate() {
 #[derive(Default)]
 struct Pool {
     busy: HashMap<i64, Entry>,
-    free: Vec<(i64, Instance<SignalBridge, Shared>)>,
+    free: Vec<(i64, Instance<SignalBridge>)>,
     next_id: i64,
 }
 
@@ -42,7 +41,7 @@ struct Entry {
     resume: Resume<Vec<Variant>>,
 
     // Just need to keep this alive.
-    _obj: Instance<SignalBridge, Shared>,
+    _obj: Instance<SignalBridge>,
 }
 
 pub(super) struct SignalBridge {
@@ -97,7 +96,7 @@ impl SignalBridge {
 struct OnSignalFn;
 
 impl Method<SignalBridge> for OnSignalFn {
-    fn call(&self, this: TInstance<'_, SignalBridge, Shared>, args: Varargs<'_>) -> Variant {
+    fn call(&self, this: TInstance<'_, SignalBridge>, args: Varargs<'_>) -> Variant {
         let args = args.cloned().collect();
 
         let this_persist = this.clone().claim();

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -6,7 +6,7 @@ use gdnative_core::export::{
     SignalArgument, StaticArgs, StaticArgsMethod,
 };
 use gdnative_core::godot_site;
-use gdnative_core::object::ownership::{Shared, Unique};
+use gdnative_core::object::ownership::Unique;
 use gdnative_core::object::{Instance, TInstance};
 use gdnative_derive::FromVarargs;
 
@@ -57,7 +57,7 @@ impl FuncState {
     }
 }
 
-pub(super) fn resolve(this: TInstance<'_, FuncState, Shared>, value: Variant) {
+pub(super) fn resolve(this: TInstance<'_, FuncState>, value: Variant) {
     this.script()
         .map_mut(|s| {
             match s.kind {
@@ -80,7 +80,7 @@ pub(super) fn resolve(this: TInstance<'_, FuncState, Shared>, value: Variant) {
     this.base().emit_signal("completed", &[value]);
 }
 
-pub(super) fn make_resumable(this: TInstance<'_, FuncState, Shared>, resume: Resume<Variant>) {
+pub(super) fn make_resumable(this: TInstance<'_, FuncState>, resume: Resume<Variant>) {
     let kind = this
         .script()
         .map_mut(|s| std::mem::replace(&mut s.kind, Kind::Resumable(resume)))
@@ -113,7 +113,7 @@ struct IsValidArgs {
 
 impl StaticArgsMethod<FuncState> for IsValidFn {
     type Args = IsValidArgs;
-    fn call(&self, this: TInstance<'_, FuncState, Shared>, args: Self::Args) -> Variant {
+    fn call(&self, this: TInstance<'_, FuncState>, args: Self::Args) -> Variant {
         if args.extended_check.is_some() {
             gdnative_core::log::warn(
                 Self::site().unwrap(),
@@ -145,7 +145,7 @@ struct ResumeArgs {
 
 impl StaticArgsMethod<FuncState> for ResumeFn {
     type Args = ResumeArgs;
-    fn call(&self, this: TInstance<'_, FuncState, Shared>, args: Self::Args) -> Variant {
+    fn call(&self, this: TInstance<'_, FuncState>, args: Self::Args) -> Variant {
         this.map_mut(
             |s, owner| match std::mem::replace(&mut s.kind, Kind::Pending) {
                 Kind::Resumable(resume) => {

--- a/gdnative-bindings/src/utils.rs
+++ b/gdnative-bindings/src/utils.rs
@@ -1,7 +1,6 @@
 //! Utility functions and extension traits that depend on generated bindings
 
 use gdnative_core::export::NativeClass;
-use gdnative_core::object::ownership::Shared;
 use gdnative_core::object::{SubClass, TInstance, TRef};
 
 use super::generated::{Engine, Node, SceneTree};
@@ -58,7 +57,7 @@ pub trait NodeExt {
     /// invariants must be observed for the resulting node during `'a`, if any.
     ///
     /// [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
-    unsafe fn get_node_as_instance<'a, T>(&self, path: &str) -> Option<TInstance<'a, T, Shared>>
+    unsafe fn get_node_as_instance<'a, T>(&self, path: &str) -> Option<TInstance<'a, T>>
     where
         T: NativeClass,
         T::Base: SubClass<Node>,

--- a/gdnative-core/src/export/class_builder.rs
+++ b/gdnative-core/src/export/class_builder.rs
@@ -140,7 +140,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     /// // Now, wrap the method (this can do anything and does not need to actually call a method)
     /// struct MyMethod;
     /// impl Method<MyType> for MyMethod {
-    ///     fn call(&self, this: TInstance<'_, MyType, Shared>, _args: Varargs<'_>) -> Variant {
+    ///     fn call(&self, this: TInstance<'_, MyType>, _args: Varargs<'_>) -> Variant {
     ///         this.map(|obj: &MyType, _| {
     ///             let result = obj.my_method();
     ///             Variant::new(result)

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -140,7 +140,7 @@ pub struct ScriptMethod<'l> {
 /// Safe low-level trait for stateful, variadic methods that can be called on a native script type.
 pub trait Method<C: NativeClass>: Send + Sync + 'static {
     /// Calls the method on `this` with `args`.
-    fn call(&self, this: TInstance<'_, C, Shared>, args: Varargs<'_>) -> Variant;
+    fn call(&self, this: TInstance<'_, C>, args: Varargs<'_>) -> Variant;
 
     /// Returns an optional site where this method is defined. Used for logging errors in FFI wrappers.
     ///
@@ -157,7 +157,7 @@ struct Stateless<F> {
 }
 
 impl<C: NativeClass, F: Method<C> + Copy + Default> Method<C> for Stateless<F> {
-    fn call(&self, this: TInstance<'_, C, Shared>, args: Varargs<'_>) -> Variant {
+    fn call(&self, this: TInstance<'_, C>, args: Varargs<'_>) -> Variant {
         let f = F::default();
         f.call(this, args)
     }
@@ -182,7 +182,7 @@ impl<F> StaticArgs<F> {
 /// "static method".
 pub trait StaticArgsMethod<C: NativeClass>: Send + Sync + 'static {
     type Args: FromVarargs;
-    fn call(&self, this: TInstance<'_, C, Shared>, args: Self::Args) -> Variant;
+    fn call(&self, this: TInstance<'_, C>, args: Self::Args) -> Variant;
 
     /// Returns an optional site where this method is defined. Used for logging errors in FFI wrappers.
     ///
@@ -195,7 +195,7 @@ pub trait StaticArgsMethod<C: NativeClass>: Send + Sync + 'static {
 
 impl<C: NativeClass, F: StaticArgsMethod<C>> Method<C> for StaticArgs<F> {
     #[inline]
-    fn call(&self, this: TInstance<'_, C, Shared>, mut args: Varargs<'_>) -> Variant {
+    fn call(&self, this: TInstance<'_, C>, mut args: Varargs<'_>) -> Variant {
         match args.read_many::<F::Args>() {
             Ok(parsed) => {
                 if let Err(err) = args.done() {

--- a/gdnative-core/src/object/instance.rs
+++ b/gdnative-core/src/object/instance.rs
@@ -20,7 +20,7 @@ use crate::private::{get_api, ReferenceCountedClassPlaceholder};
 ///
 /// See the type-level documentation on `Ref` for more information on typed thread accesses.
 #[derive(Debug)]
-pub struct Instance<T: NativeClass, Own: Ownership> {
+pub struct Instance<T: NativeClass, Own: Ownership = Shared> {
     owner: Ref<T::Base, Own>,
     script: T::UserData,
 }
@@ -30,7 +30,7 @@ pub struct Instance<T: NativeClass, Own: Ownership> {
 ///
 /// See the type-level documentation on `Ref` for more information on typed thread accesses.
 #[derive(Debug)]
-pub struct TInstance<'a, T: NativeClass, Own: Ownership> {
+pub struct TInstance<'a, T: NativeClass, Own: Ownership = Shared> {
     owner: TRef<'a, T::Base, Own>,
     script: T::UserData,
 }

--- a/test/src/test_map_owned.rs
+++ b/test/src/test_map_owned.rs
@@ -24,7 +24,7 @@ struct VecBuilder {
 #[methods]
 impl VecBuilder {
     #[export]
-    fn append(mut self, _owner: TRef<Reference>, mut numbers: Vec<i32>) -> Instance<Self, Shared> {
+    fn append(mut self, _owner: TRef<Reference>, mut numbers: Vec<i32>) -> Instance<Self> {
         self.v.append(&mut numbers);
         Instance::emplace(Self { v: self.v }).into_shared()
     }

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -139,7 +139,7 @@ where
     C: NativeClass,
 {
     type Args = AddArgs<T>;
-    fn call(&self, _this: TInstance<'_, C, Shared>, args: AddArgs<T>) -> Variant {
+    fn call(&self, _this: TInstance<'_, C>, args: AddArgs<T>) -> Variant {
         let AddArgs { a, b, c } = args;
 
         let mut acc = a;


### PR DESCRIPTION
Simplifies most of `Instance` usages, and is consistent with `Ref`/`TRef`.

bors try