### PR TITLE
Allow `impl Into<NodePath>` for `NodeExt` methods and simplify impls

### DIFF
--- a/test/src/test_as_arg.rs
+++ b/test/src/test_as_arg.rs
@@ -1,5 +1,5 @@
 use gdnative::derive::{methods, NativeClass};
-use gdnative::prelude::NodeExt;
+use gdnative::prelude::NodeResolveExt;
 use gdnative::prelude::*;
 use std::ops::Deref;
 


### PR DESCRIPTION
For reference, as discussed several months ago in Discord:
> Part of the problem is that using `impl Into<NodePath>` means that you can no longer explicitly declare `T` with e.g. `owner.get_node_as::<Node>(path)`, because the compiler complains about `impl Trait` creating an implicit type parameter. But turning it into
> ```rust
> unsafe fn get_node_as<'a, T, P>(&self, path: P) -> Option<TRef<'a, T>>
> where
>   T: SubClass<Node>,
>   P: Into<NodePath>;
> ```
> Means you have to always either declare the type of the path argument, or use `get_node_as::<Node, _>(path)`

Eventually I came up with the solution of putting the path generic parameter in the trait declaration rather than the methods, and haven't been able to come up with a significant drawback.

Just today I realized there was little reason to have impls for both `&T` and `TRef` when all methods already take `&self` -- the compiler will auto-dereference `TRef`s, and this will also let it work with unique & thread-local `Ref`s.