### PR TITLE
Add PoolArray::to_vec(), improve doc around read()/write()

### DIFF
--- a/gdnative-core/src/core_types/byte_array.rs
+++ b/gdnative-core/src/core_types/byte_array.rs
@@ -40,6 +40,9 @@ godot_test!(
 
         // the write shouldn't have affected the original array
         assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7], original_read.as_slice());
+
+        // check to_vec()
+        assert_eq!(arr.to_vec(), vec![0, 1, 2, 3, 4, 5, 6, 7]);
     }
 );
 


### PR DESCRIPTION
Closes #806.

I noticed that the documentation around the `read()` and `write()` methods was a bit lacking, and tried to make it a bit easier to understand. Also moved trait `impl`s after the inherent `impl`.

I'm not 100% sure that we really need `to_vec()`. It's nice as a convenience, but it may cause people to do things like
```rs
pool_array.to_vec().map(...).collect()
// or
for elem in pool_array.to_vec()
```
instead of going via `read()`. After all, `read().to_vec()` is not much longer.
On the other hand, we already have `PoolArray::from_vec()`, so it's somewhat symmetric.

I'd be happy for some input on that.