### PR TITLE
Feature flag for custom Godot version

### DIFF
--- a/.github/composite/godot/action.yml
+++ b/.github/composite/godot/action.yml
@@ -68,7 +68,7 @@ runs:
         if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
           exit 1;
         fi;
-        cargo build --features=type_tag_fallback;
+        cargo build --features type-tag-fallback;
         mkdir -p ./project/lib;
         cp ../target/debug/libgdnative_test.so ./project/lib/;
         ${GODOT_BIN} --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");

--- a/.github/composite/godot/action.yml
+++ b/.github/composite/godot/action.yml
@@ -1,0 +1,82 @@
+name: godot
+description: "Run Godot integration tests"
+
+inputs:
+  godot_ver:
+    required: true
+    description: "Godot version (e.g. '3.2')"
+
+  rust_toolchain:
+    required: false
+    default: 'stable'
+    description: "Rust toolchain specifier (e.g. 'nightly')"
+
+  rust_extra_args:
+    required: false
+    default: ''
+    description: "Extra command line arguments for 'cargo build', e.g. features"
+
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      uses: ./.github/composite/rust
+      with:
+        rust: ${{ inputs.rust_toolchain }}
+    - name: "Check cache for installed Godot version"
+      id: "cache-godot"
+      uses: actions/cache@v2
+      with:
+        path: ${{ runner.temp }}/godot_bin
+        key: godot-${{ runner.os }}-v${{ inputs.godot_ver }}
+    - name: "Install Godot"
+      if: steps.cache-godot.outputs.cache-hit != 'true'
+      run: |
+        wget --no-verbose "https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_ver }}/Godot_v${{ inputs.godot_ver }}-stable_linux_headless.64.zip" -O /tmp/godot.zip
+        unzip -o /tmp/godot.zip -d ${{ runner.temp }}/godot_bin
+      shell: bash
+    - name: "Set environment variable"
+      run: |
+        echo "GODOT_BIN=${{ runner.temp }}/godot_bin/Godot_v${{ inputs.godot_ver }}-stable_linux_headless.64" >> $GITHUB_ENV
+      shell: bash
+    - name: "Build godot-rust"
+      run: |
+        echo "File size of api.json -- before:"
+        stat -c %s gdnative-bindings/api.json
+        
+        #echo "CRC32 of api.json: "
+        #crc32 gdnative-bindings/api.json
+        cd test
+        cargo build ${{ inputs.rust_extra_args }}
+        
+        cd ..
+        echo "File size of api.json -- after:"
+        stat -c %s gdnative-bindings/api.json
+      shell: bash
+    - name: "Run Godot integration tests"
+      run: |
+        cd test;
+        mkdir -p ./project/lib;
+        cp ../target/debug/libgdnative_test.so ./project/lib/;
+        ${GODOT_BIN} --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
+        if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+          exit 1;
+        fi;
+        ${GODOT_BIN} -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
+        if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+          exit 1;
+        fi;
+        cargo build --features=type_tag_fallback;
+        mkdir -p ./project/lib;
+        cp ../target/debug/libgdnative_test.so ./project/lib/;
+        ${GODOT_BIN} --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
+        if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+          exit 1;
+        fi;
+        ${GODOT_BIN} -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
+        if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
+          exit 1;
+        fi;
+      shell: bash

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,13 +14,14 @@ on:
 
 
 env:
-  GDNATIVE_LIB_RS_PREFIX: |-
+  GDRUST_LIB_RS_PREFIX: |-
       //! _**Note:** This documentation refers to the [latest GitHub version](https://github.com/godot-rust/godot-rust) and is subject to change._<br>
       //! _For stable releases, visit [docs.rs/gdnative](https://docs.rs/gdnative)._
       //! <br><br>
       //!
-  GDNATIVE_DOC_REPO: git@github.com:godot-rust/docs.git
-  GDNATIVE_DOC_BRANCH: gh-pages
+  GDRUST_DOC_REPO: git@github.com:godot-rust/docs.git
+  GDRUST_DOC_BRANCH: gh-pages
+  GDRUST_FEATURES: "async,serde"
 
 
 # In the very unlikely cases where two PRs are merged, and the first 'doc' job is still running when the 2nd 'full-ci' starts,
@@ -46,13 +47,13 @@ jobs:
       - name: "Pre-process input"
         run: |
           mv ${GITHUB_WORKSPACE}/gdnative/src/lib.rs tmp_lib.rs
