### PR TITLE
Remove deprecated symbols from v0.9

### DIFF
--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -136,7 +136,7 @@ impl MethodSig {
 }
 
 fn skip_method(method: &GodotMethod, name: &str) -> bool {
-    const METHODS: &[&str] = &["free", "reference", "unreference"];
+    const METHODS: &[&str] = &["free", "reference", "unreference", "init_ref"];
     METHODS.contains(&name) || method.is_virtual
 }
 

--- a/examples/array_export/src/lib.rs
+++ b/examples/array_export/src/lib.rs
@@ -14,25 +14,28 @@ impl ExportsArrays {
 
     fn register(builder: &ClassBuilder<Self>) {
         builder
-            .add_property::<VariantArray>("single_array")
+            .build_property::<VariantArray>("single_array")
             .with_setter(ExportsArrays::set_single_array)
             .done();
+
         builder
-            .add_property::<VariantArray>("single_array_range")
+            .build_property::<VariantArray>("single_array_range")
             .with_setter(ExportsArrays::set_single_array_range)
             .with_hint(ArrayHint::with_element_hint::<i64>(IntHint::Range(
                 RangeHint::new(-5, 5),
             )))
             .done();
+
         builder
-            .add_property::<VariantArray>("double_array")
+            .build_property::<VariantArray>("double_array")
             .with_setter(ExportsArrays::set_double_array)
             .with_hint(ArrayHint::with_element_hint::<VariantArray>(
                 ArrayHint::new(),
             ))
             .done();
+
         builder
-            .add_property::<VariantArray>("double_array_range")
+            .build_property::<VariantArray>("double_array_range")
             .with_setter(ExportsArrays::set_double_array_range)
             .with_hint(ArrayHint::with_element_hint::<VariantArray>(
                 ArrayHint::with_element_hint::<i64>(IntHint::Range(RangeHint::new(-5, 5))),

--- a/examples/array_export/src/lib.rs
+++ b/examples/array_export/src/lib.rs
@@ -14,12 +14,12 @@ impl ExportsArrays {
 
     fn register(builder: &ClassBuilder<Self>) {
         builder
-            .build_property::<VariantArray>("single_array")
+            .property::<VariantArray>("single_array")
             .with_setter(ExportsArrays::set_single_array)
             .done();
 
         builder
-            .build_property::<VariantArray>("single_array_range")
+            .property::<VariantArray>("single_array_range")
             .with_setter(ExportsArrays::set_single_array_range)
             .with_hint(ArrayHint::with_element_hint::<i64>(IntHint::Range(
                 RangeHint::new(-5, 5),
@@ -27,7 +27,7 @@ impl ExportsArrays {
             .done();
 
         builder
-            .build_property::<VariantArray>("double_array")
+            .property::<VariantArray>("double_array")
             .with_setter(ExportsArrays::set_double_array)
             .with_hint(ArrayHint::with_element_hint::<VariantArray>(
                 ArrayHint::new(),
@@ -35,7 +35,7 @@ impl ExportsArrays {
             .done();
 
         builder
-            .build_property::<VariantArray>("double_array_range")
+            .property::<VariantArray>("double_array_range")
             .with_setter(ExportsArrays::set_double_array_range)
             .with_hint(ArrayHint::with_element_hint::<VariantArray>(
                 ArrayHint::with_element_hint::<i64>(IntHint::Range(RangeHint::new(-5, 5))),

--- a/examples/dodge_the_creeps/src/hud.rs
+++ b/examples/dodge_the_creeps/src/hud.rs
@@ -9,10 +9,7 @@ pub struct Hud;
 #[methods]
 impl Hud {
     fn register_hud(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal {
-            name: "start_game",
-            args: &[],
-        });
+        builder.signal("start_game").done();
     }
 
     fn new(_owner: &CanvasLayer) -> Self {

--- a/examples/dodge_the_creeps/src/player.rs
+++ b/examples/dodge_the_creeps/src/player.rs
@@ -16,10 +16,7 @@ pub struct Player {
 #[methods]
 impl Player {
     fn register_player(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal {
-            name: "hit",
-            args: &[],
-        });
+        builder.signal("hit").done()
     }
 
     fn new(_owner: &Area2D) -> Self {

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -12,21 +12,13 @@ struct SignalEmitter {
 #[methods]
 impl SignalEmitter {
     fn register_signals(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal {
-            name: "tick",
-            args: &[],
-        });
+        builder.signal("tick").done();
 
-        builder.add_signal(Signal {
-            name: "tick_with_data",
+        builder
+            .signal("tick_with_data")
             // Argument list used by the editor for GUI and generation of GDScript handlers. It can be omitted if the signal is only used from code.
-            args: &[SignalArgument {
-                name: "data",
-                default: Variant::new(100),
-                export_info: ExportInfo::new(VariantType::I64),
-                usage: PropertyUsage::DEFAULT,
-            }],
-        });
+            .with_param_default("data", Variant::new(100))
+            .done();
     }
 
     fn new(_owner: &Node) -> Self {

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -15,7 +15,7 @@ struct RustTest {
 
 fn register_properties(builder: &ClassBuilder<RustTest>) {
     builder
-        .build_property::<String>("test/test_enum")
+        .property::<String>("test/test_enum")
         .with_hint(StringHint::Enum(EnumHint::new(vec![
             "Hello".into(),
             "World".into(),
@@ -25,7 +25,7 @@ fn register_properties(builder: &ClassBuilder<RustTest>) {
         .done();
 
     builder
-        .build_property("test/test_flags")
+        .property("test/test_flags")
         .with_hint(IntHint::Flags(EnumHint::new(vec![
             "A".into(),
             "B".into(),

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -15,7 +15,7 @@ struct RustTest {
 
 fn register_properties(builder: &ClassBuilder<RustTest>) {
     builder
-        .add_property::<String>("test/test_enum")
+        .build_property::<String>("test/test_enum")
         .with_hint(StringHint::Enum(EnumHint::new(vec![
             "Hello".into(),
             "World".into(),
@@ -25,7 +25,7 @@ fn register_properties(builder: &ClassBuilder<RustTest>) {
         .done();
 
     builder
-        .add_property("test/test_flags")
+        .build_property("test/test_flags")
         .with_hint(IntHint::Flags(EnumHint::new(vec![
             "A".into(),
             "B".into(),

--- a/gdnative-async/src/rt/bridge.rs
+++ b/gdnative-async/src/rt/bridge.rs
@@ -134,8 +134,6 @@ impl Method<SignalBridge> for OnSignalFn {
 
 impl NativeClassMethods for SignalBridge {
     fn register(builder: &ClassBuilder<Self>) {
-        builder
-            .build_method("_on_signal", OnSignalFn)
-            .done_stateless();
+        builder.method("_on_signal", OnSignalFn).done_stateless();
     }
 }

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -1,9 +1,8 @@
 use gdnative_bindings::Reference;
-use gdnative_core::core_types::{ToVariant, Variant, VariantType};
+use gdnative_core::core_types::{ToVariant, Variant};
 use gdnative_core::export::user_data::{LocalCellData, Map, MapMut};
 use gdnative_core::export::{
-    ClassBuilder, ExportInfo, NativeClass, NativeClassMethods, PropertyUsage, Signal,
-    SignalArgument, StaticArgs, StaticArgsMethod,
+    ClassBuilder, NativeClass, NativeClassMethods, StaticArgs, StaticArgsMethod,
 };
 use gdnative_core::godot_site;
 use gdnative_core::object::ownership::Unique;
@@ -32,20 +31,12 @@ impl NativeClass for FuncState {
     }
 
     fn register_properties(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal {
-            name: "completed",
-            args: &[SignalArgument {
-                name: "value",
-                default: Variant::nil(),
-                export_info: ExportInfo::new(VariantType::Nil),
-                usage: PropertyUsage::DEFAULT,
-            }],
-        });
+        builder
+            .signal("completed")
+            .with_param_untyped("value")
+            .done();
 
-        builder.add_signal(Signal {
-            name: "resumable",
-            args: &[],
-        });
+        builder.signal("resumable").done();
     }
 }
 

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -169,10 +169,10 @@ impl StaticArgsMethod<FuncState> for ResumeFn {
 impl NativeClassMethods for FuncState {
     fn register(builder: &ClassBuilder<Self>) {
         builder
-            .build_method("is_valid", StaticArgs::new(IsValidFn))
+            .method("is_valid", StaticArgs::new(IsValidFn))
             .done_stateless();
         builder
-            .build_method("resume", StaticArgs::new(ResumeFn))
+            .method("resume", StaticArgs::new(ResumeFn))
             .done_stateless();
     }
 }

--- a/gdnative-core/src/core_types/access.rs
+++ b/gdnative-core/src/core_types/access.rs
@@ -50,12 +50,12 @@ pub unsafe trait Guard: private::Sealed {
 pub unsafe trait WritePtr: Guard + private::Sealed {}
 
 pub(crate) mod private {
-    use crate::core_types::pool_array::Element;
+    use crate::core_types::PoolElement;
 
     pub trait Sealed {}
 
-    impl<'a, T: Element> Sealed for crate::core_types::pool_array::ReadGuard<'a, T> {}
-    impl<'a, T: Element> Sealed for crate::core_types::pool_array::WriteGuard<'a, T> {}
+    impl<'a, T: PoolElement> Sealed for crate::core_types::pool_array::ReadGuard<'a, T> {}
+    impl<'a, T: PoolElement> Sealed for crate::core_types::pool_array::WriteGuard<'a, T> {}
 }
 
 impl<G: Guard> MaybeUnaligned<G> {

--- a/gdnative-core/src/core_types/byte_array.rs
+++ b/gdnative-core/src/core_types/byte_array.rs
@@ -1,6 +1,8 @@
 use crate::core_types::PoolArray;
 
 /// A reference-counted vector of `u8` that uses Godot's pool allocator.
+///
+/// See [`PoolByteArray`](https://docs.godotengine.org/en/stable/classes/class_poolbytearray.html) in Godot.
 pub type ByteArray = PoolArray<u8>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/color.rs
+++ b/gdnative-core/src/core_types/color.rs
@@ -15,18 +15,6 @@ pub struct Color {
 }
 
 impl Color {
-    #[deprecated]
-    #[inline]
-    pub fn rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
-        Color { r, g, b, a }
-    }
-
-    #[deprecated]
-    #[inline]
-    pub fn rgb(r: f32, g: f32, b: f32) -> Color {
-        Color { r, g, b, a: 1.0 }
-    }
-
     #[inline]
     pub fn from_rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
         Color { r, g, b, a }

--- a/gdnative-core/src/core_types/color_array.rs
+++ b/gdnative-core/src/core_types/color_array.rs
@@ -2,6 +2,8 @@ use crate::core_types::Color;
 use crate::core_types::PoolArray;
 
 /// A reference-counted vector of `Color` that uses Godot's pool allocator.
+///
+/// See [`PoolColorArray`](https://docs.godotengine.org/en/stable/classes/class_poolcolorarray.html) in Godot.
 pub type ColorArray = PoolArray<Color>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/float32_array.rs
+++ b/gdnative-core/src/core_types/float32_array.rs
@@ -1,6 +1,8 @@
 use crate::core_types::PoolArray;
 
 /// A reference-counted vector of `f32` that uses Godot's pool allocator.
+///
+/// See [`PoolRealArray`](https://docs.godotengine.org/en/stable/classes/class_poolrealarray.html) in Godot.
 pub type Float32Array = PoolArray<f32>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/int32_array.rs
+++ b/gdnative-core/src/core_types/int32_array.rs
@@ -1,6 +1,8 @@
 use crate::core_types::PoolArray;
 
 /// A reference-counted vector of `i32` that uses Godot's pool allocator.
+///
+/// See [`PoolIntArray`](https://docs.godotengine.org/en/stable/classes/class_poolintarray.html) in Godot.
 pub type Int32Array = PoolArray<i32>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/mod.rs
+++ b/gdnative-core/src/core_types/mod.rs
@@ -37,7 +37,7 @@ pub use float32_array::*;
 pub use geom::*;
 pub use int32_array::*;
 pub use node_path::*;
-pub use pool_array::*; // TODO rename Element to something more specific
+pub use pool_array::*;
 pub use rid::*;
 pub use string::*;
 pub use string_array::*;

--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -237,15 +237,14 @@ impl GodotString {
         Self(unsafe { (get_api().godot_string_format)(&self.0, &values.0) })
     }
 
-    /// Returns the internal ffi representation of the string and consumes
-    /// the rust object without running the destructor.
+    /// Returns the internal FFI representation of the string and consumes
+    /// the Rust object without running the destructor.
     ///
-    /// This should be only used when certain that the receiving side is
-    /// responsible for running the destructor for the object, otherwise
-    /// it is leaked.
+    /// The returned object has no `Drop` implementation. The caller is
+    /// responsible of manually ensuring destruction.
     #[doc(hidden)]
     #[inline]
-    pub fn forget(self) -> sys::godot_string {
+    pub fn leak(self) -> sys::godot_string {
         let v = self.0;
         forget(self);
         v
@@ -285,7 +284,7 @@ impl GodotString {
     pub fn clone_from_sys(sys: sys::godot_string) -> Self {
         let sys_string = GodotString(sys);
         let this = sys_string.clone();
-        sys_string.forget();
+        sys_string.leak();
         this
     }
 

--- a/gdnative-core/src/core_types/string_array.rs
+++ b/gdnative-core/src/core_types/string_array.rs
@@ -2,6 +2,8 @@ use crate::core_types::GodotString;
 use crate::core_types::PoolArray;
 
 /// A reference-counted vector of `GodotString` that uses Godot's pool allocator.
+///
+/// See [`PoolStringArray`](https://docs.godotengine.org/en/stable/classes/class_poolstringarray.html) in Godot.
 pub type StringArray = PoolArray<GodotString>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -1348,7 +1348,7 @@ from_variant_from_sys!(
     impl FromVariant for Dictionary<Shared> as Dictionary : godot_variant_as_dictionary;
 );
 
-impl<T: crate::core_types::pool_array::Element> ToVariant for PoolArray<T> {
+impl<T: crate::core_types::PoolElement> ToVariant for PoolArray<T> {
     #[inline]
     fn to_variant(&self) -> Variant {
         unsafe {
@@ -1359,9 +1359,9 @@ impl<T: crate::core_types::pool_array::Element> ToVariant for PoolArray<T> {
         }
     }
 }
-impl<T: crate::core_types::pool_array::Element + Eq> ToVariantEq for PoolArray<T> {}
+impl<T: crate::core_types::PoolElement + Eq> ToVariantEq for PoolArray<T> {}
 
-impl<T: crate::core_types::pool_array::Element> FromVariant for PoolArray<T> {
+impl<T: crate::core_types::PoolElement> FromVariant for PoolArray<T> {
     #[inline]
     fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
         unsafe {

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -524,15 +524,14 @@ impl Variant {
         unsafe { &mut *(ptr as *mut variant::Variant) }
     }
 
-    /// Returns the internal ffi representation of the variant and consumes
-    /// the rust object without running the destructor.
+    /// Returns the internal FFI representation of the variant and consumes
+    /// the Rust object without running the destructor.
     ///
-    /// This should be only used when certain that the receiving side is
-    /// responsible for running the destructor for the object, otherwise
-    /// it is leaked.
+    /// The returned object has no `Drop` implementation. The caller is
+    /// responsible of manually ensuring destruction.
     #[inline]
     #[doc(hidden)]
-    pub fn forget(self) -> sys::godot_variant {
+    pub fn leak(self) -> sys::godot_variant {
         let v = self.0;
         forget(self);
         v

--- a/gdnative-core/src/core_types/vector2_array.rs
+++ b/gdnative-core/src/core_types/vector2_array.rs
@@ -2,6 +2,8 @@ use crate::core_types::PoolArray;
 use crate::core_types::Vector2;
 
 /// A reference-counted vector of `Vector2` that uses Godot's pool allocator.
+///
+/// See [`PoolVector2Array`](https://docs.godotengine.org/en/stable/classes/class_poolvector2array.html) in Godot.
 pub type Vector2Array = PoolArray<Vector2>;
 
 godot_test!(

--- a/gdnative-core/src/core_types/vector3_array.rs
+++ b/gdnative-core/src/core_types/vector3_array.rs
@@ -2,6 +2,8 @@ use crate::core_types::PoolArray;
 use crate::core_types::Vector3;
 
 /// A reference-counted vector of `Vector3` that uses Godot's pool allocator.
+///
+/// See [`PoolVector3Array`](https://docs.godotengine.org/en/stable/classes/class_poolvector3array.html) in Godot.
 pub type Vector3Array = PoolArray<Vector3>;
 
 godot_test!(

--- a/gdnative-core/src/export/class_builder.rs
+++ b/gdnative-core/src/export/class_builder.rs
@@ -76,7 +76,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     ///
     ///     fn my_register(builder: &ClassBuilder<MyType>) {
     ///         builder
-    ///             .build_method("my_method", MyMethod)
+    ///             .method("my_method", MyMethod)
     ///             .with_rpc_mode(RpcMode::RemoteSync)
     ///             .done();
     ///     }
@@ -95,11 +95,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     /// ```
     ///
     #[inline]
-    pub fn build_method<'a, F: Method<C>>(
-        &'a self,
-        name: &'a str,
-        method: F,
-    ) -> MethodBuilder<'a, C, F> {
+    pub fn method<'a, F: Method<C>>(&'a self, name: &'a str, method: F) -> MethodBuilder<'a, C, F> {
         MethodBuilder::new(self, name, method)
     }
 
@@ -128,7 +124,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     ///
     ///     fn my_register(builder: &ClassBuilder<MyType>) {
     ///         builder
-    ///             .build_property("foo")
+    ///             .property("foo")
     ///             .with_default(5)
     ///             .with_hint((-10..=30).into())
     ///             .with_getter(MyType::get_foo)
@@ -138,7 +134,7 @@ impl<C: NativeClass> ClassBuilder<C> {
     /// }
     /// ```
     #[inline]
-    pub fn build_property<'a, T>(&'a self, name: &'a str) -> PropertyBuilder<'a, C, T>
+    pub fn property<'a, T>(&'a self, name: &'a str) -> PropertyBuilder<'a, C, T>
     where
         T: Export,
     {

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -12,8 +12,9 @@ use crate::object::ownership::Shared;
 use crate::object::{Ref, TInstance, TRef};
 
 /// Builder type used to register a method on a `NativeClass`.
+#[must_use = "MethodBuilder left unbuilt -- did you forget to call done() or done_stateless()?"]
 pub struct MethodBuilder<'a, C, F> {
-    class_builder: &'a super::ClassBuilder<C>,
+    class_builder: &'a ClassBuilder<C>,
     name: &'a str,
     method: F,
 
@@ -66,7 +67,7 @@ where
     F: Method<C> + Copy + Default,
 {
     /// Register the method as a stateless method. Stateless methods do not have data
-    /// pointers and destructors and is thus slightly lighter. This is intended for ZSTs,
+    /// pointers and destructors and are thus slightly lighter. This is intended for ZSTs,
     /// but can be used with any `Method` type with `Copy + Default`.
     #[inline]
     pub fn done_stateless(self) {

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -1,8 +1,5 @@
 //! Method registration
 
-// Temporary for unsafe method registration
-#![allow(deprecated)]
-
 use std::borrow::Cow;
 use std::fmt;
 use std::marker::PhantomData;
@@ -59,7 +56,7 @@ where
             free_func: Some(free_func::<F>),
         };
 
-        self.class_builder.add_method_advanced(script_method);
+        self.class_builder.add_method(script_method);
     }
 }
 
@@ -86,14 +83,11 @@ where
             free_func: None,
         };
 
-        self.class_builder.add_method_advanced(script_method);
+        self.class_builder.add_method(script_method);
     }
 }
 
-#[deprecated(
-    note = "Unsafe registration is deprecated. Use the safe, higher-level `MethodBuilder` API instead."
-)]
-pub type ScriptMethodFn = unsafe extern "C" fn(
+type ScriptMethodFn = unsafe extern "C" fn(
     *mut sys::godot_object,
     *mut libc::c_void,
     *mut libc::c_void,
@@ -118,17 +112,11 @@ impl Default for RpcMode {
     }
 }
 
-#[deprecated(
-    note = "Unsafe registration is deprecated. Use the safe, higher-level `MethodBuilder` API instead."
-)]
-pub struct ScriptMethodAttributes {
+pub(crate) struct ScriptMethodAttributes {
     pub rpc_mode: RpcMode,
 }
 
-#[deprecated(
-    note = "Unsafe registration is deprecated. Use the safe, higher-level `MethodBuilder` API instead."
-)]
-pub struct ScriptMethod<'l> {
+pub(crate) struct ScriptMethod<'l> {
     pub name: &'l str,
     pub method_ptr: Option<ScriptMethodFn>,
     pub attributes: ScriptMethodAttributes,

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -549,7 +549,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
                 C::class_name(),
             ),
         );
-        return Variant::nil().forget();
+        return Variant::nil().leak();
     }
 
     let this = match std::ptr::NonNull::new(this) {
@@ -562,7 +562,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
                     C::class_name(),
                 ),
             );
-            return Variant::nil().forget();
+            return Variant::nil().leak();
         }
     };
 
@@ -586,7 +586,7 @@ unsafe extern "C" fn method_wrapper<C: NativeClass, F: Method<C>>(
             );
             Variant::nil()
         })
-        .forget()
+        .leak()
 }
 
 unsafe extern "C" fn free_func<F>(method_data: *mut libc::c_void) {

--- a/gdnative-core/src/export/mod.rs
+++ b/gdnative-core/src/export/mod.rs
@@ -2,18 +2,48 @@
 //!
 //! NativeScript allows users to have their own scripts in a native language (in this case Rust).
 //! It is _not_ the same as GDNative, the native interface to call into Godot.
-//!
 //! Symbols in this module allow registration, exporting and management of user-defined types
 //! which are wrapped in native scripts.
 //!
 //! If you are looking for how to manage Godot core types or classes (objects), check
 //! out the [`core_types`][crate::core_types] and [`object`][crate::object] modules, respectively.
+//!
+//! ## Init and exit hooks
+//!
+//! Three endpoints are automatically invoked by the engine during startup and shutdown:
+//!
+//! * [`godot_gdnative_init`],
+//! * [`godot_nativescript_init`],
+//! * [`godot_gdnative_terminate`],
+//!
+//! All three must be present. To quickly define all three endpoints using the default names,
+//! use [`godot_init`].
+//!
+//! ## Registering script classes
+//!
+//! [`InitHandle`] is the registry of all your exported symbols.
+//! To register script classes, call [`InitHandle::add_class()`] or [`InitHandle::add_tool_class()`]
+//! in your [`godot_nativescript_init`] or [`godot_init`] callback:
+//!
+//! ```ignore
+//! use gdnative::prelude::*;
+//!
+//! fn init(handle: InitHandle) {
+//!     handle.add_class::<HelloWorld>();
+//! }
+//!
+//! godot_init!(init);
+//! ```
+//!
+//! For full examples, see [`examples`](https://github.com/godot-rust/godot-rust/tree/master/examples)
+//! in the godot-rust repository.
 
 mod class;
 mod class_builder;
 mod macros;
 mod method;
 mod property;
+mod signal;
 
 pub(crate) mod class_registry;
 pub(crate) mod emplace;
@@ -26,3 +56,4 @@ pub use class::*;
 pub use class_builder::*;
 pub use method::*;
 pub use property::*;
+pub use signal::*;

--- a/gdnative-core/src/export/property.rs
+++ b/gdnative-core/src/export/property.rs
@@ -64,7 +64,7 @@ impl ExportInfo {
 
 /// Builder type used to register a property on a `NativeClass`.
 #[derive(Debug)]
-#[must_use]
+#[must_use = "PropertyBuilder left unbuilt -- did you forget to call done()?"]
 pub struct PropertyBuilder<'a, C, T: Export, S = InvalidSetter<'a>, G = InvalidGetter<'a>> {
     name: &'a str,
     setter: S,
@@ -161,6 +161,8 @@ where
 
     /// Provides a setter function with the signature `fn(&C, owner: C::Base, value: T)`
     /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    ///
+    /// "shr" stands for "shared reference", as opposed to the more common `&mut self`.
     #[inline]
     pub fn with_shr_setter<NS>(
         self,

--- a/gdnative-core/src/export/property/accessor.rs
+++ b/gdnative-core/src/export/property/accessor.rs
@@ -296,7 +296,7 @@ where
                     "gdnative-core: user data pointer for {} is null (did the constructor fail?)",
                     C::class_name(),
                 );
-                return Variant::nil().forget();
+                return Variant::nil().leak();
             }
 
             let this = match NonNull::new(this) {
@@ -306,7 +306,7 @@ where
                         "gdnative-core: owner pointer for {} is null",
                         C::class_name(),
                     );
-                    return Variant::nil().forget();
+                    return Variant::nil().leak();
                 }
             };
 
@@ -316,17 +316,17 @@ where
                 let func = &*(method as *const F);
 
                 match <(SelfArg, RetKind)>::map_get(&user_data, func, owner) {
-                    Ok(variant) => variant.forget(),
+                    Ok(variant) => variant.leak(),
                     Err(err) => {
                         godot_error!("gdnative-core: cannot call property getter: {:?}", err);
-                        Variant::nil().forget()
+                        Variant::nil().leak()
                     }
                 }
             });
 
             result.unwrap_or_else(|_| {
                 godot_error!("gdnative-core: property getter panicked (check stderr for output)");
-                Variant::nil().forget()
+                Variant::nil().leak()
             })
         }
         get.get_func = Some(invoke::<SelfArg, RetKind, C, F, T>);

--- a/gdnative-core/src/export/property/hint.rs
+++ b/gdnative-core/src/export/property/hint.rs
@@ -265,8 +265,6 @@ pub enum FloatHint<T> {
     Range(RangeHint<T>),
     /// Hints that an integer or float property should be within an exponential range.
     ExpRange(RangeHint<T>),
-    /// Hints that an integer, float or string property is an enumerated value to pick in a list.
-    Enum(EnumHint),
     /// Hints that a float property should be edited via an exponential easing function.
     ExpEasing(ExpEasingHint),
 }
@@ -282,13 +280,11 @@ where
         let hint_kind = match &self {
             FH::Range(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_RANGE,
             FH::ExpRange(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_EXP_RANGE,
-            FH::Enum(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_ENUM,
             FH::ExpEasing(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_EXP_EASING,
         };
 
         let hint_string = match self {
             FH::Range(range) | FH::ExpRange(range) => range.to_godot_hint_string(),
-            FH::Enum(e) => e.to_godot_hint_string(),
             FH::ExpEasing(e) => e.to_godot_hint_string(),
         };
 
@@ -317,13 +313,6 @@ where
     #[inline]
     fn from(range: RangeInclusive<T>) -> Self {
         Self::Range(range.into())
-    }
-}
-
-impl<T> From<EnumHint> for FloatHint<T> {
-    #[inline]
-    fn from(hint: EnumHint) -> Self {
-        Self::Enum(hint)
     }
 }
 

--- a/gdnative-core/src/export/property/invalid_accessor.rs
+++ b/gdnative-core/src/export/property/invalid_accessor.rs
@@ -70,7 +70,7 @@ extern "C" fn invalid_getter(
         property_name,
         class_name
     );
-    Variant::nil().forget()
+    Variant::nil().leak()
 }
 
 extern "C" fn invalid_free_func(data: *mut libc::c_void) {

--- a/gdnative-core/src/export/signal.rs
+++ b/gdnative-core/src/export/signal.rs
@@ -1,0 +1,109 @@
+use crate::core_types::{GodotString, Variant, VariantType};
+use crate::export::{ClassBuilder, ExportInfo, NativeClass, PropertyUsage};
+
+/// Class to construct a signal. Make sure to call [`Self::done()`] in the end.
+///
+/// Signal parameters can be added with the various `param*()` methods.
+/// Keep in mind that unlike function parameters, signal parameters (both their lengths and types)
+/// are not statically checked in Godot. The parameter signature you specify is simply to assist you
+/// in the editor UI and with auto-generation of GDScript signal handlers.
+#[must_use = "SignalBuilder left unbuilt -- did you forget to call done()?"]
+pub struct SignalBuilder<'a, C> {
+    class_builder: &'a ClassBuilder<C>,
+    name: GodotString,
+    args: Vec<SignalParam>,
+}
+
+impl<'a, C: NativeClass> SignalBuilder<'a, C> {
+    pub(super) fn new(class_builder: &'a ClassBuilder<C>, signal_name: GodotString) -> Self {
+        Self {
+            class_builder,
+            name: signal_name,
+            args: vec![],
+        }
+    }
+
+    /// Add a parameter for the signal with a name and type.
+    ///
+    /// Note that GDScript signal parameters are generally untyped and not checked at runtime.
+    /// The type is solely used for UI purposes.
+    #[inline]
+    pub fn with_param(self, parameter_name: &str, parameter_type: VariantType) -> Self {
+        self.with_param_custom(SignalParam {
+            name: parameter_name.into(),
+            default: Variant::nil(),
+            export_info: ExportInfo::new(parameter_type),
+            usage: PropertyUsage::DEFAULT,
+        })
+    }
+
+    /// Add a parameter for the signal with a name and default value.
+    ///
+    /// The type is inferred from the default value.
+    /// Note that GDScript signal parameters are generally untyped and not checked at runtime.
+    /// The type is solely used for UI purposes.
+    #[inline]
+    pub fn with_param_default(self, parameter_name: &str, default_value: Variant) -> Self {
+        let variant_type = default_value.get_type();
+
+        self.with_param_custom(SignalParam {
+            name: parameter_name.into(),
+            default: default_value,
+            export_info: ExportInfo::new(variant_type),
+            usage: PropertyUsage::DEFAULT,
+        })
+    }
+
+    /// Add a (untyped) parameter for the signal with a name.
+    ///
+    /// Types are not required or checked at runtime, but they help for editor UI and auto-generation of signal listeners.
+    #[inline]
+    pub fn with_param_untyped(self, parameter_name: &str) -> Self {
+        // Note: the use of 'Nil' to express "untyped" is not following official documentation and could be improved.
+
+        self.with_param_custom(SignalParam {
+            name: parameter_name.into(),
+            default: Variant::nil(),
+            export_info: ExportInfo::new(VariantType::Nil),
+            usage: PropertyUsage::DEFAULT,
+        })
+    }
+
+    /// Add a parameter for the signal, manually configured.
+    #[inline]
+    pub fn with_param_custom(mut self, parameter: SignalParam) -> Self {
+        self.args.push(parameter);
+        self
+    }
+
+    /// Finish registering the signal.
+    #[inline]
+    pub fn done(self) {
+        self.class_builder.add_signal(Signal {
+            name: self.name,
+            args: self.args,
+        });
+    }
+}
+
+pub(crate) struct Signal {
+    pub name: GodotString,
+    pub args: Vec<SignalParam>,
+}
+
+/// Parameter in a signal declaration.
+///
+/// Instead of providing values for each field, check out the `param*()` methods in [`SignalBuilder`].
+pub struct SignalParam {
+    /// Parameter name.
+    pub name: GodotString,
+
+    /// Default value, used when no argument is provided.
+    pub default: Variant,
+
+    /// Metadata and UI hints about exporting, e.g. parameter type.
+    pub export_info: ExportInfo,
+
+    /// In which context the signal parameter is used.
+    pub usage: PropertyUsage,
+}

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -176,8 +176,8 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///         Self {}
 ///     }
 ///     fn my_register_function(builder: &ClassBuilder<Foo>) {
-///         builder.add_signal(Signal { name: "foo", args: &[] });
-///         builder.property::<f32>("bar")
+///         builder.signal("my_sig").done();
+///         builder.property::<f32>("my_prop")
 ///             .with_getter(|_, _| 42.0)
 ///             .with_hint(FloatHint::Range(RangeHint::new(0.0, 100.0)))
 ///             .done();

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -177,7 +177,7 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///     }
 ///     fn my_register_function(builder: &ClassBuilder<Foo>) {
 ///         builder.add_signal(Signal { name: "foo", args: &[] });
-///         builder.add_property::<f32>("bar")
+///         builder.build_property::<f32>("bar")
 ///             .with_getter(|_, _| 42.0)
 ///             .with_hint(FloatHint::Range(RangeHint::new(0.0, 100.0)))
 ///             .done();

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -50,7 +50,7 @@ mod variant;
 /// impl gdnative::export::NativeClassMethods for Foo {
 ///     fn register(builder: &ClassBuilder<Self>) {
 ///         use gdnative::export::*;
-///         builder.build_method("foo", gdnative::export::godot_wrap_method!(Foo, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
+///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
 ///             .with_rpc_mode(RpcMode::Disabled)
 ///             .done_stateless();
 ///     }
@@ -177,7 +177,7 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///     }
 ///     fn my_register_function(builder: &ClassBuilder<Foo>) {
 ///         builder.add_signal(Signal { name: "foo", args: &[] });
-///         builder.build_property::<f32>("bar")
+///         builder.property::<f32>("bar")
 ///             .with_getter(|_, _| 42.0)
 ///             .with_hint(FloatHint::Range(RangeHint::new(0.0, 100.0)))
 ///             .done();

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -133,7 +133,7 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
                         fn #name ( #( #args )* ) -> #ret_ty
                     );
 
-                    #builder.build_method(#name_string, method)
+                    #builder.method(#name_string, method)
                         .with_rpc_mode(#rpc)
                         .done_stateless();
                 }

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
 
             let label = config.path.unwrap_or_else(|| format!("{}", ident));
             quote!({
-                builder.build_property(#label)
+                builder.property(#label)
                     #with_default
                     #with_hint
                     #with_usage

--- a/gdnative-derive/src/native_script.rs
+++ b/gdnative-derive/src/native_script.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
 
             let label = config.path.unwrap_or_else(|| format!("{}", ident));
             quote!({
-                builder.add_property(#label)
+                builder.build_property(#label)
                     #with_default
                     #with_hint
                     #with_usage

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -17,7 +17,7 @@ pub use gdnative_core::core_types::{
 };
 pub use gdnative_core::export::{
     ClassBuilder, ExportInfo, Method, MethodBuilder, NativeClass, NativeClassMethods,
-    PropertyUsage, Signal, SignalArgument,
+    PropertyUsage, SignalBuilder, SignalParam,
 };
 pub use gdnative_core::init::InitHandle;
 pub use gdnative_core::object::{

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -75,7 +75,7 @@ pub extern "C" fn run_tests(
     status &= test_variant_ops::run_tests();
     status &= test_vararray_return::run_tests();
 
-    gdnative::core_types::Variant::new(status).forget()
+    gdnative::core_types::Variant::new(status).leak()
 }
 
 fn test_underscore_method_binding() -> bool {

--- a/test/src/test_async.rs
+++ b/test/src/test_async.rs
@@ -93,7 +93,5 @@ impl AsyncMethod<AsyncMethods> for ResumeAddFn {
 }
 
 fn register_methods(builder: &ClassBuilder<AsyncMethods>) {
-    builder
-        .build_method("resume_add", Async::new(ResumeAddFn))
-        .done();
+    builder.method("resume_add", Async::new(ResumeAddFn)).done();
 }

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -31,15 +31,10 @@ impl NativeClass for RegisterSignal {
         RegisterSignal
     }
     fn register_properties(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal {
-            name: "progress",
-            args: &[SignalArgument {
-                name: "amount",
-                default: Variant::nil(),
-                export_info: ExportInfo::new(VariantType::I64),
-                usage: PropertyUsage::DEFAULT,
-            }],
-        });
+        builder
+            .signal("progress")
+            .with_param("amount", VariantType::I64)
+            .done();
     }
 }
 

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -61,7 +61,7 @@ impl NativeClass for RegisterProperty {
     }
     fn register_properties(builder: &ClassBuilder<Self>) {
         builder
-            .build_property("value")
+            .property("value")
             .with_default(42)
             .with_setter(RegisterProperty::set_value)
             .with_getter(RegisterProperty::get_value)
@@ -155,15 +155,15 @@ where
 
 fn register_methods(builder: &ClassBuilder<AdvancedMethods>) {
     builder
-        .build_method("add_ints", StaticArgs::new(StatefulMixin { d: 42 }))
+        .method("add_ints", StaticArgs::new(StatefulMixin { d: 42 }))
         .done();
 
     builder
-        .build_method("add_floats", StaticArgs::new(StatefulMixin { d: 4.0 }))
+        .method("add_floats", StaticArgs::new(StatefulMixin { d: 4.0 }))
         .done();
 
     builder
-        .build_method(
+        .method(
             "add_vectors",
             StaticArgs::new(StatefulMixin {
                 d: Vector2::new(1.0, 2.0),

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -61,7 +61,7 @@ impl NativeClass for RegisterProperty {
     }
     fn register_properties(builder: &ClassBuilder<Self>) {
         builder
-            .add_property("value")
+            .build_property("value")
             .with_default(42)
             .with_setter(RegisterProperty::set_value)
             .with_getter(RegisterProperty::get_value)


### PR DESCRIPTION
Changes:
* `PoolArray` type aliases: document name of Godot equivalent + API link
* `ClassBuilder`
  * Remove `add_method()`
  * Remove `add_method_advanced()` -- now private
  * Remove `add_method_with_rpc_mode()`
  * Rename `add_property()` -> `property()`
  * Rename `build_method()` -> `method()`
  * Add `signal()`
* Add `SignalBuilder` + `with_param*()` methods
* Remove `ScriptMethod`, `ScriptMethodFn`, `ScriptMethodAttributes`
* Remove `Color::rgb()`, `Color::rgba()`
* Remove `Reference::init_ref()` (unsound to call directly)
* Remove `FloatHint::Enum` (has no effect)
* Rename `Element` -> `PoolElement`
* Rename `SignalArgument` -> `SignalParam`
* Rename `String::forget()` -> `leak()`
* Rename `Variant::forget()` -> `leak()`
* Fix bug with signal parameter types annotated in builder not propagated to Godot
* Annotate 3 builders with `#[must_use]` to avoid forgetting building
   * Not done for `ClassBuilder`; it's not a builder in that sense