### PR TITLE
Returns the dereferenced type in the exported method

### DIFF
--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -24,6 +24,13 @@ macro_rules! godot_wrap_method_if_deref {
 
 #[doc(hidden)]
 #[macro_export]
+#[deprecated = "This function does not actually pass by reference to the Godot engine. You can clarify by writing #[export(deref_return)]."]
+macro_rules! deprecated_reference_return {
+    () => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -13,9 +13,21 @@ macro_rules! godot_wrap_method_parameter_count {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! godot_wrap_method_if_deref {
+    (true, $ret:expr) => {
+        std::ops::Deref::deref(&$ret)
+    };
+    (false, $ret:expr) => {
+        $ret
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,
+        $is_deref_return:ident,
         $map_method:ident,
         fn $method_name:ident(
             $self:ident,
@@ -56,7 +68,9 @@ macro_rules! godot_wrap_method_inner {
                                     $($pname,)*
                                     $($opt_pname,)*
                                 );
-                                gdnative::core_types::OwnedToVariant::owned_to_variant(ret)
+                                gdnative::core_types::OwnedToVariant::owned_to_variant(
+                                    $crate::godot_wrap_method_if_deref!($is_deref_return, ret)
+                                )
                             }
                         })
                         .unwrap_or_else(|err| {
@@ -83,6 +97,7 @@ macro_rules! godot_wrap_method {
     // mutable
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             &mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -93,6 +108,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_mut,
             fn $method_name(
                 $self,
@@ -105,6 +121,7 @@ macro_rules! godot_wrap_method {
     // immutable
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             & $self:ident,
             $owner:ident : $owner_ty:ty
@@ -115,6 +132,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map,
             fn $method_name(
                 $self,
@@ -127,6 +145,7 @@ macro_rules! godot_wrap_method {
     // owned
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -137,6 +156,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_owned,
             fn $method_name(
                 $self,
@@ -149,6 +169,7 @@ macro_rules! godot_wrap_method {
     // owned
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             $self:ident,
             $owner:ident : $owner_ty:ty
@@ -159,6 +180,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_owned,
             fn $method_name(
                 $self,
@@ -171,6 +193,7 @@ macro_rules! godot_wrap_method {
     // mutable without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             &mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -181,6 +204,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 &mut $self,
                 $owner: $owner_ty
@@ -192,6 +216,7 @@ macro_rules! godot_wrap_method {
     // immutable without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             & $self:ident,
             $owner:ident : $owner_ty:ty
@@ -202,6 +227,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 & $self,
                 $owner: $owner_ty
@@ -213,6 +239,7 @@ macro_rules! godot_wrap_method {
     // owned without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -223,6 +250,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 $self,
                 $owner: $owner_ty
@@ -234,6 +262,7 @@ macro_rules! godot_wrap_method {
     // owned without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             $self:ident,
             $owner:ident : $owner_ty:ty
@@ -244,6 +273,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 $self,
                 $owner: $owner_ty

--- a/gdnative-core/src/export/mod.rs
+++ b/gdnative-core/src/export/mod.rs
@@ -26,6 +26,8 @@ pub(crate) mod type_tag;
 
 pub mod user_data;
 
+#[allow(deprecated)]
+pub use crate::deprecated_reference_return;
 pub use crate::godot_wrap_method;
 pub use class::*;
 pub use class_builder::*;

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -50,7 +50,7 @@ mod variant;
 /// impl gdnative::export::NativeClassMethods for Foo {
 ///     fn register(builder: &ClassBuilder<Self>) {
 ///         use gdnative::export::*;
-///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
+///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, false, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
 ///             .with_rpc_mode(RpcMode::Disabled)
 ///             .done_stateless();
 ///     }


### PR DESCRIPTION
### Feature
Add #[export(deref_return)] to allow exported methods to return dereferenced types. This can be used with types that implement Deref traits.

For example.
```rust
#[derive(NativeClass)]
#[no_constructor]
struct Foo {
    bar: i32,
    baz: Rc<RefCell<f64>>,
}

#[methods]
impl Foo {
    #[export(deref_return)]
    fn get_bar(&self, _owner: &Reference) -> &i32 {
        &self.bar
    }

    #[export(deref_return)]
    fn get_baz(&self, _owner: &Reference) -> std::cell::Ref<f64> {
        self.baz.borrow()
    }
}
```

This feature has the following advantages.
- Types such as `std::cell::Ref<f64>` can be written in the return type signature.
- Clarify that the expoted method is not pass by reference to Godot engine, but converting and passing by value to Godot engine.
- There is no conflict in the implementation of ToVariant Trait.

### Incidental changes
Returning a reference without applying deref_return will display the following warning.
```
warning: use of deprecated macro `::gdnative::export::deprecated_reference_return`: This function does not actually pass by reference to the Godot engine. You can clarify by writing #[export(deref_return)].
```

### Compatibility
The godot_wrap_method! macro is not compatible because its definition has changed. (Can be fixed for compatibility if needed)