### PR TITLE
Fix UI tests, whitespace in error messages is different in Rust 1.58

### DIFF
--- a/gdnative/tests/ui/from_variant_fail_01.stderr
+++ b/gdnative/tests/ui/from_variant_fail_01.stderr
@@ -1,6 +1,6 @@
 error: Missing macro arguments
-    expecting #[variant(...)]. See documentation:
-    https://docs.rs/gdnative/0.9.0/gdnative/core_types/trait.ToVariant.html#field-attributes
+           expecting #[variant(...)]. See documentation:
+           https://docs.rs/gdnative/0.9.0/gdnative/core_types/trait.ToVariant.html#field-attributes
  --> $DIR/from_variant_fail_01.rs:5:7
   |
 5 |     #[variant]

--- a/gdnative/tests/ui/from_variant_fail_07.stderr
+++ b/gdnative/tests/ui/from_variant_fail_07.stderr
@@ -1,5 +1,5 @@
 error: unknown argument, expected one of:
-    to_variant_with, from_variant_with, with, skip_to_variant, skip_from_variant, skip
+           to_variant_with, from_variant_with, with, skip_to_variant, skip_from_variant, skip
  --> $DIR/from_variant_fail_07.rs:5:15
   |
 5 |     #[variant(aoeu = "aoeu")]

--- a/gdnative/tests/ui/to_variant_fail_01.stderr
+++ b/gdnative/tests/ui/to_variant_fail_01.stderr
@@ -1,6 +1,6 @@
 error: Missing macro arguments
-    expecting #[variant(...)]. See documentation:
-    https://docs.rs/gdnative/0.9.0/gdnative/core_types/trait.ToVariant.html#field-attributes
+           expecting #[variant(...)]. See documentation:
+           https://docs.rs/gdnative/0.9.0/gdnative/core_types/trait.ToVariant.html#field-attributes
  --> $DIR/to_variant_fail_01.rs:5:7
   |
 5 |     #[variant]

--- a/gdnative/tests/ui/to_variant_fail_07.stderr
+++ b/gdnative/tests/ui/to_variant_fail_07.stderr
@@ -1,5 +1,5 @@
 error: unknown argument, expected one of:
-    to_variant_with, from_variant_with, with, skip_to_variant, skip_from_variant, skip
+           to_variant_with, from_variant_with, with, skip_to_variant, skip_from_variant, skip
  --> $DIR/to_variant_fail_07.rs:5:15
   |
 5 |     #[variant(aoeu = "aoeu")]


### PR DESCRIPTION
For some reason, Rust changes their whitespacing in error messages every couple of versions. This breaks UI tests and makes CI fail.

bors r+