### PR TITLE
Clippy warnings on nightly + first cargo-deny entry

### DIFF
--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -22,7 +22,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
 
     let return_expr = match repr {
         Repr::Struct(var_repr) => {
-            let from_variant = var_repr.from_variant(&input_ident, &quote! { #ident })?;
+            let from_variant = var_repr.make_from_variant_expr(&input_ident, &quote! { #ident })?;
             quote! {
                 {
                     #from_variant
@@ -54,7 +54,8 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
             let var_from_variants = variants
                 .iter()
                 .map(|(var_ident, var_repr)| {
-                    var_repr.from_variant(&var_input_ident, &quote! { #ident::#var_ident })
+                    var_repr
+                        .make_from_variant_expr(&var_input_ident, &quote! { #ident::#var_ident })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -25,7 +25,7 @@ pub(crate) fn expand_to_variant(
     let return_expr = match repr {
         Repr::Struct(var_repr) => {
             let destructure_pattern = var_repr.destructure_pattern();
-            let to_variant = var_repr.to_variant(trait_kind)?;
+            let to_variant = var_repr.make_to_variant_expr(trait_kind)?;
             quote! {
                 {
                     let #ident #destructure_pattern = self;
@@ -43,7 +43,7 @@ pub(crate) fn expand_to_variant(
                     .iter()
                     .map(|(var_ident, var_repr)| {
                         let destructure_pattern = var_repr.destructure_pattern();
-                        let to_variant = var_repr.to_variant(trait_kind)?;
+                        let to_variant = var_repr.make_to_variant_expr(trait_kind)?;
                         let var_ident_string = format!("{}", var_ident);
                         let var_ident_string_literal = Literal::string(&var_ident_string);
                         let tokens = quote! {

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -165,14 +165,16 @@ allow = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#{ name = "ansi_term", version = "=0.11.0" },
+#
+# Wrapper crates can optionally be specified to allow the crate when it
+# is a direct dependency of the otherwise banned crate
+#{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+    # unmaintained since Feb 20 + https://github.com/noamtashma/owning-ref-unsoundness
+    { name = "owning_ref" },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [


### PR DESCRIPTION
### clippy warnings

The first commit fixes warnings on nightly:
```rs
  Checking gdnative-derive v0.9.3 (/home/runner/work/godot-rust/godot-rust/gdnative-derive)
error: methods called `from_*` usually take no `self`
   --> gdnative-derive/src/variant/repr.rs:174:9
    |
174 |         &self,
    |         ^^^^^
    |
    = note: `-D clippy::wrong-self-convention` implied by `-D clippy::style`
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

error: methods called `from_*` usually take no `self`
   --> gdnative-derive/src/variant/repr.rs:330:21
    |
330 |     fn from_variant(&self, variant: &TokenStream2) -> TokenStream2 {
    |                     ^^^^^
    |
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```

---

### cargo-deny entry

After reading [this Reddit post](https://www.reddit.com/r/rust/comments/sdgcg9/unsoundness_in_owning_ref), the `owning_ref` crate seemed to be a good candidate for cargo-deny. First, it hasn't been maintained in two years, and second, there is [known unsoundness](https://github.com/noamtashma/owning-ref-unsoundness) but it's not marked in any CVE database.

I'm not suggesting we go hunt down crates now, but if people come across other problematic crates, let's add them. That doesn't mean there will be a strict ban on such crates forever, but it means adding a potentially problematic dependency is a concious, opt-in process.

bors try