### PR TITLE
Fix unresolved enum name in bindings generator

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -1,9 +1,9 @@
-use heck::ToPascalCase as _;
+use super::classes::generate_enum_name;
+use miniserde::Deserialize;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::{HashMap, HashSet};
 
-use miniserde::Deserialize;
 miniserde::make_place!(Place);
 
 pub struct Api {
@@ -400,7 +400,8 @@ impl Ty {
                 // Enums may reference known types (above list), check if it's a known type first
                 let mut split = ty[5..].split("::");
                 let class_name = split.next().unwrap();
-                let name = format_ident!("{}", split.next().unwrap().to_pascal_case());
+                let enum_raw_name = split.next().unwrap();
+                let name = format_ident!("{}", generate_enum_name(class_name, enum_raw_name));
                 let module = format_ident!("{}", module_name_from_class_name(class_name));
                 // Is it a known type?
                 match Ty::from_src(class_name) {

--- a/bindings_generator/src/classes.rs
+++ b/bindings_generator/src/classes.rs
@@ -143,7 +143,7 @@ pub(crate) fn generate_enums(class: &GodotClass) -> TokenStream {
     }
 }
 
-fn generate_enum_name(class_name: &str, enum_name: &str) -> String {
+pub(crate) fn generate_enum_name(class_name: &str, enum_name: &str) -> String {
     // In order to not pollute the API with more Result types,
     // rename the Result enum used by Search to SearchResult.
     // to_pascal_case() is used to make the enums more rust-like.


### PR DESCRIPTION
Example: when using godot-rust with the VoxelTools engine module, the api.json has many nested `Result` types. In some occurrences, these identifiers are prefixed with the containing class, e.g. `VoxelStreamResult`. However, some references to these type names are not using the prefixed identifier, thus creating compile errors (see commit message for details).

This PR addresses this by prefixing other occurrences, when enums are constructed.