### PR TITLE
Implement methods on Rect2 and Aabb

### DIFF
--- a/bindings-generator/src/api.rs
+++ b/bindings-generator/src/api.rs
@@ -39,13 +39,7 @@ impl Api {
     }
 
     pub fn find_class(&self, name: &str) -> Option<&GodotClass> {
-        for class in &self.classes {
-            if class.name == name {
-                return Some(class);
-            }
-        }
-
-        None
+        self.classes.iter().find(|&class| class.name == name)
     }
 
     pub fn class_inherits(&self, class: &GodotClass, base_class_name: &str) -> bool {

--- a/gdnative-core/src/core_types/geom/aabb.rs
+++ b/gdnative-core/src/core_types/geom/aabb.rs
@@ -1,15 +1,392 @@
-use crate::core_types::Vector3;
+use crate::core_types::{Axis, Plane, Vector3};
 
 /// Axis-aligned bounding box.
+///
+/// `Aabb` consists of a position, a size, and several utility functions. It is typically used for
+/// fast overlap tests.
+///
+/// The 2D counterpart to `Aabb` is [`Rect2`](crate::core_types::Rect2).
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Aabb {
+    /// The bounding box's position in 3D space.
     pub position: Vector3,
+    /// Width, height, and depth of the bounding box.
     pub size: Vector3,
 }
 
 impl Aabb {
+    /// Creates an `Aabb` by position and size.
+    #[inline]
+    pub fn new(position: Vector3, size: Vector3) -> Self {
+        Self { position, size }
+    }
+
+    /// Creates an `Aabb` by x, y, z, width, height, and depth.
+    #[inline]
+    pub fn from_components(x: f32, y: f32, z: f32, width: f32, height: f32, depth: f32) -> Self {
+        let position = Vector3::new(x, y, z);
+        let size = Vector3::new(width, height, depth);
+
+        Self { position, size }
+    }
+
+    /// Ending corner. This is calculated as `position + size`.
+    #[inline]
+    pub fn get_end(&self) -> Vector3 {
+        self.position + self.size
+    }
+
+    /// Ending corner. Setting this value will change the size.
+    #[inline]
+    pub fn set_end(&mut self, new_end: Vector3) {
+        self.size = new_end - self.position;
+    }
+
+    /// Returns an `Aabb` with equivalent position and area, modified so that the most-negative
+    /// corner is the origin and the size is positive.
+    #[inline]
+    pub fn abs(&self) -> Self {
+        let position = self.position
+            + Vector3::new(
+                self.size.x.min(0.0),
+                self.size.y.min(0.0),
+                self.size.z.min(0.0),
+            );
+        let size = self.size.abs();
+
+        Self { position, size }
+    }
+
+    /// Returns the volume of the bounding box. See also [`has_no_volume`][Self::has_no_volume].
+    ///
+    /// This method corresponds to the [`get_area`][get_area] GDScript method.
+    ///
+    /// [get_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-area
+    #[inline]
+    pub fn get_volume(&self) -> f32 {
+        self.size.x * self.size.y * self.size.z
+    }
+
+    /// Returns true if the bounding box is flat or empty. See also
+    /// [`get_volume`][Self::get_volume].
+    ///
+    /// This method corresponds to the [`has_no_area`][has_no_area] GDScript method.
+    ///
+    /// Note: If the bounding box has a negative size and is not flat or empty, this method will
+    /// return true.
+    ///
+    /// [has_no_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-has-no-area
+    #[inline]
+    pub fn has_no_volume(&self) -> bool {
+        self.size.x <= 0.0 || self.size.y <= 0.0 || self.size.z <= 0.0
+    }
+
+    /// Returns true if the bounding box is empty or all of its dimensions are negative.
+    #[inline]
+    pub fn has_no_surface(&self) -> bool {
+        self.size.x <= 0.0 && self.size.y <= 0.0 && self.size.z <= 0.0
+    }
+
+    /// Returns true if the bounding box contains a point. By convention, the right and bottom edges of
+    /// the `Rect2` are considered exclusive, so points on these edges are not included.
+    ///
+    /// Note: This method is not reliable for bounding boxes with a negative size. Use
+    /// [`abs`][Self::abs] to get a positive sized equivalent box to check for contained points.
+    #[inline]
+    pub fn has_point(&self, point: Vector3) -> bool {
+        let point = point - self.position;
+
+        point.abs() == point
+            && point.x < self.size.x
+            && point.y < self.size.y
+            && point.z < self.size.z
+    }
+
+    /// Returns true if this bounding box and `b` are approximately equal, by calling
+    /// [`is_equal_approx`](Vector3::is_equal_approx) on each component.
+    #[inline]
+    pub fn is_equal_approx(&self, b: Self) -> bool {
+        self.position.is_equal_approx(b.position) && self.size.is_equal_approx(b.size)
+    }
+
+    /// Gets the position of the 8 endpoints of the bounding in space.
+    ///
+    /// The index returns an arbitrary point, but all points are guaranteed to be unique.
+    #[inline]
+    pub fn get_endpoint(&self, index: i64) -> Option<Vector3> {
+        match index {
+            0 => Some(self.position),
+            1 => Some(self.position + Vector3::new(0.0, 0.0, self.size.z)),
+            2 => Some(self.position + Vector3::new(0.0, self.size.y, 0.0)),
+            3 => Some(self.position + Vector3::new(0.0, self.size.y, self.size.z)),
+            4 => Some(self.position + Vector3::new(self.size.x, 0.0, 0.0)),
+            5 => Some(self.position + Vector3::new(self.size.x, 0.0, self.size.z)),
+            6 => Some(self.position + Vector3::new(self.size.x, self.size.y, 0.0)),
+            7 => Some(self.position + self.size),
+            _ => None,
+        }
+    }
+
+    /// Returns the normalized longest axis of the bounding box.
+    #[inline]
+    pub fn get_longest_axis(&self) -> Vector3 {
+        let mut axis = Vector3::RIGHT;
+        let mut axis_max = self.size.x;
+
+        if self.size.y > axis_max {
+            axis = Vector3::UP;
+            axis_max = self.size.y;
+        }
+
+        if self.size.z > axis_max {
+            axis = Vector3::BACK;
+        }
+
+        axis
+    }
+
+    /// Returns the index of the longest axis of the bounding box.
+    #[inline]
+    pub fn get_longest_axis_index(&self) -> Axis {
+        let mut axis = Axis::X;
+        let mut axis_max = self.size.x;
+
+        if self.size.y > axis_max {
+            axis = Axis::Y;
+            axis_max = self.size.y;
+        }
+
+        if self.size.z > axis_max {
+            axis = Axis::Z;
+        }
+
+        axis
+    }
+
+    /// Returns the scalar length of the longest axis of the bounding box.
+    #[inline]
+    pub fn get_longest_axis_size(&self) -> f32 {
+        let mut axis_max = self.size.x;
+
+        if self.size.y > axis_max {
+            axis_max = self.size.y;
+        }
+
+        if self.size.z > axis_max {
+            axis_max = self.size.z;
+        }
+
+        axis_max
+    }
+
+    /// Returns the normalized shortest axis of the bounding box.
+    #[inline]
+    pub fn get_shortest_axis(&self) -> Vector3 {
+        let mut axis = Vector3::RIGHT;
+        let mut axis_min = self.size.x;
+
+        if self.size.y < axis_min {
+            axis = Vector3::UP;
+            axis_min = self.size.y;
+        }
+
+        if self.size.z < axis_min {
+            axis = Vector3::BACK;
+        }
+
+        axis
+    }
+
+    /// Returns the index of the shortest axis of the bounding box.
+    #[inline]
+    pub fn get_shortest_axis_index(&self) -> Axis {
+        let mut axis = Axis::X;
+        let mut axis_min = self.size.x;
+
+        if self.size.y < axis_min {
+            axis = Axis::Y;
+            axis_min = self.size.y;
+        }
+
+        if self.size.z < axis_min {
+            axis = Axis::Z;
+        }
+
+        axis
+    }
+
+    /// Returns the scalar length of the shortest axis of the bounding box.
+    #[inline]
+    pub fn get_shortest_axis_size(&self) -> f32 {
+        let mut axis_min = self.size.x;
+
+        if self.size.y < axis_min {
+            axis_min = self.size.y;
+        }
+
+        if self.size.z < axis_min {
+            axis_min = self.size.z;
+        }
+
+        axis_min
+    }
+
+    /// Returns the support point in a given direction. This is useful for collision detection
+    /// algorithms.
+    #[inline]
+    pub fn get_support(&self, dir: Vector3) -> Vector3 {
+        let center = self.size * 0.5;
+        let offset = self.position + center;
+
+        Vector3::new(
+            if dir.x > 0.0 { -center.x } else { center.x },
+            if dir.y > 0.0 { -center.y } else { center.y },
+            if dir.z > 0.0 { -center.z } else { center.z },
+        ) + offset
+    }
+
+    /// Returns a copy of the bounding box grown a given amount of units on all the sides.
+    #[inline]
+    pub fn grow(&self, by: f32) -> Self {
+        let position = self.position - Vector3::new(by, by, by);
+        let size = self.size + Vector3::new(by, by, by) * 2.0;
+
+        Self { position, size }
+    }
+
+    /// Returns true if the bounding box overlaps with `b`.
+    #[inline]
+    pub fn intersects(&self, b: Self) -> bool {
+        !(self.position.x >= b.position.x + b.size.x
+            || self.position.x + self.size.x <= b.position.x
+            || self.position.y >= b.position.y + b.size.y
+            || self.position.y + self.size.y <= b.size.y
+            || self.position.z >= b.position.z + b.size.z
+            || self.position.z + self.size.z <= b.size.z)
+    }
+
+    /// Returns true if the bounding box is on both sides of a plane.
+    #[inline]
+    pub fn intersects_plane(&self, plane: Plane) -> bool {
+        let points = [
+            self.position,
+            self.position + Vector3::new(0.0, 0.0, self.size.z),
+            self.position + Vector3::new(0.0, self.size.y, 0.0),
+            self.position + Vector3::new(0.0, self.size.y, self.size.z),
+            self.position + Vector3::new(self.size.x, 0.0, 0.0),
+            self.position + Vector3::new(self.size.x, 0.0, self.size.z),
+            self.position + Vector3::new(self.size.x, self.size.y, 0.0),
+            self.position + self.size,
+        ];
+
+        let mut over = false;
+        let mut under = false;
+
+        for point in points {
+            if plane.distance_to(point) > 0.0 {
+                over = true;
+            } else {
+                under = true;
+            }
+        }
+
+        under && over
+    }
+
+    /// Returns true if the bounding box intersects the line segment between `from` and `to`.
+    #[inline]
+    pub fn intersects_segment(&self, from: Vector3, to: Vector3) -> bool {
+        let mut min: f32 = 0.0;
+        let mut max: f32 = 1.0;
+
+        let from = from.as_ref().iter();
+        let to = to.as_ref().iter();
+        let begin = self.position.as_ref().iter();
+        let end = self.get_end();
+        let end = end.as_ref().iter();
+
+        for (((from, to), begin), end) in from.zip(to).zip(begin).zip(end) {
+            let length = to - from;
+            let mut cmin = 0.0;
+            let mut cmax = 1.0;
+
+            if from < to {
+                if from > end || to < begin {
+                    return false;
+                }
+
+                if from < begin {
+                    cmin = (begin - from) / length;
+                }
+                if to < end {
+                    cmax = (end - from) / length;
+                }
+            } else {
+                if to > end || from < begin {
+                    return false;
+                }
+
+                if from > end {
+                    cmin = (end - from) / length;
+                }
+                if to < begin {
+                    cmax = (begin - from) / length;
+                }
+            }
+
+            min = min.max(cmin);
+            max = max.min(cmax);
+            if max < min {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Returns the intersection between two bounding boxes. An empty bounding box (size 0,0,0) is
+    /// returned if there is no intersection.
+    #[inline]
+    pub fn intersection(&self, b: Self) -> Self {
+        if !self.intersects(b) {
+            return Self::default();
+        }
+
+        let mut aabb = b;
+        aabb.position.x = aabb.position.x.max(self.position.x);
+        aabb.position.y = aabb.position.y.max(self.position.y);
+        aabb.position.z = aabb.position.z.max(self.position.z);
+
+        let end = self.get_end();
+        let end_b = b.get_end();
+
+        aabb.size.x = end.x.min(end_b.x) - aabb.position.x;
+        aabb.size.y = end.y.min(end_b.y) - aabb.position.y;
+        aabb.size.z = end.y.min(end_b.z) - aabb.position.z;
+
+        aabb
+    }
+
+    /// Returns a larger bounding box that contains both this `Aabb` and `b`.
+    #[inline]
+    pub fn merge(&self, b: Self) -> Self {
+        let position = Vector3::new(
+            self.position.x.min(b.position.x),
+            self.position.y.min(b.position.y),
+            self.position.z.min(b.position.z),
+        );
+        let end = Vector3::new(
+            (self.position.x + self.size.x).max(b.position.x + b.size.x),
+            (self.position.y + self.size.y).max(b.position.y + b.size.y),
+            (self.position.z + self.size.z).max(b.position.z + b.size.z),
+        );
+        let size = end - position;
+
+        Self { position, size }
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn sys(&self) -> *const sys::godot_aabb {
@@ -20,5 +397,165 @@ impl Aabb {
     #[inline]
     pub fn from_sys(c: sys::godot_aabb) -> Self {
         unsafe { std::mem::transmute::<sys::godot_aabb, Self>(c) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_types::IsEqualApprox;
+
+    #[test]
+    fn test_has_point() {
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+
+        assert!(aabb.has_point(Vector3::new(5.5, 5.5, 5.5)));
+        assert!(!aabb.has_point(Vector3::new(1.0, 1.0, 1.0)));
+        assert!(!aabb.has_point(Vector3::new(1.0, 1.0, 5.5)));
+        assert!(!aabb.has_point(Vector3::new(1.0, 5.5, 1.0)));
+        assert!(!aabb.has_point(Vector3::new(5.5, 1.0, 1.0)));
+        assert!(!aabb.has_point(Vector3::new(8.0, 8.0, 8.0)));
+        assert!(!aabb.has_point(Vector3::new(8.0, 8.0, 5.5)));
+        assert!(!aabb.has_point(Vector3::new(8.0, 5.5, 8.0)));
+        assert!(!aabb.has_point(Vector3::new(5.5, 8.0, 8.0)));
+    }
+
+    #[test]
+    fn test_has_point_negative_size() {
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(-3.0, -3.0, -3.0));
+
+        assert!(!aabb.has_point(Vector3::new(1.5, 1.5, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, 1.5, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(1.5, -1.0, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 4.0)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 1.5, 4.0)));
+        assert!(!aabb.has_point(Vector3::new(1.5, 4.0, 4.0)));
+
+        let aabb = aabb.abs();
+        assert!(aabb.has_point(Vector3::new(1.5, 1.5, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(-1.0, 1.5, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(1.5, -1.0, -1.0)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 4.0)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 1.5)));
+        assert!(!aabb.has_point(Vector3::new(4.0, 1.5, 4.0)));
+        assert!(!aabb.has_point(Vector3::new(1.5, 4.0, 4.0)));
+    }
+
+    #[test]
+    fn test_get_axis() {
+        let aabb = Aabb::new(Vector3::ZERO, Vector3::new(1.0, 2.0, 3.0));
+        assert!(aabb.get_longest_axis().is_equal_approx(Vector3::BACK));
+        assert_eq!(aabb.get_longest_axis_index(), Axis::Z);
+        assert!(aabb.get_longest_axis_size().is_equal_approx(3.0));
+
+        assert!(aabb.get_shortest_axis().is_equal_approx(Vector3::RIGHT));
+        assert_eq!(aabb.get_shortest_axis_index(), Axis::X);
+        assert!(aabb.get_shortest_axis_size().is_equal_approx(1.0));
+    }
+
+    #[test]
+    fn test_grow() {
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        let expected = Aabb::new(Vector3::new(1.0, 1.0, 1.0), Vector3::new(7.0, 7.0, 7.0));
+        assert_eq!(aabb.grow(2.0), expected);
+
+        let aabb = Aabb::new(Vector3::new(6.0, 6.0, 6.0), Vector3::new(-3.0, -3.0, -3.0));
+        let expected = Aabb::new(Vector3::new(4.0, 4.0, 4.0), Vector3::new(1.0, 1.0, 1.0));
+        assert_eq!(aabb.grow(2.0), expected);
+    }
+
+    #[test]
+    fn test_intersects() {
+        let a = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        let b = Aabb::new(Vector3::new(5.0, 5.0, 5.0), Vector3::new(3.0, 3.0, 3.0));
+        let c = Aabb::new(Vector3::new(6.0, 6.0, 6.0), Vector3::new(3.0, 3.0, 3.0));
+        let d = Aabb::new(Vector3::new(8.0, 8.0, 8.0), Vector3::new(-3.0, -3.0, -3.0));
+
+        assert!(a.intersects(b));
+        assert!(b.intersects(a));
+
+        assert!(!a.intersects(c));
+        assert!(!c.intersects(a));
+        assert!(!a.intersects(d));
+        assert!(!d.intersects(a));
+
+        let d = d.abs();
+        assert!(a.intersects(d));
+        assert!(d.intersects(a));
+    }
+
+    #[test]
+    fn test_intersects_plane() {
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        let plane_a = Plane::from_points(
+            Vector3::ZERO,
+            Vector3::new(0.0, 9.0, 9.0),
+            Vector3::new(9.0, 9.0, 0.0),
+        );
+        let plane_b = Plane::from_points(
+            Vector3::ZERO,
+            Vector3::new(0.0, 9.0, 9.0),
+            Vector3::new(0.0, 9.0, -9.0),
+        );
+        assert!(aabb.intersects_plane(plane_a.unwrap()));
+        assert!(!aabb.intersects_plane(plane_b.unwrap()));
+
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(-3.0, -3.0, -3.0));
+        let plane_a = Plane::from_points(
+            Vector3::ZERO,
+            Vector3::new(0.0, 3.0, 3.0),
+            Vector3::new(3.0, 3.0, 0.0),
+        );
+        let plane_b = Plane::from_points(
+            Vector3::ZERO,
+            Vector3::new(0.0, -3.0, 3.0),
+            Vector3::new(0.0, -3.0, -3.0),
+        );
+        assert!(aabb.intersects_plane(plane_a.unwrap()));
+        assert!(!aabb.intersects_plane(plane_b.unwrap()));
+    }
+
+    #[test]
+    fn test_intersects_segment() {
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        assert!(aabb.intersects_segment(Vector3::ZERO, Vector3::new(9.0, 9.0, 9.0)));
+        assert!(!aabb.intersects_segment(Vector3::ZERO, Vector3::new(9.0, 9.0, 0.0)));
+
+        let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(-3.0, -3.0, -3.0));
+        assert!(aabb.intersects_segment(Vector3::ZERO, Vector3::new(3.0, 3.0, 3.0)));
+        assert!(!aabb.intersects_segment(Vector3::ZERO, Vector3::new(3.0, 3.0, -3.0)));
+    }
+
+    #[test]
+    fn test_intersection() {
+        let a = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        let b = Aabb::new(Vector3::new(5.0, 5.0, 5.0), Vector3::new(3.0, 3.0, 3.0));
+        let c = Aabb::new(Vector3::new(6.0, 6.0, 6.0), Vector3::new(3.0, 3.0, 3.0));
+        let d = Aabb::new(Vector3::new(8.0, 8.0, 8.0), Vector3::new(-3.0, -3.0, -3.0));
+
+        let expected = Aabb::new(Vector3::new(5.0, 5.0, 5.0), Vector3::new(1.0, 1.0, 1.0));
+
+        assert_eq!(a.intersection(b), expected);
+        assert_eq!(a.intersection(c), Aabb::default());
+        assert_eq!(a.intersection(d), Aabb::default());
+        assert_eq!(a.intersection(d.abs()), expected);
+    }
+
+    #[test]
+    fn test_merge() {
+        let a = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
+        let b = Aabb::new(Vector3::new(5.0, 5.0, 5.0), Vector3::new(3.0, 3.0, 3.0));
+        let c = Aabb::new(Vector3::new(8.0, 8.0, 8.0), Vector3::new(-3.0, -3.0, -3.0));
+
+        let expected = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(5.0, 5.0, 5.0));
+
+        assert_eq!(a.merge(b), expected);
+        assert_ne!(a.merge(c), expected);
+        assert_eq!(a.merge(c.abs()), expected);
     }
 }

--- a/gdnative-core/src/core_types/geom/aabb.rs
+++ b/gdnative-core/src/core_types/geom/aabb.rs
@@ -28,7 +28,7 @@ impl Aabb {
 
     /// Ending corner. This is calculated as `position + size`.
     #[inline]
-    pub fn end(&self) -> Vector3 {
+    pub fn end(self) -> Vector3 {
         self.position + self.size
     }
 
@@ -41,7 +41,7 @@ impl Aabb {
     /// Returns an `Aabb` with equivalent position and area, modified so that the most-negative
     /// corner is the origin and the size is positive.
     #[inline]
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         let position = self.position + Vector3::gd(self.size.glam().min(glam::Vec3A::ZERO));
         let size = self.size.abs();
 
@@ -54,7 +54,7 @@ impl Aabb {
     ///
     /// [get_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-area
     #[inline]
-    pub fn get_volume(&self) -> f32 {
+    pub fn get_volume(self) -> f32 {
         self.size.x * self.size.y * self.size.z
     }
 
@@ -68,13 +68,13 @@ impl Aabb {
     ///
     /// [`has_no_area`]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-has-no-area
     #[inline]
-    pub fn has_no_volume(&self) -> bool {
+    pub fn has_no_volume(self) -> bool {
         self.size.x <= 0.0 || self.size.y <= 0.0 || self.size.z <= 0.0
     }
 
     /// Returns true if the bounding box is empty or all of its dimensions are negative.
     #[inline]
-    pub fn has_no_surface(&self) -> bool {
+    pub fn has_no_surface(self) -> bool {
         self.size.x <= 0.0 && self.size.y <= 0.0 && self.size.z <= 0.0
     }
 
@@ -84,7 +84,7 @@ impl Aabb {
     /// Note: This method is not reliable for bounding boxes with a negative size. Use
     /// [`abs`][Self::abs] to get a positive sized equivalent box to check for contained points.
     #[inline]
-    pub fn contains_point(&self, point: Vector3) -> bool {
+    pub fn contains_point(self, point: Vector3) -> bool {
         let point = point - self.position;
 
         point.abs() == point
@@ -96,7 +96,7 @@ impl Aabb {
     /// Returns true if this bounding box and `b` are approximately equal, by calling
     /// [`is_equal_approx`](Vector3::is_equal_approx) on each component.
     #[inline]
-    pub fn is_equal_approx(&self, b: Self) -> bool {
+    pub fn is_equal_approx(self, b: Self) -> bool {
         self.position.is_equal_approx(b.position) && self.size.is_equal_approx(b.size)
     }
 
@@ -104,7 +104,7 @@ impl Aabb {
     ///
     /// The index returns an arbitrary point, but all points are guaranteed to be unique.
     #[inline]
-    pub fn get_endpoint(&self, index: usize) -> Option<Vector3> {
+    pub fn get_endpoint(self, index: usize) -> Option<Vector3> {
         match index {
             0 => Some(self.position),
             1 => Some(self.position + Vector3::new(0.0, 0.0, self.size.z)),
@@ -120,7 +120,7 @@ impl Aabb {
 
     /// Returns the normalized longest axis of the bounding box.
     #[inline]
-    pub fn get_longest_axis(&self) -> Vector3 {
+    pub fn get_longest_axis(self) -> Vector3 {
         self.size.max_axis().to_unit_vector()
     }
 
@@ -128,20 +128,20 @@ impl Aabb {
     ///
     /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
     #[inline]
-    pub fn get_longest_axis_index(&self) -> Axis {
+    pub fn get_longest_axis_index(self) -> Axis {
         self.size.max_axis()
     }
 
     /// Returns the scalar length of the longest axis of the bounding box.
     #[inline]
-    pub fn get_longest_axis_size(&self) -> f32 {
+    pub fn get_longest_axis_size(self) -> f32 {
         let Vector3 { x, y, z } = self.size;
         x.max(y).max(z)
     }
 
     /// Returns the normalized shortest axis of the bounding box.
     #[inline]
-    pub fn get_shortest_axis(&self) -> Vector3 {
+    pub fn get_shortest_axis(self) -> Vector3 {
         self.size.min_axis().to_unit_vector()
     }
 
@@ -149,13 +149,13 @@ impl Aabb {
     ///
     /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
     #[inline]
-    pub fn get_shortest_axis_index(&self) -> Axis {
+    pub fn get_shortest_axis_index(self) -> Axis {
         self.size.min_axis()
     }
 
     /// Returns the scalar length of the shortest axis of the bounding box.
     #[inline]
-    pub fn get_shortest_axis_size(&self) -> f32 {
+    pub fn get_shortest_axis_size(self) -> f32 {
         let Vector3 { x, y, z } = self.size;
         x.min(y).min(z)
     }
@@ -173,7 +173,7 @@ impl Aabb {
     /// [1]: https://ncollide.org/geometric_representations/#support-mappings
     /// [2]: https://www.toptal.com/game/video-game-physics-part-ii-collision-detection-for-solid-objects
     #[inline]
-    pub fn get_support(&self, dir: Vector3) -> Vector3 {
+    pub fn get_support(self, dir: Vector3) -> Vector3 {
         self.position
             + Vector3::new(
                 if dir.x > 0.0 { 0.0 } else { self.size.x },
@@ -187,7 +187,7 @@ impl Aabb {
     /// It is possible to specify a negative amount to shrink the AABB (note that this can invert the AABB).
     #[inline]
     #[must_use]
-    pub fn grow(&self, by: f32) -> Self {
+    pub fn grow(self, by: f32) -> Self {
         let position = self.position - Vector3::new(by, by, by);
         let size = self.size + Vector3::new(by, by, by) * 2.0;
 
@@ -198,7 +198,7 @@ impl Aabb {
     ///
     /// This **excludes** borders; if the intersection has no volume, `false` is returned.
     #[inline]
-    pub fn intersects(&self, b: Self) -> bool {
+    pub fn intersects(self, b: Self) -> bool {
         self.position.x < b.position.x + b.size.x
             && self.position.x + self.size.x > b.position.x
             && self.position.y < b.position.y + b.size.y
@@ -209,7 +209,7 @@ impl Aabb {
 
     /// Returns true if the bounding box is on both sides of a plane.
     #[inline]
-    pub fn intersects_plane(&self, plane: Plane) -> bool {
+    pub fn intersects_plane(self, plane: Plane) -> bool {
         let mut corners = [Vector3::ZERO; 8];
         for (i, corner) in corners.iter_mut().enumerate() {
             *corner = self.get_endpoint(i).unwrap();
@@ -230,7 +230,7 @@ impl Aabb {
 
     /// Returns true if the bounding box intersects the line segment between `from` and `to`.
     #[inline]
-    pub fn intersects_segment(&self, from: Vector3, to: Vector3) -> bool {
+    pub fn intersects_segment(self, from: Vector3, to: Vector3) -> bool {
         let mut min: f32 = 0.0;
         let mut max: f32 = 1.0;
 
@@ -283,7 +283,7 @@ impl Aabb {
     /// This **excludes** borders; if the intersection has no volume, `None` is returned.
     #[inline]
     #[must_use]
-    pub fn intersection(&self, b: Self) -> Option<Self> {
+    pub fn intersection(self, b: Self) -> Option<Self> {
         if !self.intersects(b) {
             return None;
         }
@@ -306,7 +306,7 @@ impl Aabb {
     /// Returns a larger bounding box that contains both this `Aabb` and `b`.
     #[inline]
     #[must_use]
-    pub fn merge(&self, b: Self) -> Self {
+    pub fn merge(self, b: Self) -> Self {
         let position = Vector3::new(
             self.position.x.min(b.position.x),
             self.position.y.min(b.position.y),

--- a/gdnative-core/src/core_types/geom/aabb.rs
+++ b/gdnative-core/src/core_types/geom/aabb.rs
@@ -52,14 +52,14 @@ impl Aabb {
     ///
     /// This method corresponds to the [`get_area`] GDScript method.
     ///
-    /// [get_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-area
+    /// [`get_area`]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-area
     #[inline]
-    pub fn get_volume(self) -> f32 {
+    pub fn volume(self) -> f32 {
         self.size.x * self.size.y * self.size.z
     }
 
     /// Returns true if the bounding box is flat or empty. See also
-    /// [`get_volume`][Self::get_volume].
+    /// [`volume`][Self::volume].
     ///
     /// This method corresponds to the [`has_no_area`] GDScript method.
     ///
@@ -118,46 +118,40 @@ impl Aabb {
         }
     }
 
-    /// Returns the normalized longest axis of the bounding box.
-    #[inline]
-    pub fn get_longest_axis(self) -> Vector3 {
-        self.size.max_axis().to_unit_vector()
-    }
-
-    /// Returns the index of the longest axis of the bounding box.
+    /// Returns the longest side of this AABB as an axis index and its length.
     ///
-    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
-    #[inline]
-    pub fn get_longest_axis_index(self) -> Axis {
-        self.size.max_axis()
-    }
-
-    /// Returns the scalar length of the longest axis of the bounding box.
-    #[inline]
-    pub fn get_longest_axis_size(self) -> f32 {
-        let Vector3 { x, y, z } = self.size;
-        x.max(y).max(z)
-    }
-
-    /// Returns the normalized shortest axis of the bounding box.
-    #[inline]
-    pub fn get_shortest_axis(self) -> Vector3 {
-        self.size.min_axis().to_unit_vector()
-    }
-
-    /// Returns the index of the shortest axis of the bounding box.
+    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.  
+    /// To get the unit vector along the axis, use [`Axis::to_unit_vector()`].
     ///
-    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
+    /// If you want to emulate the separate GDScript methods, you can do this:
+    /// ```no_run
+    /// # let aabb: gdnative::core_types::Aabb = todo!();
+    /// let (index, size) = aabb.longest_axis();
+    /// let axis = index.to_unit_vector();
+    /// ```
     #[inline]
-    pub fn get_shortest_axis_index(self) -> Axis {
-        self.size.min_axis()
+    pub fn longest_axis(self) -> (Axis, f32) {
+        let Vector3 { x, y, z } = self.size;
+
+        (self.size.max_axis(), x.max(y).max(z))
     }
 
-    /// Returns the scalar length of the shortest axis of the bounding box.
+    /// Returns the shortest side of this AABB as an axis index and its length.
+    ///
+    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.  
+    /// To get the unit vector along the axis, use [`Axis::to_unit_vector()`].
+    ///
+    /// If you want to emulate the separate GDScript methods, you can do this:
+    /// ```no_run
+    /// # let aabb: gdnative::core_types::Aabb = todo!();
+    /// let (index, size) = aabb.shortest_axis();
+    /// let axis = index.to_unit_vector();
+    /// ```
     #[inline]
-    pub fn get_shortest_axis_size(self) -> f32 {
+    pub fn shortest_axis(self) -> (Axis, f32) {
         let Vector3 { x, y, z } = self.size;
-        x.min(y).min(z)
+
+        (self.size.min_axis(), x.min(y).min(z))
     }
 
     /// Returns the support point in a given direction. This is useful for collision detection
@@ -382,15 +376,22 @@ mod tests {
     }
 
     #[test]
-    fn test_get_axis() {
+    fn test_longest_shortest_axis() {
         let aabb = Aabb::new(Vector3::ZERO, Vector3::new(1.0, 2.0, 3.0));
-        assert!(aabb.get_longest_axis().is_equal_approx(Vector3::BACK));
-        assert_eq!(aabb.get_longest_axis_index(), Axis::Z);
-        assert!(aabb.get_longest_axis_size().is_equal_approx(3.0));
 
-        assert!(aabb.get_shortest_axis().is_equal_approx(Vector3::RIGHT));
-        assert_eq!(aabb.get_shortest_axis_index(), Axis::X);
-        assert!(aabb.get_shortest_axis_size().is_equal_approx(1.0));
+        let (longest_axis, longest_size) = aabb.longest_axis();
+        let longest_vector = longest_axis.to_unit_vector();
+
+        assert!(longest_vector.is_equal_approx(Vector3::BACK));
+        assert_eq!(longest_axis, Axis::Z);
+        assert!(longest_size.is_equal_approx(3.0));
+
+        let (shortest_axis, shortest_size) = aabb.shortest_axis();
+        let shortest_vector = shortest_axis.to_unit_vector();
+
+        assert!(shortest_vector.is_equal_approx(Vector3::RIGHT));
+        assert_eq!(shortest_axis, Axis::X);
+        assert!(shortest_size.is_equal_approx(1.0));
     }
 
     #[test]

--- a/gdnative-core/src/core_types/geom/aabb.rs
+++ b/gdnative-core/src/core_types/geom/aabb.rs
@@ -18,23 +18,17 @@ pub struct Aabb {
 
 impl Aabb {
     /// Creates an `Aabb` by position and size.
+    ///
+    /// Note that while `size` components are allowed to be negative, they can lead to unintuitive results.
+    /// It is recommended to use [`abs`][Self::abs] on such AABBs.
     #[inline]
     pub fn new(position: Vector3, size: Vector3) -> Self {
         Self { position, size }
     }
 
-    /// Creates an `Aabb` by x, y, z, width, height, and depth.
-    #[inline]
-    pub fn from_components(x: f32, y: f32, z: f32, width: f32, height: f32, depth: f32) -> Self {
-        let position = Vector3::new(x, y, z);
-        let size = Vector3::new(width, height, depth);
-
-        Self { position, size }
-    }
-
     /// Ending corner. This is calculated as `position + size`.
     #[inline]
-    pub fn get_end(&self) -> Vector3 {
+    pub fn end(&self) -> Vector3 {
         self.position + self.size
     }
 
@@ -48,12 +42,7 @@ impl Aabb {
     /// corner is the origin and the size is positive.
     #[inline]
     pub fn abs(&self) -> Self {
-        let position = self.position
-            + Vector3::new(
-                self.size.x.min(0.0),
-                self.size.y.min(0.0),
-                self.size.z.min(0.0),
-            );
+        let position = self.position + Vector3::gd(self.size.glam().min(glam::Vec3A::ZERO));
         let size = self.size.abs();
 
         Self { position, size }
@@ -61,7 +50,7 @@ impl Aabb {
 
     /// Returns the volume of the bounding box. See also [`has_no_volume`][Self::has_no_volume].
     ///
-    /// This method corresponds to the [`get_area`][get_area] GDScript method.
+    /// This method corresponds to the [`get_area`] GDScript method.
     ///
     /// [get_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-area
     #[inline]
@@ -72,12 +61,12 @@ impl Aabb {
     /// Returns true if the bounding box is flat or empty. See also
     /// [`get_volume`][Self::get_volume].
     ///
-    /// This method corresponds to the [`has_no_area`][has_no_area] GDScript method.
+    /// This method corresponds to the [`has_no_area`] GDScript method.
     ///
     /// Note: If the bounding box has a negative size and is not flat or empty, this method will
     /// return true.
     ///
-    /// [has_no_area]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-has-no-area
+    /// [`has_no_area`]: https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-has-no-area
     #[inline]
     pub fn has_no_volume(&self) -> bool {
         self.size.x <= 0.0 || self.size.y <= 0.0 || self.size.z <= 0.0
@@ -95,7 +84,7 @@ impl Aabb {
     /// Note: This method is not reliable for bounding boxes with a negative size. Use
     /// [`abs`][Self::abs] to get a positive sized equivalent box to check for contained points.
     #[inline]
-    pub fn has_point(&self, point: Vector3) -> bool {
+    pub fn contains_point(&self, point: Vector3) -> bool {
         let point = point - self.position;
 
         point.abs() == point
@@ -111,11 +100,11 @@ impl Aabb {
         self.position.is_equal_approx(b.position) && self.size.is_equal_approx(b.size)
     }
 
-    /// Gets the position of the 8 endpoints of the bounding in space.
+    /// Gets the position of the 8 endpoints of the bounding box in space.
     ///
     /// The index returns an arbitrary point, but all points are guaranteed to be unique.
     #[inline]
-    pub fn get_endpoint(&self, index: i64) -> Option<Vector3> {
+    pub fn get_endpoint(&self, index: usize) -> Option<Vector3> {
         match index {
             0 => Some(self.position),
             1 => Some(self.position + Vector3::new(0.0, 0.0, self.size.z)),
@@ -132,123 +121,72 @@ impl Aabb {
     /// Returns the normalized longest axis of the bounding box.
     #[inline]
     pub fn get_longest_axis(&self) -> Vector3 {
-        let mut axis = Vector3::RIGHT;
-        let mut axis_max = self.size.x;
-
-        if self.size.y > axis_max {
-            axis = Vector3::UP;
-            axis_max = self.size.y;
-        }
-
-        if self.size.z > axis_max {
-            axis = Vector3::BACK;
-        }
-
-        axis
+        self.size.max_axis().to_unit_vector()
     }
 
     /// Returns the index of the longest axis of the bounding box.
+    ///
+    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
     #[inline]
     pub fn get_longest_axis_index(&self) -> Axis {
-        let mut axis = Axis::X;
-        let mut axis_max = self.size.x;
-
-        if self.size.y > axis_max {
-            axis = Axis::Y;
-            axis_max = self.size.y;
-        }
-
-        if self.size.z > axis_max {
-            axis = Axis::Z;
-        }
-
-        axis
+        self.size.max_axis()
     }
 
     /// Returns the scalar length of the longest axis of the bounding box.
     #[inline]
     pub fn get_longest_axis_size(&self) -> f32 {
-        let mut axis_max = self.size.x;
-
-        if self.size.y > axis_max {
-            axis_max = self.size.y;
-        }
-
-        if self.size.z > axis_max {
-            axis_max = self.size.z;
-        }
-
-        axis_max
+        let Vector3 { x, y, z } = self.size;
+        x.max(y).max(z)
     }
 
     /// Returns the normalized shortest axis of the bounding box.
     #[inline]
     pub fn get_shortest_axis(&self) -> Vector3 {
-        let mut axis = Vector3::RIGHT;
-        let mut axis_min = self.size.x;
-
-        if self.size.y < axis_min {
-            axis = Vector3::UP;
-            axis_min = self.size.y;
-        }
-
-        if self.size.z < axis_min {
-            axis = Vector3::BACK;
-        }
-
-        axis
+        self.size.min_axis().to_unit_vector()
     }
 
     /// Returns the index of the shortest axis of the bounding box.
+    ///
+    /// If multiple axes have the same length, then the first in order X, Y, Z is returned.
     #[inline]
     pub fn get_shortest_axis_index(&self) -> Axis {
-        let mut axis = Axis::X;
-        let mut axis_min = self.size.x;
-
-        if self.size.y < axis_min {
-            axis = Axis::Y;
-            axis_min = self.size.y;
-        }
-
-        if self.size.z < axis_min {
-            axis = Axis::Z;
-        }
-
-        axis
+        self.size.min_axis()
     }
 
     /// Returns the scalar length of the shortest axis of the bounding box.
     #[inline]
     pub fn get_shortest_axis_size(&self) -> f32 {
-        let mut axis_min = self.size.x;
-
-        if self.size.y < axis_min {
-            axis_min = self.size.y;
-        }
-
-        if self.size.z < axis_min {
-            axis_min = self.size.z;
-        }
-
-        axis_min
+        let Vector3 { x, y, z } = self.size;
+        x.min(y).min(z)
     }
 
     /// Returns the support point in a given direction. This is useful for collision detection
     /// algorithms.
+    ///
+    /// The support point is a point on the boundary of the AABB, which is the furthest from the center in the given direction `dir`.
+    /// In other words, when you cast a ray from the AABB's center toward `dir` and intersect that with the AABB boundary, you will get
+    /// the support point.
+    ///
+    /// Mathematically, the support point corresponds to the point which maximizes its dot product with `dir`.
+    /// See also [1] and [2] for more information.
+    ///
+    /// [1]: https://ncollide.org/geometric_representations/#support-mappings
+    /// [2]: https://www.toptal.com/game/video-game-physics-part-ii-collision-detection-for-solid-objects
     #[inline]
     pub fn get_support(&self, dir: Vector3) -> Vector3 {
-        let center = self.size * 0.5;
-        let offset = self.position + center;
-
-        Vector3::new(
-            if dir.x > 0.0 { -center.x } else { center.x },
-            if dir.y > 0.0 { -center.y } else { center.y },
-            if dir.z > 0.0 { -center.z } else { center.z },
-        ) + offset
+        self.position
+            + Vector3::new(
+                if dir.x > 0.0 { 0.0 } else { self.size.x },
+                if dir.y > 0.0 { 0.0 } else { self.size.y },
+                if dir.z > 0.0 { 0.0 } else { self.size.z },
+            )
     }
 
-    /// Returns a copy of the bounding box grown a given amount of units on all the sides.
+    /// Returns a copy of the bounding box, grown a given amount of units on all 6 sides.
+    ///
+    /// It is possible to specify a negative amount to shrink the AABB (note that this can invert the AABB).
     #[inline]
+    #[must_use]
     pub fn grow(&self, by: f32) -> Self {
         let position = self.position - Vector3::new(by, by, by);
         let size = self.size + Vector3::new(by, by, by) * 2.0;
@@ -257,34 +195,29 @@ impl Aabb {
     }
 
     /// Returns true if the bounding box overlaps with `b`.
+    ///
+    /// This **excludes** borders; if the intersection has no volume, `false` is returned.
     #[inline]
     pub fn intersects(&self, b: Self) -> bool {
-        !(self.position.x >= b.position.x + b.size.x
-            || self.position.x + self.size.x <= b.position.x
-            || self.position.y >= b.position.y + b.size.y
-            || self.position.y + self.size.y <= b.size.y
-            || self.position.z >= b.position.z + b.size.z
-            || self.position.z + self.size.z <= b.size.z)
+        self.position.x < b.position.x + b.size.x
+            && self.position.x + self.size.x > b.position.x
+            && self.position.y < b.position.y + b.size.y
+            && self.position.y + self.size.y > b.size.y
+            && self.position.z < b.position.z + b.size.z
+            && self.position.z + self.size.z > b.size.z
     }
 
     /// Returns true if the bounding box is on both sides of a plane.
     #[inline]
     pub fn intersects_plane(&self, plane: Plane) -> bool {
-        let points = [
-            self.position,
-            self.position + Vector3::new(0.0, 0.0, self.size.z),
-            self.position + Vector3::new(0.0, self.size.y, 0.0),
-            self.position + Vector3::new(0.0, self.size.y, self.size.z),
-            self.position + Vector3::new(self.size.x, 0.0, 0.0),
-            self.position + Vector3::new(self.size.x, 0.0, self.size.z),
-            self.position + Vector3::new(self.size.x, self.size.y, 0.0),
-            self.position + self.size,
-        ];
+        let mut corners = [Vector3::ZERO; 8];
+        for (i, corner) in corners.iter_mut().enumerate() {
+            *corner = self.get_endpoint(i).unwrap();
+        }
 
         let mut over = false;
         let mut under = false;
-
-        for point in points {
+        for point in corners {
             if plane.distance_to(point) > 0.0 {
                 over = true;
             } else {
@@ -301,13 +234,12 @@ impl Aabb {
         let mut min: f32 = 0.0;
         let mut max: f32 = 1.0;
 
-        let from = from.as_ref().iter();
-        let to = to.as_ref().iter();
-        let begin = self.position.as_ref().iter();
-        let end = self.get_end();
-        let end = end.as_ref().iter();
+        for i in 0..3 {
+            let from = from.as_ref()[i];
+            let to = to.as_ref()[i];
+            let begin = self.position.as_ref()[i];
+            let end = self.end().as_ref()[i];
 
-        for (((from, to), begin), end) in from.zip(to).zip(begin).zip(end) {
             let length = to - from;
             let mut cmin = 0.0;
             let mut cmax = 1.0;
@@ -346,12 +278,14 @@ impl Aabb {
         true
     }
 
-    /// Returns the intersection between two bounding boxes. An empty bounding box (size 0,0,0) is
-    /// returned if there is no intersection.
+    /// Returns the intersection between two bounding boxes, or `None` if there is no intersection.
+    ///
+    /// This **excludes** borders; if the intersection has no volume, `None` is returned.
     #[inline]
-    pub fn intersection(&self, b: Self) -> Self {
+    #[must_use]
+    pub fn intersection(&self, b: Self) -> Option<Self> {
         if !self.intersects(b) {
-            return Self::default();
+            return None;
         }
 
         let mut aabb = b;
@@ -359,18 +293,19 @@ impl Aabb {
         aabb.position.y = aabb.position.y.max(self.position.y);
         aabb.position.z = aabb.position.z.max(self.position.z);
 
-        let end = self.get_end();
-        let end_b = b.get_end();
+        let end = self.end();
+        let end_b = b.end();
 
         aabb.size.x = end.x.min(end_b.x) - aabb.position.x;
         aabb.size.y = end.y.min(end_b.y) - aabb.position.y;
         aabb.size.z = end.y.min(end_b.z) - aabb.position.z;
 
-        aabb
+        Some(aabb)
     }
 
     /// Returns a larger bounding box that contains both this `Aabb` and `b`.
     #[inline]
+    #[must_use]
     pub fn merge(&self, b: Self) -> Self {
         let position = Vector3::new(
             self.position.x.min(b.position.x),
@@ -409,41 +344,41 @@ mod tests {
     fn test_has_point() {
         let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(3.0, 3.0, 3.0));
 
-        assert!(aabb.has_point(Vector3::new(5.5, 5.5, 5.5)));
-        assert!(!aabb.has_point(Vector3::new(1.0, 1.0, 1.0)));
-        assert!(!aabb.has_point(Vector3::new(1.0, 1.0, 5.5)));
-        assert!(!aabb.has_point(Vector3::new(1.0, 5.5, 1.0)));
-        assert!(!aabb.has_point(Vector3::new(5.5, 1.0, 1.0)));
-        assert!(!aabb.has_point(Vector3::new(8.0, 8.0, 8.0)));
-        assert!(!aabb.has_point(Vector3::new(8.0, 8.0, 5.5)));
-        assert!(!aabb.has_point(Vector3::new(8.0, 5.5, 8.0)));
-        assert!(!aabb.has_point(Vector3::new(5.5, 8.0, 8.0)));
+        assert!(aabb.contains_point(Vector3::new(5.5, 5.5, 5.5)));
+        assert!(!aabb.contains_point(Vector3::new(1.0, 1.0, 1.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.0, 1.0, 5.5)));
+        assert!(!aabb.contains_point(Vector3::new(1.0, 5.5, 1.0)));
+        assert!(!aabb.contains_point(Vector3::new(5.5, 1.0, 1.0)));
+        assert!(!aabb.contains_point(Vector3::new(8.0, 8.0, 8.0)));
+        assert!(!aabb.contains_point(Vector3::new(8.0, 8.0, 5.5)));
+        assert!(!aabb.contains_point(Vector3::new(8.0, 5.5, 8.0)));
+        assert!(!aabb.contains_point(Vector3::new(5.5, 8.0, 8.0)));
     }
 
     #[test]
     fn test_has_point_negative_size() {
         let aabb = Aabb::new(Vector3::new(3.0, 3.0, 3.0), Vector3::new(-3.0, -3.0, -3.0));
 
-        assert!(!aabb.has_point(Vector3::new(1.5, 1.5, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, 1.5, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(1.5, -1.0, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 4.0)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 1.5, 4.0)));
-        assert!(!aabb.has_point(Vector3::new(1.5, 4.0, 4.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.5, 1.5, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, -1.0, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, -1.0, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, 1.5, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.5, -1.0, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 4.0, 4.0)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 4.0, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 1.5, 4.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.5, 4.0, 4.0)));
 
         let aabb = aabb.abs();
-        assert!(aabb.has_point(Vector3::new(1.5, 1.5, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, -1.0, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(-1.0, 1.5, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(1.5, -1.0, -1.0)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 4.0)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 4.0, 1.5)));
-        assert!(!aabb.has_point(Vector3::new(4.0, 1.5, 4.0)));
-        assert!(!aabb.has_point(Vector3::new(1.5, 4.0, 4.0)));
+        assert!(aabb.contains_point(Vector3::new(1.5, 1.5, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, -1.0, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, -1.0, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(-1.0, 1.5, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.5, -1.0, -1.0)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 4.0, 4.0)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 4.0, 1.5)));
+        assert!(!aabb.contains_point(Vector3::new(4.0, 1.5, 4.0)));
+        assert!(!aabb.contains_point(Vector3::new(1.5, 4.0, 4.0)));
     }
 
     #[test]
@@ -476,6 +411,7 @@ mod tests {
         let c = Aabb::new(Vector3::new(6.0, 6.0, 6.0), Vector3::new(3.0, 3.0, 3.0));
         let d = Aabb::new(Vector3::new(8.0, 8.0, 8.0), Vector3::new(-3.0, -3.0, -3.0));
 
+        assert!(a.intersects(a));
         assert!(a.intersects(b));
         assert!(b.intersects(a));
 
@@ -540,10 +476,11 @@ mod tests {
 
         let expected = Aabb::new(Vector3::new(5.0, 5.0, 5.0), Vector3::new(1.0, 1.0, 1.0));
 
-        assert_eq!(a.intersection(b), expected);
-        assert_eq!(a.intersection(c), Aabb::default());
-        assert_eq!(a.intersection(d), Aabb::default());
-        assert_eq!(a.intersection(d.abs()), expected);
+        assert_eq!(a.intersection(a), Some(a));
+        assert_eq!(a.intersection(b), Some(expected));
+        assert_eq!(a.intersection(c), None);
+        assert_eq!(a.intersection(d), None);
+        assert_eq!(a.intersection(d.abs()), Some(expected));
     }
 
     #[test]

--- a/gdnative-core/src/core_types/geom/plane.rs
+++ b/gdnative-core/src/core_types/geom/plane.rs
@@ -242,7 +242,7 @@ impl Plane {
     fn ensure_normalized(self) {
         assert!(
             self.normal.is_normalized(),
-            "Plane::normal {:?} does not have unit length",
+            "Plane {:?} -- normal does not have unit length",
             self.normal
         );
     }

--- a/gdnative-core/src/core_types/geom/rect2.rs
+++ b/gdnative-core/src/core_types/geom/rect2.rs
@@ -35,7 +35,7 @@ impl Rect2 {
 
     /// Ending corner. This is calculated as `position + size`.
     #[inline]
-    pub fn end(&self) -> Vector2 {
+    pub fn end(self) -> Vector2 {
         self.position + self.size
     }
 
@@ -48,7 +48,7 @@ impl Rect2 {
     /// Returns a rectangle with equivalent position and area, modified so that the top-left corner
     /// is the origin and `width` and `height` are positive.
     #[inline]
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         let position = self.position + Vector2::new(self.size.x.min(0.0), self.size.y.min(0.0));
         let size = self.size.abs();
 
@@ -57,7 +57,7 @@ impl Rect2 {
 
     /// Returns the area of the rectangle. See also [`has_no_area`][Self::has_no_area].
     #[inline]
-    pub fn get_area(&self) -> f32 {
+    pub fn get_area(self) -> f32 {
         self.size.x * self.size.y
     }
 
@@ -80,7 +80,7 @@ impl Rect2 {
     /// # }
     /// ```
     #[inline]
-    pub fn has_no_area(&self) -> bool {
+    pub fn has_no_area(self) -> bool {
         self.size.x <= 0.0 || self.size.y <= 0.0
     }
 
@@ -90,7 +90,7 @@ impl Rect2 {
     /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
     /// to get a positive sized equivalent rectangle to check for contained points.
     #[inline]
-    pub fn contains_point(&self, point: Vector2) -> bool {
+    pub fn contains_point(self, point: Vector2) -> bool {
         let point = point - self.position;
 
         point.abs() == point && point.x < self.size.x && point.y < self.size.y
@@ -99,7 +99,7 @@ impl Rect2 {
     /// Returns true if this rectangle and `b` are approximately equal, by calling
     /// [`is_equal_approx`](Vector2::is_equal_approx) on each component.
     #[inline]
-    pub fn is_equal_approx(&self, b: Self) -> bool {
+    pub fn is_equal_approx(self, b: Self) -> bool {
         self.position.is_equal_approx(b.position) && self.size.is_equal_approx(b.size)
     }
 
@@ -111,7 +111,7 @@ impl Rect2 {
     /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
     /// to get a positive sized equivalent rectangle to check for intersections.
     #[inline]
-    pub fn intersects(&self, b: Self) -> bool {
+    pub fn intersects(self, b: Self) -> bool {
         self.position.x < b.position.x + b.size.x
             && self.position.x + self.size.x > b.position.x
             && self.position.y < b.position.y + b.size.y
@@ -126,7 +126,7 @@ impl Rect2 {
     /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
     /// to get a positive sized equivalent rectangle to check for intersections.
     #[inline]
-    pub fn intersects_including_borders(&self, b: Self) -> bool {
+    pub fn intersects_including_borders(self, b: Self) -> bool {
         self.position.x <= b.position.x + b.size.x
             && self.position.x + self.size.x >= b.position.x
             && self.position.y <= b.position.y + b.size.y
@@ -137,7 +137,7 @@ impl Rect2 {
     ///
     /// This is true when `self` covers all the area of `b`, and possibly (but not necessarily) more.
     #[inline]
-    pub fn encloses(&self, b: Self) -> bool {
+    pub fn encloses(self, b: Self) -> bool {
         b.position.x >= self.position.x
             && b.position.y >= self.position.y
             && b.position.x + b.size.x <= self.position.x + self.size.x
@@ -153,7 +153,7 @@ impl Rect2 {
     /// to get a positive sized equivalent rectangle for clipping.
     #[inline]
     #[must_use]
-    pub fn intersection(&self, b: Self) -> Option<Self> {
+    pub fn intersection(self, b: Self) -> Option<Self> {
         if !self.intersects(b) {
             return None;
         }
@@ -177,7 +177,7 @@ impl Rect2 {
     /// to get a positive sized equivalent rectangle for merging.
     #[inline]
     #[must_use]
-    pub fn merge(&self, b: Self) -> Self {
+    pub fn merge(self, b: Self) -> Self {
         let position = Vector2::new(
             self.position.x.min(b.position.x),
             self.position.y.min(b.position.y),
@@ -214,14 +214,14 @@ impl Rect2 {
     /// ```
     #[inline]
     #[must_use]
-    pub fn expand(&self, to: Vector2) -> Self {
+    pub fn expand(self, to: Vector2) -> Self {
         self.merge(Self::new(to, Vector2::ZERO))
     }
 
     /// Returns a copy of this rectangle grown by a given amount of units on all the sides.
     #[inline]
     #[must_use]
-    pub fn grow(&self, by: f32) -> Self {
+    pub fn grow(self, by: f32) -> Self {
         let position = self.position - Vector2::new(by, by);
         let size = self.size + Vector2::new(by, by) * 2.0;
 
@@ -232,22 +232,20 @@ impl Rect2 {
     /// individually.
     #[inline]
     #[must_use]
-    pub fn grow_individual(&self, left: f32, top: f32, right: f32, bottom: f32) -> Self {
-        let mut rect = *self;
+    pub fn grow_individual(mut self, left: f32, top: f32, right: f32, bottom: f32) -> Self {
+        self.position.x -= left;
+        self.position.y -= top;
+        self.size.x += left + right;
+        self.size.y += top + bottom;
 
-        rect.position.x -= left;
-        rect.position.y -= top;
-        rect.size.x += left + right;
-        rect.size.y += top + bottom;
-
-        rect
+        self
     }
 
     /// Returns a copy of this rectangle grown by a given amount of units towards the [`Margin`]
     /// direction.
     #[inline]
     #[must_use]
-    pub fn grow_margin(&self, margin: Margin, amount: f32) -> Self {
+    pub fn grow_margin(self, margin: Margin, amount: f32) -> Self {
         let left = if margin == Margin::Left { amount } else { 0.0 };
         let top = if margin == Margin::Top { amount } else { 0.0 };
         let right = if margin == Margin::Right { amount } else { 0.0 };

--- a/gdnative-core/src/core_types/geom/rect2.rs
+++ b/gdnative-core/src/core_types/geom/rect2.rs
@@ -1,9 +1,483 @@
 use crate::core_types::Vector2;
+use std::convert::TryFrom;
 
+/// 2D axis-aligned bounding box.
+///
+/// `Rect2` consists of a position, a size, and several utility functions. It is typically used for
+/// fast overlap tests.
+///
+/// The 3D counterpart to `Rect2` is [`Aabb`](crate::core_types::Aabb).
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Rect2 {
+    /// The rectangle's position in 2D space.
     pub position: Vector2,
+    /// Width and height.
     pub size: Vector2,
+}
+
+impl Rect2 {
+    /// Creates a `Rect2` by position and size.
+    #[inline]
+    pub fn new(position: Vector2, size: Vector2) -> Self {
+        Self { position, size }
+    }
+
+    /// Creates a `Rect2` by x, y, width, and height.
+    #[inline]
+    pub fn from_components(x: f32, y: f32, width: f32, height: f32) -> Self {
+        let position = Vector2::new(x, y);
+        let size = Vector2::new(width, height);
+
+        Self { position, size }
+    }
+
+    /// Ending corner. This is calculated as `position + size`.
+    #[inline]
+    pub fn get_end(&self) -> Vector2 {
+        self.position + self.size
+    }
+
+    /// Ending corner. Setting this value will change the size.
+    #[inline]
+    pub fn set_end(&mut self, new_end: Vector2) {
+        self.size = new_end - self.position;
+    }
+
+    /// Returns a rectangle with equivalent position and area, modified so that the top-left corner
+    /// is the origin and `width` and `height` are positive.
+    #[inline]
+    pub fn abs(&self) -> Self {
+        let position = self.position + Vector2::new(self.size.x.min(0.0), self.size.y.min(0.0));
+        let size = self.size.abs();
+
+        Self { position, size }
+    }
+
+    /// Returns the area of the rectangle. See also [`has_no_area`][Self::has_no_area].
+    #[inline]
+    pub fn get_area(&self) -> f32 {
+        self.size.x * self.size.y
+    }
+
+    /// Returns true if the rectangle is flat or empty. See also [`get_area`][Self::get_area].
+    ///
+    /// Note: If the `Rect2` has a negative size and is not flat or empty, this method will return
+    /// true. Use [`abs`][Self::abs] to make the size positive.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gdnative::prelude::*;
+    /// # fn main() {
+    /// let rect = Rect2::new(
+    ///     Vector2::new(2.0, 3.0),
+    ///     Vector2::new(-3.0, -4.0),
+    /// );
+    /// assert!(rect.has_no_area());
+    /// assert!(!rect.abs().has_no_area());
+    /// # }
+    /// ```
+    #[inline]
+    pub fn has_no_area(&self) -> bool {
+        self.size.x <= 0.0 || self.size.y <= 0.0
+    }
+
+    /// Returns true if the rectangle contains a point. By convention, the right and bottom edges of
+    /// the rectangle are considered exclusive, so points on these edges are not included.
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle to check for contained points.
+    #[inline]
+    pub fn has_point(&self, point: Vector2) -> bool {
+        let point = point - self.position;
+
+        point.abs() == point && point.x < self.size.x && point.y < self.size.y
+    }
+
+    /// Returns true if this rectangle and `b` are approximately equal, by calling
+    /// [`is_equal_approx`](Vector2::is_equal_approx) on each component.
+    #[inline]
+    pub fn is_equal_approx(&self, b: Self) -> bool {
+        self.position.is_equal_approx(b.position) && self.size.is_equal_approx(b.size)
+    }
+
+    /// Returns true if the rectangle overlaps with `b` (i.e. they have at least one point in
+    /// common).
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle to check for intersections.
+    #[inline]
+    pub fn intersects(&self, b: Self) -> bool {
+        !(self.position.x >= b.position.x + b.size.x
+            || self.position.x + self.size.x <= b.position.x
+            || self.position.y >= b.position.y + b.size.y
+            || self.position.y + self.size.y <= b.size.y)
+    }
+
+    /// Returns true if the rectangle overlaps with `b` (i.e. they have at least one point in
+    /// common) or their borders touch even without intersection.
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle to check for intersections.
+    #[inline]
+    pub fn intersects_including_borders(&self, b: Self) -> bool {
+        !(self.position.x > b.position.x + b.size.x
+            || self.position.x + self.size.x < b.position.x
+            || self.position.y > b.position.y + b.size.y
+            || self.position.y + self.size.y < b.size.y)
+    }
+
+    /// Returns true if this rectangle completely encloses `b`.
+    #[inline]
+    pub fn encloses(&self, b: Self) -> bool {
+        b.position.x >= self.position.x
+            && b.position.y >= self.position.y
+            && b.position.x + b.size.x <= self.position.x + self.size.x
+            && b.position.y + b.size.y <= self.position.y + self.size.y
+    }
+
+    /// Returns the intersection of this rectangle and `b`. Returns a copy of this `Rect2` if there
+    /// is no intersection.
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle for clipping.
+    #[inline]
+    pub fn clip(&self, b: Self) -> Self {
+        if !self.intersects(b) {
+            return *self;
+        }
+
+        let mut rect = b;
+        rect.position.x = rect.position.x.max(self.position.x);
+        rect.position.y = rect.position.y.max(self.position.y);
+
+        let end = self.get_end();
+        let end_b = b.get_end();
+
+        rect.size.x = end.x.min(end_b.x) - rect.position.x;
+        rect.size.y = end.y.min(end_b.y) - rect.position.y;
+
+        rect
+    }
+
+    /// Returns a larger rectangle that contains this `Rect2` and `b`.
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle for merging.
+    #[inline]
+    pub fn merge(&self, b: Self) -> Self {
+        let position = Vector2::new(
+            self.position.x.min(b.position.x),
+            self.position.y.min(b.position.y),
+        );
+        let end = Vector2::new(
+            (self.position.x + self.size.x).max(b.position.x + b.size.x),
+            (self.position.y + self.size.y).max(b.position.y + b.size.y),
+        );
+        let size = end - position;
+
+        Self { position, size }
+    }
+
+    /// Returns a copy of this rectangle expanded to include a given point.
+    ///
+    /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
+    /// to get a positive sized equivalent rectangle for expanding.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use gdnative::prelude::*;
+    /// # fn main() {
+    /// let rect = Rect2::new(
+    ///     Vector2::new(-3.0, 2.0),
+    ///     Vector2::new(1.0, 1.0),
+    /// );
+    ///
+    /// let rect2 = rect.expand(Vector2::new(0.0, -1.0));
+    ///
+    /// assert_eq!(rect2.position, Vector2::new(-3.0, -1.0));
+    /// assert_eq!(rect2.size, Vector2::new(3.0, 4.0));
+    /// # }
+    /// ```
+    #[inline]
+    pub fn expand(&self, to: Vector2) -> Self {
+        self.merge(Self::new(to, Vector2::ZERO))
+    }
+
+    /// Returns a copy of this rectangle grown by a given amount of units on all the sides.
+    #[inline]
+    pub fn grow(&self, by: f32) -> Self {
+        let position = self.position - Vector2::new(by, by);
+        let size = self.size + Vector2::new(by, by) * 2.0;
+
+        Self { position, size }
+    }
+
+    /// Returns a copy of this rectangle grown by a given amount of units towards each direction
+    /// individually.
+    #[inline]
+    pub fn grow_individual(&self, left: f32, top: f32, right: f32, bottom: f32) -> Self {
+        let mut rect = *self;
+
+        rect.position.x -= left;
+        rect.position.y -= top;
+        rect.size.x += left + right;
+        rect.size.y += top + bottom;
+
+        rect
+    }
+
+    /// Returns a copy of this rectangle grown by a given amount of units towards the [`Margin`]
+    /// direction.
+    #[inline]
+    pub fn grow_margin(&self, margin: Margin, amount: f32) -> Self {
+        let left = if margin == Margin::Left { amount } else { 0.0 };
+        let top = if margin == Margin::Top { amount } else { 0.0 };
+        let right = if margin == Margin::Right { amount } else { 0.0 };
+        let bottom = if margin == Margin::Bottom {
+            amount
+        } else {
+            0.0
+        };
+
+        self.grow_individual(left, top, right, bottom)
+    }
+}
+
+/// Error indicating that an `i64` cannot be converted to a [`Margin`].
+#[derive(Debug)]
+pub struct MarginError(i64);
+
+/// Provides compatibility with Godot's [`Margin` enum][margin] through the [`TryFrom`] trait.
+///
+/// [margin]: https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-margin
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Margin {
+    Left,
+    Top,
+    Right,
+    Bottom,
+}
+
+impl TryFrom<i64> for Margin {
+    type Error = MarginError;
+
+    #[inline]
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        // XXX: Can't use the constants defined in `gdnative_bindings::GlobalConstants`
+        match value {
+            0 => Ok(Self::Left),
+            1 => Ok(Self::Top),
+            2 => Ok(Self::Right),
+            3 => Ok(Self::Bottom),
+            _ => Err(MarginError(value)),
+        }
+    }
+}
+
+impl From<Margin> for i64 {
+    #[inline]
+    fn from(margin: Margin) -> Self {
+        // XXX: Can't use the constants defined in `gdnative_bindings::GlobalConstants`
+        match margin {
+            Margin::Left => 0,
+            Margin::Top => 1,
+            Margin::Right => 2,
+            Margin::Bottom => 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_point() {
+        let rect = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+
+        assert!(rect.has_point(Vector2::new(5.5, 5.5)));
+        assert!(!rect.has_point(Vector2::new(1.0, 1.0)));
+        assert!(!rect.has_point(Vector2::new(1.0, 5.5)));
+        assert!(!rect.has_point(Vector2::new(5.5, 1.0)));
+        assert!(!rect.has_point(Vector2::new(8.0, 8.0)));
+        assert!(!rect.has_point(Vector2::new(8.0, 5.5)));
+        assert!(!rect.has_point(Vector2::new(5.5, 8.0)));
+    }
+
+    #[test]
+    fn test_has_point_negative_size() {
+        let rect = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(-3.0, -3.0));
+
+        assert!(!rect.has_point(Vector2::new(1.5, 1.5)));
+        assert!(!rect.has_point(Vector2::new(-1.0, -1.0)));
+        assert!(!rect.has_point(Vector2::new(-1.0, 1.5)));
+        assert!(!rect.has_point(Vector2::new(1.5, -1.0)));
+        assert!(!rect.has_point(Vector2::new(4.0, 4.0)));
+        assert!(!rect.has_point(Vector2::new(4.0, 1.5)));
+        assert!(!rect.has_point(Vector2::new(1.5, 4.0)));
+
+        let rect = rect.abs();
+        assert!(rect.has_point(Vector2::new(1.5, 1.5)));
+        assert!(!rect.has_point(Vector2::new(-1.0, -1.0)));
+        assert!(!rect.has_point(Vector2::new(-1.0, 1.5)));
+        assert!(!rect.has_point(Vector2::new(1.5, -1.0)));
+        assert!(!rect.has_point(Vector2::new(4.0, 4.0)));
+        assert!(!rect.has_point(Vector2::new(4.0, 1.5)));
+        assert!(!rect.has_point(Vector2::new(1.5, 4.0)));
+    }
+
+    #[test]
+    fn test_intersects() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(5.0, 5.0), Vector2::new(3.0, 3.0));
+        let c = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(3.0, 3.0));
+        let d = Rect2::new(Vector2::new(8.0, 8.0), Vector2::new(-3.0, -3.0));
+
+        assert!(a.intersects(b));
+        assert!(b.intersects(a));
+
+        assert!(!a.intersects(c));
+        assert!(!c.intersects(a));
+        assert!(!a.intersects(d));
+        assert!(!d.intersects(a));
+
+        let d = d.abs();
+        assert!(a.intersects(d));
+        assert!(d.intersects(a));
+    }
+
+    #[test]
+    fn test_intersects_including_borders() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(3.0, 3.0));
+        let c = Rect2::new(Vector2::new(9.0, 9.0), Vector2::new(-3.0, -3.0));
+
+        assert!(a.intersects_including_borders(b));
+        assert!(b.intersects_including_borders(a));
+
+        assert!(!a.intersects_including_borders(c));
+        assert!(!c.intersects_including_borders(a));
+
+        let c = c.abs();
+        assert!(a.intersects_including_borders(c));
+        assert!(c.intersects_including_borders(a));
+    }
+
+    #[test]
+    fn test_encloses() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(4.0, 4.0), Vector2::new(2.0, 2.0));
+        let c = Rect2::new(Vector2::new(5.0, 5.0), Vector2::new(2.0, 2.0));
+        let d = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-2.0, -2.0));
+
+        assert!(a.encloses(b));
+        assert!(!a.encloses(c));
+        assert!(a.encloses(d));
+    }
+
+    #[test]
+    fn test_clip() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(5.0, 5.0), Vector2::new(3.0, 3.0));
+        let c = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(3.0, 3.0));
+        let d = Rect2::new(Vector2::new(8.0, 8.0), Vector2::new(-3.0, -3.0));
+
+        let expected = Rect2::new(Vector2::new(5.0, 5.0), Vector2::new(1.0, 1.0));
+
+        assert_eq!(a.clip(b), expected);
+        assert_eq!(a.clip(c), a);
+        assert_eq!(a.clip(d), a);
+        assert_eq!(a.clip(d.abs()), expected);
+    }
+
+    #[test]
+    fn test_merge() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(5.0, 5.0), Vector2::new(3.0, 3.0));
+        let c = Rect2::new(Vector2::new(8.0, 8.0), Vector2::new(-3.0, -3.0));
+
+        let expected = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(5.0, 5.0));
+
+        assert_eq!(a.merge(b), expected);
+        assert_ne!(a.merge(c), expected);
+        assert_eq!(a.merge(c.abs()), expected);
+    }
+
+    #[test]
+    fn test_expand() {
+        let a = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let b = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-3.0, -3.0));
+
+        let begin = Vector2::new(-1.0, -1.0);
+        let expected = Rect2::new(begin, Vector2::new(7.0, 7.0));
+
+        assert_eq!(a.expand(begin), expected);
+        assert_ne!(b.expand(begin), expected);
+        assert_eq!(b.abs().expand(begin), expected);
+    }
+
+    #[test]
+    fn test_grow() {
+        let rect = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let expected = Rect2::new(Vector2::new(1.0, 1.0), Vector2::new(7.0, 7.0));
+        assert_eq!(rect.grow(2.0), expected);
+
+        let rect = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-3.0, -3.0));
+        let expected = Rect2::new(Vector2::new(4.0, 4.0), Vector2::new(1.0, 1.0));
+        assert_eq!(rect.grow(2.0), expected);
+    }
+
+    #[test]
+    fn test_grow_individual() {
+        let rect = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        let expected = Rect2::new(Vector2::new(2.0, 1.0), Vector2::new(7.0, 9.0));
+        assert_eq!(rect.grow_individual(1.0, 2.0, 3.0, 4.0), expected);
+
+        let rect = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-3.0, -3.0));
+        let expected = Rect2::new(Vector2::new(5.0, 4.0), Vector2::new(1.0, 3.0));
+        assert_eq!(rect.grow_individual(1.0, 2.0, 3.0, 4.0), expected);
+    }
+
+    #[test]
+    fn test_grow_margin() {
+        let rect = Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 3.0));
+        assert_eq!(
+            rect.grow_margin(Margin::Left, 2.0),
+            Rect2::new(Vector2::new(1.0, 3.0), Vector2::new(5.0, 3.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Right, 2.0),
+            Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(5.0, 3.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Top, 2.0),
+            Rect2::new(Vector2::new(3.0, 1.0), Vector2::new(3.0, 5.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Bottom, 2.0),
+            Rect2::new(Vector2::new(3.0, 3.0), Vector2::new(3.0, 5.0)),
+        );
+
+        let rect = Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-3.0, -3.0));
+        assert_eq!(
+            rect.grow_margin(Margin::Left, 2.0),
+            Rect2::new(Vector2::new(4.0, 6.0), Vector2::new(-1.0, -3.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Right, 2.0),
+            Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-1.0, -3.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Top, 2.0),
+            Rect2::new(Vector2::new(6.0, 4.0), Vector2::new(-3.0, -1.0)),
+        );
+        assert_eq!(
+            rect.grow_margin(Margin::Bottom, 2.0),
+            Rect2::new(Vector2::new(6.0, 6.0), Vector2::new(-3.0, -1.0)),
+        );
+    }
 }

--- a/gdnative-core/src/core_types/geom/rect2.rs
+++ b/gdnative-core/src/core_types/geom/rect2.rs
@@ -57,18 +57,18 @@ impl Rect2 {
 
     /// Returns the area of the rectangle. See also [`has_no_area`][Self::has_no_area].
     #[inline]
-    pub fn get_area(self) -> f32 {
+    pub fn area(self) -> f32 {
         self.size.x * self.size.y
     }
 
-    /// Returns true if the rectangle is flat or empty. See also [`get_area`][Self::get_area].
+    /// Returns true if the rectangle is flat or empty. See also [`area`][Self::area].
     ///
     /// Note: If the `Rect2` has a negative size and is not flat or empty, this method will return
     /// true. Use [`abs`][Self::abs] to make the size positive.
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use gdnative::prelude::*;
     /// # fn main() {
     /// let rect = Rect2::new(
@@ -198,7 +198,7 @@ impl Rect2 {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use gdnative::prelude::*;
     /// # fn main() {
     /// let rect = Rect2::new(

--- a/gdnative-core/src/core_types/vector3.rs
+++ b/gdnative-core/src/core_types/vector3.rs
@@ -24,9 +24,9 @@ pub enum Axis {
 }
 
 impl Axis {
-    /// Returns this axis as a vector.
-    // Before making public, consider also Vector3::from_unit_axis() or so.
-    pub(crate) fn to_unit_vector(self) -> Vector3 {
+    /// Returns this axis as a vector of length 1, with only one component set.
+    #[inline]
+    pub fn to_unit_vector(self) -> Vector3 {
         match self {
             Axis::X => Vector3::RIGHT,
             Axis::Y => Vector3::UP,

--- a/gdnative-core/src/core_types/vector3.rs
+++ b/gdnative-core/src/core_types/vector3.rs
@@ -23,6 +23,18 @@ pub enum Axis {
     Z = sys::godot_vector3_axis_GODOT_VECTOR3_AXIS_Z as u32,
 }
 
+impl Axis {
+    /// Returns this axis as a vector.
+    // Before making public, consider also Vector3::from_unit_axis() or so.
+    pub(crate) fn to_unit_vector(self) -> Vector3 {
+        match self {
+            Axis::X => Vector3::RIGHT,
+            Axis::Y => Vector3::UP,
+            Axis::Z => Vector3::BACK,
+        }
+    }
+}
+
 /// Helper methods for `Vector3`.
 ///
 /// See the official [`Godot documentation`](https://docs.godotengine.org/en/3.1/classes/class_vector3.html).
@@ -202,8 +214,9 @@ impl Vector3 {
         Self::gd(self.glam().lerp(b.glam(), t))
     }
 
-    /// Returns the axis of the vector's largest value. See `Axis` enum.
-    /// If all components are equal, this method returns `Axis::X`.
+    /// Returns the axis of the vector's largest value. See [`Axis`] enum.
+    ///
+    /// If multiple components are equal, this method returns in preferred order `Axis::X`, `Axis::Y`, `Axis::Z`.
     #[inline]
     #[allow(clippy::collapsible_else_if)]
     pub fn max_axis(self) -> Axis {
@@ -223,7 +236,8 @@ impl Vector3 {
     }
 
     /// Returns the axis of the vector's smallest value. See `Axis` enum.
-    /// If all components are equal, this method returns `Axis::Z`.
+    ///
+    /// If multiple components are equal, this method returns in preferred order `Axis::X`, `Axis::Y`, `Axis::Z`.
     #[inline]
     #[allow(clippy::collapsible_else_if)]
     pub fn min_axis(self) -> Axis {

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -75,6 +75,7 @@ allow = [
     "Zlib",
     "BSD-3-Clause",
     "ISC",
+    "Unicode-DFS-2016",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # What to do if a license in the above list is not actually used in a dependency


### PR DESCRIPTION
The docs are based on the Godot documentation for these types, and the code is based on the C++ that implements them.

Only documented methods are implemented here. This is especially notable for the `Aabb` type, which has many methods in C++ which are not documented for GDScript.

I also took some liberties with a few method names and types. For instance, `Rect2::grow_margin` takes an enum argument, and `Aabb::get_endpoint` returns `Option<Vector3>`. These are different from the GDScript counterparts. `Aabb::get_area` was renamed to `Aabb::get_volume`, etc.

Finally, I haven't added any tests for `Aabb` because I did that file last and got bored/lazy before writing any tests (this is what happens when you are not adamant about TDD). The `Rect2` tests did help find plenty of minor bugs, so it is worthwhile to test `Aabb`.

Closes #864