-          (echo "${GDNATIVE_LIB_RS_PREFIX}"; cat tmp_lib.rs) > ${GITHUB_WORKSPACE}/gdnative/src/lib.rs
+          (echo "${GDRUST_LIB_RS_PREFIX}"; cat tmp_lib.rs) > ${GITHUB_WORKSPACE}/gdnative/src/lib.rs
 
       - name: "Generate documentation"
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -p gdnative --lib --no-deps --all-features
+          args: -p gdnative --lib --no-deps --features ${GDRUST_FEATURES}
 
       # For email address, see https://github.community/t/github-actions-bot-email-address/17204
       # As search-index.js changes every time, even if source hasn't changed, this will not need 'git commit --allow-empty'
@@ -65,25 +66,25 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           mkdir doc && cd doc
-          git clone --single-branch --branch ${GDNATIVE_DOC_BRANCH} --no-checkout ${GDNATIVE_DOC_REPO} . \
-            || (git init -b ${GDNATIVE_DOC_BRANCH} && git remote add origin ${GDNATIVE_DOC_REPO})
+          git clone --single-branch --branch ${GDRUST_DOC_BRANCH} --no-checkout ${GDRUST_DOC_REPO} . \
+            || (git init -b ${GDRUST_DOC_BRANCH} && git remote add origin ${GDRUST_DOC_REPO})
 
           mv ${GITHUB_WORKSPACE}/target/doc/* .
           mv ${GITHUB_WORKSPACE}/.github/workflows/doc/* .
 
-          GDNATIVE_VERSION=$(grep -Po '^version = "\K[^"]*' ${GITHUB_WORKSPACE}/gdnative/Cargo.toml)
-          GDNATIVE_SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA}")
+          GDRUST_VERSION=$(grep -Po '^version = "\K[^"]*' ${GITHUB_WORKSPACE}/gdnative/Cargo.toml)
+          GDRUST_SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA}")
 
-          find gdnative -name .html -o -type f -print0 | xargs -0 sed -i 's/'"${GDNATIVE_VERSION}"'/master/g'
+          find gdnative -name .html -o -type f -print0 | xargs -0 sed -i 's/'"${GDRUST_VERSION}"'/master/g'
 
           git add --all
-          git commit -m "Sync doc from ${GDNATIVE_SHORT_SHA}
+          git commit -m "Sync doc from ${GDRUST_SHORT_SHA}
 
           Revision in godot-rust: ${GITHUB_SHA}"
 
       - name: "Upload"
         working-directory: doc
-        run: git push origin ${GDNATIVE_DOC_BRANCH}
+        run: git push origin ${GDRUST_DOC_BRANCH}
 
       - name: "Cleanup"
         run: shred -u ~/.ssh/id_rsa

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -34,6 +34,7 @@ env:
   # Note: using variables is limited at the moment, see https://github.com/actions/runner/issues/480
   GODOT_VER: "3.4"
   GODOT_REL: stable
+  GDRUST_FEATURES: "gdnative/async,gdnative/serde"
 
 on:
   push:
@@ -77,7 +78,7 @@ jobs:
           rust: ${{ matrix.rust.toolchain }}
           components: clippy
       - name: Check clippy
-        run: cargo clippy --workspace --all-features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
+        run: cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
 
   test:
     name: test-${{ matrix.os.name }}${{ matrix.rust.postfix }}
@@ -119,9 +120,9 @@ jobs:
         uses: ./.github/composite/llvm
         if: ${{ matrix.os.id == 'windows-latest' }}
       - name: Compile tests
-        run: cargo test --workspace --all-features --no-run;
+        run: cargo test --workspace --features ${GDRUST_FEATURES} --no-run;
       - name: Test
-        run: cargo test --workspace --all-features ${{ matrix.testflags }};
+        run: cargo test --workspace --features ${GDRUST_FEATURES} ${{ matrix.testflags }};
 
   build-release:
     name: build-release-${{ matrix.os.name }}

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -105,7 +105,7 @@ jobs:
           - rust: { toolchain: 'nightly' }
             testflags: '-- --skip ui_tests'
           - os: { id: ubuntu-latest, name: linux }
-            rust: { toolchain: '1.48', postfix: ' (msrv 1.48)' }
+            rust: { toolchain: '1.51', postfix: ' (msrv 1.51)' }
             testflags: '-- --skip ui_tests'
     runs-on: ${{ matrix.os.id }}
     steps:
@@ -233,17 +233,21 @@ jobs:
       fail-fast: false # cancel all jobs as soon as one fails?
       matrix:
         include:
+          # Latest Godot with different Rust versions
           - rust: stable
             godot: "3.4.1"
             postfix: ''
           - rust: nightly
             godot: "3.4.1"
             postfix: ' (nightly)'
-          - rust: '1.48'
+          - rust: '1.51'
             godot: "3.4.1"
-            postfix: ' (msrv 1.48)'
+            postfix: ' (msrv 1.51)'
+
+          # Test with older engine version
+          # Note: headless versions of Godot <= 3.3 may crash with a bug, see feature description in lib.rs
           - rust: stable
-            godot: "3.2"
+            godot: "3.3.1"
             postfix: ''
             build_args: '--features custom-godot'
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -32,8 +32,6 @@ env:
 
   # Local variables
   # Note: using variables is limited at the moment, see https://github.com/actions/runner/issues/480
-  GODOT_VER: "3.4"
-  GODOT_REL: stable
   GDRUST_FEATURES: "gdnative/async,gdnative/serde"
 
 on:
@@ -51,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           components: rustfmt
-      - name: Check rustfmt
+      - name: "Check rustfmt"
         run: cargo fmt --all -- --check;
 
   clippy:
@@ -72,12 +70,12 @@ jobs:
             postfix: ' (nightly)'
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: ${{ matrix.rust.toolchain }}
           components: clippy
-      - name: Check clippy
+      - name: "Check clippy"
         run: cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
 
   test:
@@ -112,16 +110,16 @@ jobs:
     runs-on: ${{ matrix.os.id }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: ${{ matrix.rust.toolchain }}
-      - name: Install LLVM
+      - name: "Install LLVM"
         uses: ./.github/composite/llvm
         if: ${{ matrix.os.id == 'windows-latest' }}
-      - name: Compile tests
+      - name: "Compile tests"
         run: cargo test --workspace --features ${GDRUST_FEATURES} --no-run;
-      - name: Test
+      - name: "Test"
         run: cargo test --workspace --features ${GDRUST_FEATURES} ${{ matrix.testflags }};
 
   build-release:
@@ -140,14 +138,14 @@ jobs:
     runs-on: ${{ matrix.os.id }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: stable
-      - name: Install LLVM
+      - name: "Install LLVM"
         uses: ./.github/composite/llvm
         if: ${{ matrix.os.id == 'windows-latest' }}
-      - name: Release build (check only)
+      - name: "Release build (check only)"
         run: cargo check --release;
 
   build-ios:
@@ -159,18 +157,18 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         #with:
         #  rust: ${{ matrix.rust.toolchain }}
-      - name: Install cargo-dinghy
+      - name: "Install cargo-dinghy"
         run: |
           rustup target add x86_64-apple-ios;
           curl -L https://github.com/sonos/dinghy/releases/download/0.4.62/cargo-dinghy-macos-0.4.62.tgz -o cargo-dinghy-macos.tar.gz;
           tar -zxvf cargo-dinghy-macos.tar.gz;
           mkdir -p $HOME/.cargo/bin;
           cp cargo-dinghy-0.4.62/cargo-dinghy $HOME/.cargo/bin;
-      - name: Cross-compile to iOS
+      - name: "Cross-compile to iOS"
         run: |
           RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1);
           export SIM_ID=$(xcrun simctl create My-iphone11 com.apple.CoreSimulator.SimDeviceType.iPhone-11 $RUNTIME_ID);
@@ -191,11 +189,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         #with:
         #  rust: ${{ matrix.rust.toolchain }}
-      - name: Install Java + NDK
+      - name: "Install Java + NDK"
         run: |
           export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64;
           export ANDROID_SDK_ROOT=/opt/ndk/android-ndk-r21d;
@@ -228,65 +226,38 @@ jobs:
           cargo build --target armv7-linux-androideabi --release;
 
   integration-test-godot:
-    name: itest-godot${{ matrix.rust.postfix }}
+    name: itest-godot-${{ matrix.godot }}${{ matrix.postfix }}
     needs: rustfmt
     continue-on-error: ${{ matrix.rust.toolchain == 'nightly' }}
     strategy:
+      fail-fast: false # cancel all jobs as soon as one fails?
       matrix:
-        rust:
-          - toolchain: stable
+        include:
+          - rust: stable
+            godot: "3.4.1"
             postfix: ''
-          - toolchain: nightly
+          - rust: nightly
+            godot: "3.4.1"
             postfix: ' (nightly)'
-          - toolchain: '1.48'
+          - rust: '1.48'
+            godot: "3.4.1"
             postfix: ' (msrv 1.48)'
+          - rust: stable
+            godot: "3.2"
+            postfix: ''
+            build_args: '--features custom-godot'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: ./.github/composite/rust
+      - name: "Run Godot integration test"
+        uses: ./.github/composite/godot
         with:
-          rust: ${{ matrix.rust.toolchain }}
-      - name: Check cache for installed Godot version
-        id: cache-godot
-        uses: actions/cache@v2
-        with:
-          path: ${{ runner.temp }}/godot_bin
-          key: godot-${{ runner.os }}-v${{ env.GODOT_VER }}-${{ env.GODOT_REL }}
-      - name: Install Godot
-        if: steps.cache-godot.outputs.cache-hit != 'true'
-        run: |
-          wget "https://downloads.tuxfamily.org/godotengine/$GODOT_VER/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64.zip" -O /tmp/godot.zip
-          unzip /tmp/godot.zip -d ${{ runner.temp }}/godot_bin
-      - name: Build godot-rust
-        run: |
-          cd test;
-          cargo build;
-      - name: Run Godot integration tests
-        run: |
-          cd test;
-          mkdir -p ./project/lib;
-          cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          cargo build --features=type_tag_fallback;
-          mkdir -p ./project/lib;
-          cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          
+          rust_toolchain: ${{ matrix.rust }}
+          rust_extra_args: ${{ matrix.build_args }}
+          godot_ver: ${{ matrix.godot }}
+
+
   # This job doesn't actually test anything, but is used to tell bors that the build completed,
   # as there is no practical way to detect when a workflow is successful, listening to webhooks only.
   # The ID (not name) of this job is the one referenced in bors.toml.
@@ -304,5 +275,5 @@ jobs:
       - build-android
     runs-on: ubuntu-latest
     steps:
-      - name: Mark the job as a success
+      - name: "Mark the job as a success"
         run: exit 0

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -14,6 +14,7 @@ env:
   # Note: using variables is limited at the moment, see https://github.com/actions/runner/issues/480
   GODOT_VER: "3.4"
   GODOT_REL: stable
+  GDRUST_FEATURES: "gdnative/async,gdnative/serde"
 
 on:
   pull_request:
@@ -53,7 +54,7 @@ jobs:
           rust: stable
           components: clippy
       - name: Check clippy
-        run: cargo clippy --workspace --all-features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
+        run: cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
 
   unit-test:
     runs-on: ubuntu-latest
@@ -62,9 +63,9 @@ jobs:
       - name: Install Rust
         uses: ./.github/composite/rust
       - name: Compile tests
-        run: cargo test --workspace --all-features --no-run;
+        run: cargo test --workspace --features ${GDRUST_FEATURES} --no-run;
       - name: Test
-        run: cargo test --workspace --all-features;
+        run: cargo test --workspace --features ${GDRUST_FEATURES};
 
   integration-test-godot:
     runs-on: ubuntu-latest

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -12,8 +12,7 @@ env:
 
   # Local variables
   # Note: using variables is limited at the moment, see https://github.com/actions/runner/issues/480
-  GODOT_VER: "3.4"
-  GODOT_REL: stable
+  GODOT_VER: "3.4.1"
   GDRUST_FEATURES: "gdnative/async,gdnative/serde"
 
 on:
@@ -35,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: stable
           components: rustfmt
-      - name: Check rustfmt
+      - name: "Check rustfmt"
         run: cargo fmt --all -- --check;
 
   clippy:
@@ -48,71 +47,33 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: stable
           components: clippy
-      - name: Check clippy
+      - name: "Check clippy"
         run: cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
 
   unit-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
+      - name: "Install Rust"
         uses: ./.github/composite/rust
-      - name: Compile tests
+      - name: "Compile tests"
         run: cargo test --workspace --features ${GDRUST_FEATURES} --no-run;
-      - name: Test
+      - name: "Test"
         run: cargo test --workspace --features ${GDRUST_FEATURES};
 
   integration-test-godot:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: ./.github/composite/rust
-      - name: Check cache for installed Godot version
-        id: cache-godot
-        uses: actions/cache@v2
+      - name: "Run Godot integration test"
+        uses: ./.github/composite/godot
         with:
-          path: ${{ runner.temp }}/godot_bin
-          key: godot-${{ runner.os }}-v${{ env.GODOT_VER }}-${{ env.GODOT_REL }}
-      - name: Install Godot
-        if: steps.cache-godot.outputs.cache-hit != 'true'
-        run: |
-          wget "https://downloads.tuxfamily.org/godotengine/$GODOT_VER/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64.zip" -O /tmp/godot.zip
-          unzip /tmp/godot.zip -d ${{ runner.temp }}/godot_bin
-      - name: Build godot-rust
-        run: |
-          cd test;
-          cargo build;
-      - name: Run Godot integration tests
-        run: |
-          cd test;
-          mkdir -p ./project/lib;
-          cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          cargo build --features=type_tag_fallback;
-          mkdir -p ./project/lib;
-          cp ../target/debug/libgdnative_test.so ./project/lib/;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --path ./project/ > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          "${{ runner.temp }}/godot_bin/Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log");
-          if grep -q "Leaked instance" "${{ runner.temp }}/stdout.log"; then
-            exit 1;
-          fi;
-          
+          godot_ver: ${{ env.GODOT_VER }}
 
 # Not really needed, since bors is not involved. Just needs an extra runner and makes the tests run longer.
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -8,6 +8,9 @@ on:
       - '0.9.[0-9]+'
       - '0.10.[0-9]+'
 
+env:
+  GDRUST_FEATURES: "gdnative/async,gdnative/serde"
+
 defaults:
   run:
     shell: bash
@@ -18,17 +21,20 @@ jobs:
     environment: Deploy
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
         with:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-      - name: Sanity tests
+
+      - name: "Sanity tests"
         run: |
           cargo fmt --all -- --check;
-          cargo clippy --all --all-features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
-          cargo test --all --all-features;
-      - name: Publishing to crates.io
+          cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented;
+          cargo test --workspace --features ${GDRUST_FEATURES};
+
+      - name: "Publish to crates.io"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The bindings cover most of the exposed API of Godot 3.4, and are being used on a
 
 We are committed to keeping compatibility with the latest stable patch releases of all minor versions of the engine, starting from Godot 3.2:
 * Godot 3.4 (works out-of-the-box)
-* Godot 3.3 (needs api.json adjustment)
-* Godot 3.2 (needs api.json adjustment)
+* Godot 3.3 (needs feature `custom-godot`)
+* Godot 3.2 (needs feature `custom-godot`)
 
 For versions 3.2 and 3.3, some extra steps are needed, see _Custom builds_ below.
 
@@ -45,6 +45,7 @@ This means that `bindgen` was unable to find the C system headers for your platf
 
 ### Latest `master` version + Godot 3.4
 
+This is the recommended way of using godot-rust, if you want to benefit from latest features.
 After `bindgen` dependencies are installed, add the `gdnative` crate as a dependency, and set the crate type to `cdylib`:
 
 ```toml
@@ -57,7 +58,7 @@ crate-type = ["cdylib"]
 
 ### Godot 3.2.3-stable
 
-To access the last released version on crates.io, use the following. If you are starting, we recommend using the `master` version at this point, as there have been significant API changes since v0.9.3.
+To access the last released version on crates.io, use the following. Note that there have been significant API changes since v0.9.3 -- if you are starting to use godot-rust, we recommend using the `master` version instead.
 
 ```toml
 [dependencies]
@@ -69,9 +70,7 @@ crate-type = ["cdylib"]
 
 ### Custom builds
 
-To use the bindings with a non-default Godot version or a custom build, see [Using custom builds of Godot](https://godot-rust.github.io/book/advanced-guides/custom-godot.html) in the user guide.
-
-In short, you will need to generate `api.json` manually, using `godot --gdnative-generate-json-api api.json` to replace the file in the `gdnative-bindings` directory.
+To use the bindings with a different Godot version or a custom build of the engine, see [Custom Godot builds](https://godot-rust.github.io/book/advanced-guides/custom-godot.html) in the user guide.
 
 ### Async / `yield` support
 

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 formatted = []
-one_class_one_file = []
+one-class-one-file = []
 custom-godot = ["which"]
 
 [dependencies]

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [features]
 formatted = []
 one_class_one_file = []
+custom-godot = ["which"]
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.9.3" }
@@ -23,3 +24,4 @@ bitflags = "1.3.2"
 [build-dependencies]
 heck = "0.4.0"
 gdnative_bindings_generator = { path = "../bindings_generator", version = "=0.9.3" }
+which = { optional = true, version = "4.2.2" }

--- a/gdnative-bindings/build.rs
+++ b/gdnative-bindings/build.rs
@@ -50,7 +50,7 @@ fn main() {
 }
 
 /// Output all the class bindings into the `generated.rs` file.
-#[cfg(not(feature = "one_class_one_file"))]
+#[cfg(not(feature = "one-class-one-file"))]
 fn generate(
     _out_path: &std::path::Path,
     generated_file: &mut BufWriter<File>,
@@ -84,7 +84,7 @@ fn generate(
 
 /// Output one file for each class and add `mod` and `use` declarations in
 /// the `generated.rs` file.
-#[cfg(feature = "one_class_one_file")]
+#[cfg(feature = "one-class-one-file")]
 fn generate(
     out_path: &std::path::Path,
     generated_file: &mut BufWriter<File>,

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [features]
 default = []
-gd_test = []
-type_tag_fallback = []
+gd-test = []
+type-tag-fallback = []
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.9.3" }

--- a/gdnative-core/src/core_types/geom/transform2d.rs
+++ b/gdnative-core/src/core_types/geom/transform2d.rs
@@ -320,7 +320,7 @@ impl std::ops::Mul<Transform2D> for Transform2D {
     }
 }
 
-#[cfg(feature = "gd_test")]
+#[cfg(feature = "gd-test")]
 fn test_transform2d_behavior_impl() {
     let api = crate::private::get_api();
 

--- a/gdnative-core/src/core_types/geom/transform2d.rs
+++ b/gdnative-core/src/core_types/geom/transform2d.rs
@@ -1,21 +1,5 @@
 use crate::core_types::Vector2;
 
-/// Clamp method for f32.
-/// NOTE: This method was copied as-is from std. This was done to avoid compatibility issues
-/// with newer rustc versions and should be removed in favor of f32::clamp once that is stable.
-#[inline]
-fn clamp(num: f32, min: f32, max: f32) -> f32 {
-    assert!(min <= max);
-    let mut x = num;
-    if x < min {
-        x = min;
-    }
-    if x > max {
-        x = max;
-    }
-    x
-}
-
 /// Affine 2D transform (2x3 matrix).
 ///
 /// Represents transformations such as translation, rotation, or scaling.
@@ -228,7 +212,7 @@ impl Transform2D {
         // slerp rotation
         let v1 = Vector2::new(f32::cos(r1), f32::sin(r1));
         let v2 = Vector2::new(f32::cos(r2), f32::sin(r2));
-        let dot = clamp(v1.dot(v2), -1.0, 1.0);
+        let dot = v1.dot(v2).clamp(-1.0, 1.0);
 
         let v = if dot > 0.9995 {
             //linearly interpolate to avoid numerical precision issues

--- a/gdnative-core/src/export/type_tag.rs
+++ b/gdnative-core/src/export/type_tag.rs
@@ -23,8 +23,8 @@ impl Tag {
 }
 
 /// Whether the type tag can be transmuted to `usize`. `true` if the layouts are compatible
-/// on the platform, and `type_tag_fallback` is not enabled.
-const USE_TRANSMUTE: bool = cfg!(not(feature = "type_tag_fallback"))
+/// on the platform, and `type-tag-fallback` is not enabled.
+const USE_TRANSMUTE: bool = cfg!(not(feature = "type-tag-fallback"))
     && size_of::<Tag>() == size_of::<usize>()
     && align_of::<Tag>() == align_of::<usize>();
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -25,7 +25,7 @@
     clippy::missing_safety_doc,
     clippy::non_send_fields_in_send_ty
 )]
-#![cfg_attr(feature = "gd_test", allow(clippy::blacklisted_name))]
+#![cfg_attr(feature = "gd-test", allow(clippy::blacklisted_name))]
 
 #[doc(hidden)]
 pub extern crate gdnative_sys as sys;
@@ -33,7 +33,7 @@ pub extern crate gdnative_sys as sys;
 #[doc(hidden)]
 pub extern crate libc;
 
-#[cfg(feature = "gd_test")]
+#[cfg(feature = "gd-test")]
 #[macro_use]
 extern crate approx;
 

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -211,7 +211,7 @@ macro_rules! impl_basic_traits_as_sys {
 macro_rules! godot_test {
     ($($test_name:ident $body:block)*) => {
         $(
-            #[cfg(feature = "gd_test")]
+            #[cfg(feature = "gd-test")]
             #[doc(hidden)]
             #[inline]
             pub fn $test_name() -> bool {

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -34,5 +34,6 @@ gdnative-async = { optional = true, path = "../gdnative-async", version = "=0.9.
 trybuild = "1.0.50"
 rustversion = "1.0.5"
 
+# See https://docs.rs/about/metadata
 [package.metadata.docs.rs]
-all-features = true
+features = ["async", "serde"]

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -13,21 +13,21 @@ edition = "2018"
 
 [features]
 # Public
+default = []
 async = ["gdnative-async"]
 custom-godot = ["gdnative-bindings/custom-godot"]
-default = []
-formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one_class_one_file"]
+formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one-class-one-file"]
 serde = ["gdnative-core/serde"]
 
 # Internal
-gd_test = ["gdnative-core/gd_test"]
-type_tag_fallback = ["gdnative-core/type_tag_fallback"]
+gd-test = ["gdnative-core/gd-test"]
+type-tag-fallback = ["gdnative-core/type-tag-fallback"]
 
 [dependencies]
 gdnative-derive = { path = "../gdnative-derive", version = "=0.9.3" }
 gdnative-core = { path = "../gdnative-core", version = "=0.9.3" }
 gdnative-bindings = { path = "../gdnative-bindings", version = "=0.9.3" }
-gdnative-async = { optional = true, path = "../gdnative-async", version = "=0.9.3" }
+gdnative-async = { path = "../gdnative-async", version = "=0.9.3", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0.50"

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -12,14 +12,17 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
+# Public
+async = ["gdnative-async", "bindings"]
+bindings = ["gdnative-bindings"]
+custom-godot = ["gdnative-bindings/custom-godot"]
 default = ["bindings"]
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one_class_one_file"]
 serde = ["gdnative-core/serde"]
 
+# Internal
 gd_test = ["gdnative-core/gd_test"]
 type_tag_fallback = ["gdnative-core/type_tag_fallback"]
-bindings = ["gdnative-bindings"]
-async = ["gdnative-async", "bindings"]
 
 [dependencies]
 gdnative-derive = { path = "../gdnative-derive", version = "=0.9.3" }

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -13,10 +13,9 @@ edition = "2018"
 
 [features]
 # Public
-async = ["gdnative-async", "bindings"]
-bindings = ["gdnative-bindings"]
+async = ["gdnative-async"]
 custom-godot = ["gdnative-bindings/custom-godot"]
-default = ["bindings"]
+default = []
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one_class_one_file"]
 serde = ["gdnative-core/serde"]
 
@@ -27,7 +26,7 @@ type_tag_fallback = ["gdnative-core/type_tag_fallback"]
 [dependencies]
 gdnative-derive = { path = "../gdnative-derive", version = "=0.9.3" }
 gdnative-core = { path = "../gdnative-core", version = "=0.9.3" }
-gdnative-bindings = { optional = true, path = "../gdnative-bindings", version = "=0.9.3" }
+gdnative-bindings = { path = "../gdnative-bindings", version = "=0.9.3" }
 gdnative-async = { optional = true, path = "../gdnative-async", version = "=0.9.3" }
 
 [dev-dependencies]

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -40,11 +40,16 @@
 //! on `Ref`.
 //!
 //! ## Feature flags
-//!
-//! * `bindings` -- *enabled* by default. Includes the crates.io version of the bindings in the
-//!   `api` module. Disable if you want to use a custom Godot version.
+//! Functionality  toggles:
+//! * `async` -- *disabled* by default. Enables asyn functionality, see [`tasks`] module for details.
 //! * `serde` -- *disabled* by default. Enable for `serde` support. See also
 //!   [`Variant`](core_types::Variant).
+//!
+//! Affecting bindings generation:
+//! * `bindings` -- *enabled* by default. Includes the crates.io version of the bindings in the
+//!   `api` module. Disable if you want to use a custom Godot version.
+//! * `custom-godot` -- *disabled* by default. When active, looks for a `GODOT_BIN` environment
+//!   variable pointing to the Godot executable, or a `godot` executable in the path.
 //! * `formatted` -- *disabled* by default. Enable if the generated binding source code should
 //!   be human-readable.
 //!

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -22,9 +22,8 @@
 //!
 //! The `api` module contains high-level wrappers for all the API types generated from a
 //! JSON description of the API. The generated types are tied to a specific version, which
-//! is currently `3.2.3-stable` for the crates.io version. If you want to use the bindings
-//! with another version of the engine, see the instructions [here][custom-version] on
-//! generating custom bindings.
+//! is currently `3.2.3-stable` for the crates.io version. If you want to use the bindings with
+//! another version of the engine, read the notes on the `custom-godot` feature flag below.
 //!
 //! ### Memory management
 //!
@@ -40,21 +39,38 @@
 //! on `Ref`.
 //!
 //! ## Feature flags
-//! Functionality  toggles:
-//! * `async` -- *disabled* by default. Enables asyn functionality, see [`tasks`] module for details.
-//! * `serde` -- *disabled* by default. Enable for `serde` support. See also
-//!   [`Variant`](core_types::Variant).
+//! All features are disabled by default.
 //!
-//! Affecting bindings generation:
-//! * `bindings` -- *enabled* by default. Includes the crates.io version of the bindings in the
-//!   `api` module. Disable if you want to use a custom Godot version.
-//! * `custom-godot` -- *disabled* by default. When active, looks for a `GODOT_BIN` environment
-//!   variable pointing to the Godot executable, or a `godot` executable in the path.
-//! * `formatted` -- *disabled* by default. Enable if the generated binding source code should
-//!   be human-readable.
+//! Functionality toggles:
+//!
+//! * **`async`**<br>
+//!   Activates async functionality, see [`tasks`] module for details.
+//!
+//! * **`serde`**<br>
+//!   Enable for `serde` support of several core types. See also [`Variant`](core_types::Variant).
+//!
+//! Bindings generation:
+//!
+//! * **`custom-godot`**<br>
+//!   When active, tries to locate a Godot executable on your system, in this order:
+//!   1. If a `GODOT_BIN` environment variable is defined, it will interpret it as a path to the binary
+//!      (not directory).
+//!   2. An executable called `godot`, accessible in your system's PATH, is used.
+//!   3. If neither of the above is found, an error is generated.
+//!
+//!   The symbols in [`api`] will be generated in a way compatible with that engine version.
+//!   This allows to use Godot versions older than the currently supported ones. Note that there
+//!   are some bugs for Godot versions prior to 3.3.1.
+//!
+//!   See [Custom Godot builds][custom-godot] for detailed instructions.
+//!
+//! * **`formatted`**<br>
+//!   Enable if the generated binding source code should be human-readable and split
+//!   into multiple files. This can also help IDEs that struggle with a single huge file.
 //!
 //! [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
-//! [custom-version]: https://github.com/godot-rust/godot-rust/#other-versions-or-custom-builds
+//! [custom-godot]: https://godot-rust.github.io/book/advanced-guides/custom-godot.html
+//!
 //!
 
 // TODO: add logo using #![doc(html_logo_url = "https://<url>")]
@@ -79,10 +95,8 @@ pub mod prelude;
 
 /// Bindings for the Godot Class API.
 #[doc(inline)]
-#[cfg(feature = "bindings")]
 pub use gdnative_bindings as api;
 
-/// Support for async code
 #[doc(inline)]
 #[cfg(feature = "async")]
 pub use gdnative_async as tasks;

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "bindings")]
 pub use gdnative_bindings::utils::*;
-#[cfg(feature = "bindings")]
 pub use gdnative_bindings::{
     Button, CanvasItem, CanvasLayer, ColorRect, Control, Image, Input, InputEvent, InputEventKey,
     KinematicBody, KinematicBody2D, Label, Node, Node2D, Object, PackedScene, Reference,

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-type_tag_fallback = ["gdnative/type_tag_fallback"]
+type-tag-fallback = ["gdnative/type-tag-fallback"]
 custom-godot = ["gdnative/custom-godot"]
 
 [dependencies]
-gdnative = { path = "../gdnative", features = ["gd_test", "serde", "async"] }
+gdnative = { path = "../gdnative", features = ["gd-test", "serde", "async"] }
 gdnative-derive = { path = "../gdnative-derive" }
 approx = "0.5.0"
 ron = "0.7.0"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [features]
 default = []
 type_tag_fallback = ["gdnative/type_tag_fallback"]
+custom-godot = ["gdnative/custom-godot"]
 
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd_test", "serde", "async"] }

--- a/test/project/addons/editor_test_runner/plugin.gd
+++ b/test/project/addons/editor_test_runner/plugin.gd
@@ -15,6 +15,8 @@ func _enter_tree():
 		print("Opening editor normally for the test project. To run tests, pass `--run-editor-tests` to the executable.")
 
 func _run_tests():
+	var version = Engine.get_version_info()
+	print(" -- Running on Godot ", version["string"])
 	print(" -- Rust GDNative test suite (called from editor):")
 	gdn = GDNative.new()
 	var status = false;

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -3,6 +3,8 @@ extends Node
 var gdn
 
 func _ready():
+	var version = Engine.get_version_info()
+	print(" -- Running on Godot ", version["string"])
 	print(" -- Rust GDNative test suite:")
 	_timeout()
 


### PR DESCRIPTION
Enables the use of custom Godot builds in a straightforward way.
This includes older versions such as Godot 3.2, for which `api.json` is no longer shipped along.

Previous process (see also [book](https://godot-rust.github.io/book/advanced-guides/custom-godot.html)):
* create a local copy of godot-rust
* Run `godot --gdnative-generate-json-api`
* replace `api.json` inside `gdnative-binding`

New process:
* enable feature `custom-godot`
* make sure `godot` executable is in path **OR** set `GODOT_BIN` env var
* done

This supersedes the previous `bindings` feature, which is now removed.

I also added CI support for previous Godot version 3.3.1, so far only for integration tests. Originally I wanted to use Godot 3.2 (the oldest supported version), however https://github.com/godotengine/godot/issues/36582 prevented headless versions from generating `api.json` reliably without crashing. This has been fixed for versions >= 3.3.1.

There is still testing to be done; feedback is always appreciated! 🙂 

Closes #640. Thanks for the great ideas in that issue.