### PR TITLE
New syntax for #[export] methods and #[base] parameters

### DIFF
--- a/examples/dodge-the-creeps/src/hud.rs
+++ b/examples/dodge-the-creeps/src/hud.rs
@@ -16,8 +16,8 @@ impl Hud {
         Hud
     }
 
-    #[export]
-    pub fn show_message(&self, owner: &CanvasLayer, text: String) {
+    #[godot]
+    pub fn show_message(&self, #[base] owner: &CanvasLayer, text: String) {
         let message_label = unsafe { owner.get_node_as::<Label>("message_label").unwrap() };
         message_label.set_text(text);
         message_label.show();
@@ -37,21 +37,21 @@ impl Hud {
         button.show();
     }
 
-    #[export]
-    pub fn update_score(&self, owner: &CanvasLayer, score: i64) {
+    #[godot]
+    pub fn update_score(&self, #[base] owner: &CanvasLayer, score: i64) {
         let label = unsafe { owner.get_node_as::<Label>("score_label").unwrap() };
         label.set_text(score.to_string());
     }
 
-    #[export]
-    fn on_start_button_pressed(&self, owner: &CanvasLayer) {
+    #[godot]
+    fn on_start_button_pressed(&self, #[base] owner: &CanvasLayer) {
         let button = unsafe { owner.get_node_as::<Button>("start_button").unwrap() };
         button.hide();
         owner.emit_signal("start_game", &[]);
     }
 
-    #[export]
-    fn on_message_timer_timeout(&self, owner: &CanvasLayer) {
+    #[godot]
+    fn on_message_timer_timeout(&self, #[base] owner: &CanvasLayer) {
         let message_label = unsafe { owner.get_node_as::<Label>("message_label").unwrap() };
         message_label.hide()
     }

--- a/examples/dodge-the-creeps/src/main_scene.rs
+++ b/examples/dodge-the-creeps/src/main_scene.rs
@@ -24,8 +24,8 @@ impl Main {
         }
     }
 
-    #[export]
-    fn game_over(&self, owner: &Node) {
+    #[godot]
+    fn game_over(&self, #[base] owner: &Node) {
         let score_timer = unsafe { owner.get_node_as::<Timer>("score_timer").unwrap() };
         let mob_timer = unsafe { owner.get_node_as::<Timer>("mob_timer").unwrap() };
 
@@ -38,8 +38,8 @@ impl Main {
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[export]
-    fn new_game(&mut self, owner: &Node) {
+    #[godot]
+    fn new_game(&mut self, #[base] owner: &Node) {
         let start_position = unsafe { owner.get_node_as::<Position2D>("start_position").unwrap() };
         let player = unsafe {
             owner
@@ -66,16 +66,16 @@ impl Main {
         .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[export]
-    fn on_start_timer_timeout(&self, owner: &Node) {
+    #[godot]
+    fn on_start_timer_timeout(&self, #[base] owner: &Node) {
         let mob_timer = unsafe { owner.get_node_as::<Timer>("mob_timer").unwrap() };
         let score_timer = unsafe { owner.get_node_as::<Timer>("score_timer").unwrap() };
         mob_timer.start(0.0);
         score_timer.start(0.0);
     }
 
-    #[export]
-    fn on_score_timer_timeout(&mut self, owner: &Node) {
+    #[godot]
+    fn on_score_timer_timeout(&mut self, #[base] owner: &Node) {
         self.score += 1;
 
         let hud = unsafe { owner.get_node_as_instance::<hud::Hud>("hud").unwrap() };
@@ -84,8 +84,8 @@ impl Main {
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[export]
-    fn on_mob_timer_timeout(&self, owner: &Node) {
+    #[godot]
+    fn on_mob_timer_timeout(&self, #[base] owner: &Node) {
         let mob_spawn_location = unsafe {
             owner
                 .get_node_as::<PathFollow2D>("mob_path/mob_spawn_locations")

--- a/examples/dodge-the-creeps/src/mob.rs
+++ b/examples/dodge-the-creeps/src/mob.rs
@@ -40,8 +40,8 @@ impl Mob {
         }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: &RigidBody2D) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: &RigidBody2D) {
         let mut rng = rand::thread_rng();
         let animated_sprite = unsafe {
             owner
@@ -51,15 +51,15 @@ impl Mob {
         animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str())
     }
 
-    #[export]
-    fn on_visibility_screen_exited(&self, owner: &RigidBody2D) {
+    #[godot]
+    fn on_visibility_screen_exited(&self, #[base] owner: &RigidBody2D) {
         unsafe {
             owner.assume_unique().queue_free();
         }
     }
 
-    #[export]
-    fn on_start_game(&self, owner: &RigidBody2D) {
+    #[godot]
+    fn on_start_game(&self, #[base] owner: &RigidBody2D) {
         unsafe {
             owner.assume_unique().queue_free();
         }

--- a/examples/dodge-the-creeps/src/player.rs
+++ b/examples/dodge-the-creeps/src/player.rs
@@ -26,15 +26,15 @@ impl Player {
         }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: &Area2D) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: &Area2D) {
         let viewport = owner.get_viewport_rect();
         self.screen_size = viewport.size;
         owner.hide();
     }
 
-    #[export]
-    fn _process(&mut self, owner: &Area2D, delta: f32) {
+    #[godot]
+    fn _process(&mut self, #[base] owner: &Area2D, delta: f32) {
         let animated_sprite = unsafe {
             owner
                 .get_node_as::<AnimatedSprite>("animated_sprite")
@@ -88,8 +88,8 @@ impl Player {
         owner.set_global_position(position);
     }
 
-    #[export]
-    fn on_player_body_entered(&self, owner: &Area2D, _body: Ref<PhysicsBody2D>) {
+    #[godot]
+    fn on_player_body_entered(&self, #[base] owner: &Area2D, _body: Ref<PhysicsBody2D>) {
         owner.hide();
         owner.emit_signal("hit", &[]);
 
@@ -102,8 +102,8 @@ impl Player {
         collision_shape.set_deferred("disabled", true);
     }
 
-    #[export]
-    pub fn start(&self, owner: &Area2D, pos: Vector2) {
+    #[godot]
+    pub fn start(&self, #[base] owner: &Area2D, pos: Vector2) {
         owner.set_global_position(pos);
         owner.show();
 

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -10,8 +10,8 @@ impl HelloWorld {
         HelloWorld
     }
 
-    #[export]
-    fn _ready(&self, _owner: &Node) {
+    #[godot]
+    fn _ready(&self) {
         godot_print!("hello, world.")
     }
 }

--- a/examples/native-plugin/src/lib.rs
+++ b/examples/native-plugin/src/lib.rs
@@ -14,8 +14,8 @@ impl CustomNode {
         CustomNode
     }
 
-    #[export]
-    fn _enter_tree(&self, owner: TRef<EditorPlugin>) {
+    #[godot]
+    fn _enter_tree(&self, #[base] owner: TRef<EditorPlugin>) {
         // Initialization of the plugin goes here.
         // Add the new type with a name, a parent type, a script and an icon.
         let script = unsafe { load::<Script>("res://my_button.gdns", "Script").unwrap() };
@@ -25,8 +25,8 @@ impl CustomNode {
         owner.add_custom_type("MyButton", "Button", script, texture);
     }
 
-    #[export]
-    fn _exit_tree(&self, owner: TRef<EditorPlugin>) {
+    #[godot]
+    fn _exit_tree(&self, #[base] owner: TRef<EditorPlugin>) {
         // Clean-up of the plugin goes here.
         // Always remember to remove it from the engine when deactivated.
         owner.remove_custom_type("MyButton");
@@ -43,15 +43,15 @@ impl MyButton {
         MyButton
     }
 
-    #[export]
-    fn _enter_tree(&self, owner: TRef<Button>) {
+    #[godot]
+    fn _enter_tree(&self, #[base] owner: TRef<Button>) {
         owner
             .connect("pressed", owner, "clicked", VariantArray::new_shared(), 0)
             .unwrap();
     }
 
-    #[export]
-    fn clicked(&self, _owner: TRef<Button>) {
+    #[godot]
+    fn clicked(&self) {
         godot_print!("You clicked me!");
     }
 }

--- a/examples/resource/src/lib.rs
+++ b/examples/resource/src/lib.rs
@@ -37,8 +37,8 @@ impl Greeter {
         }
     }
 
-    #[export]
-    fn _ready(&self, _owner: &Node) {
+    #[godot]
+    fn _ready(&self) {
         if let Some(greeting_resource) = self.greeting_resource.as_ref() {
             let greeting_resource = unsafe { greeting_resource.assume_safe() };
             greeting_resource.map(|s, o| s.say_hello(&*o)).unwrap();

--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -17,8 +17,8 @@ impl ServerPuppet {
         Self
     }
 
-    #[export]
-    fn _ready(&mut self, owner: TRef<Node>) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: TRef<Node>) {
         let peer = NetworkedMultiplayerENet::new();
         peer.create_client(
             GodotString::from(ADDRESS),
@@ -44,13 +44,13 @@ impl ServerPuppet {
         .unwrap();
     }
 
-    #[export]
-    fn on_connected_to_server(&mut self, owner: TRef<Node>) {
+    #[godot]
+    fn on_connected_to_server(&mut self, #[base] owner: TRef<Node>) {
         owner.rpc("greet_server", &[Variant::new("hello")]);
     }
 
-    #[export(rpc = "puppet")]
-    fn return_greeting(&mut self, _owner: &Node, msg: GodotString) {
+    #[godot(rpc = "puppet")]
+    fn return_greeting(&mut self, msg: GodotString) {
         godot_print!("Server says: {}", msg);
     }
 }

--- a/examples/rpc/src/server.rs
+++ b/examples/rpc/src/server.rs
@@ -16,8 +16,8 @@ impl Server {
         Self
     }
 
-    #[export]
-    fn _ready(&mut self, owner: &Node) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: &Node) {
         let peer = NetworkedMultiplayerENet::new();
         peer.create_server(PORT, MAX_CLIENTS, IN_BANDWIDTH, OUT_BANDWIDTH)
             .unwrap();
@@ -28,8 +28,8 @@ impl Server {
         tree.set_network_peer(peer);
     }
 
-    #[export(rpc = "master")]
-    fn greet_server(&mut self, owner: &Node, msg: GodotString) {
+    #[godot(rpc = "master")]
+    fn greet_server(&mut self, #[base] owner: &Node, msg: GodotString) {
         godot_print!("Client says: {}", msg);
 
         let tree = owner.get_tree().expect("could not retreive Scene Tree");

--- a/examples/scene-create/src/lib.rs
+++ b/examples/scene-create/src/lib.rs
@@ -33,8 +33,8 @@ impl SceneCreate {
         }
     }
 
-    #[gdnative::derive::export]
-    fn _ready(&mut self, _owner: &Spatial) {
+    #[gdnative::derive::godot]
+    fn _ready(&mut self) {
         self.template = load_scene("res://Child_scene.tscn");
         match &self.template {
             Some(_scene) => godot_print!("Loaded child scene successfully!"),
@@ -42,8 +42,8 @@ impl SceneCreate {
         }
     }
 
-    #[gdnative::derive::export]
-    fn spawn_one(&mut self, owner: &Spatial, message: GodotString) {
+    #[gdnative::derive::godot]
+    fn spawn_one(&mut self, #[base] owner: &Spatial, message: GodotString) {
         godot_print!("Called spawn_one({})", message.to_string());
 
         let template = if let Some(template) = &self.template {
@@ -77,8 +77,8 @@ impl SceneCreate {
         update_panel(owner, num_children);
     }
 
-    #[gdnative::derive::export]
-    fn remove_one(&mut self, owner: &Spatial, str: GodotString) {
+    #[gdnative::derive::godot]
+    fn remove_one(&mut self, #[base] owner: &Spatial, str: GodotString) {
         godot_print!("Called remove_one({})", str);
         let num_children = owner.get_child_count();
         if num_children <= 0 {

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -28,8 +28,8 @@ impl SignalEmitter {
         }
     }
 
-    #[export]
-    fn _process(&mut self, owner: &Node, delta: f64) {
+    #[godot]
+    fn _process(&mut self, #[base] owner: &Node, delta: f64) {
         if self.timer < 1.0 {
             self.timer += delta;
             return;
@@ -57,8 +57,8 @@ impl SignalSubscriber {
         SignalSubscriber { times_received: 0 }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: TRef<Label>) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: TRef<Label>) {
         let emitter = &mut owner.get_node("../SignalEmitter").unwrap();
         let emitter = unsafe { emitter.assume_safe() };
 
@@ -76,16 +76,16 @@ impl SignalSubscriber {
             .unwrap();
     }
 
-    #[export]
-    fn notify(&mut self, owner: &Label) {
+    #[godot]
+    fn notify(&mut self, #[base] owner: &Label) {
         self.times_received += 1;
         let msg = format!("Received signal \"tick\" {} times", self.times_received);
 
         owner.set_text(msg);
     }
 
-    #[export]
-    fn notify_with_data(&mut self, owner: &Label, data: Variant) {
+    #[godot]
+    fn notify_with_data(&mut self, #[base] owner: &Label, data: Variant) {
         let msg = format!(
             "Received signal \"tick_with_data\" with data {}",
             data.try_to::<u64>().unwrap()

--- a/examples/spinning-cube/src/lib.rs
+++ b/examples/spinning-cube/src/lib.rs
@@ -46,13 +46,13 @@ impl RustTest {
         }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: &MeshInstance) {
+    #[godot]
+    fn _ready(&mut self, #[base] owner: &MeshInstance) {
         owner.set_physics_process(true);
     }
 
-    #[export]
-    fn _physics_process(&mut self, owner: &MeshInstance, delta: f64) {
+    #[godot]
+    fn _physics_process(&mut self, #[base] owner: &MeshInstance, delta: f64) {
         use gdnative::api::SpatialMaterial;
 
         self.time += delta as f32;

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -24,6 +24,13 @@ macro_rules! godot_wrap_method_if_deref {
 
 #[doc(hidden)]
 #[macro_export]
+#[deprecated = "This function does not actually pass by reference to the Godot engine. You can clarify by writing #[export(deref_return)]."]
+macro_rules! deprecated_reference_return {
+    () => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -37,9 +37,9 @@ macro_rules! godot_wrap_method_inner {
         $is_deref_return:ident,
         $map_method:ident,
         fn $method_name:ident(
-            $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
+            $self:ident
+            , $owner:ident : $owner_ty:ty
+            $(, $pname:ident : $pty:ty)*
             $(, #[opt] $opt_pname:ident : $opt_pty:ty)*
         ) -> $retty:ty
     ) => {
@@ -97,6 +97,17 @@ macro_rules! godot_wrap_method_inner {
     };
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! godot_wrap_method_return_type {
+    () => {
+        ()
+    };
+    ($retty:ty) => {
+        $retty: ty
+    };
+}
+
 /// Convenience macro to wrap an object's method into a function pointer
 /// that can be passed to the engine when registering a class.
 #[macro_export]
@@ -106,23 +117,23 @@ macro_rules! godot_wrap_method {
         $type_name:ty,
         $is_deref_return:ident,
         fn $method_name:ident(
-            &mut $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            &mut $self:ident
+            , $owner:ident : $owner_ty:ty
+            $(, $pname:ident : $pty:ty)*
+            $(, #[opt] $opt_pname:ident : $opt_pty:ty)*
             $(,)?
-        ) -> $retty:ty
+        ) $(-> $retty:ty)?
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
             $is_deref_return,
             map_mut,
             fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> $retty
+                $self
+                , $owner : $owner_ty
+                $(, $pname : $pty)*
+                $(, #[opt] $opt_pname : $opt_pty)*
+            ) -> godot_wrap_method_return_type!($($retty)?)
         )
     };
     // immutable
@@ -130,23 +141,23 @@ macro_rules! godot_wrap_method {
         $type_name:ty,
         $is_deref_return:ident,
         fn $method_name:ident(
-            & $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            & $self:ident
+            , $owner:ident : $owner_ty:ty
+            $(, $pname:ident : $pty:ty)*
+            $(, #[opt] $opt_pname:ident : $opt_pty:ty)*
             $(,)?
-        ) -> $retty:ty
+        ) $(-> $retty:ty)?
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
             $is_deref_return,
             map,
             fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> $retty
+                $self
+                , $owner : $owner_ty
+                $(, $pname : $pty)*
+                $(, #[opt] $opt_pname : $opt_pty)*
+            ) -> godot_wrap_method_return_type!($($retty)?)
         )
     };
     // owned
@@ -154,23 +165,23 @@ macro_rules! godot_wrap_method {
         $type_name:ty,
         $is_deref_return:ident,
         fn $method_name:ident(
-            mut $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            mut $self:ident
+            , $owner:ident : $owner_ty:ty
+            $(, $pname:ident : $pty:ty)*
+            $(, #[opt] $opt_pname:ident : $opt_pty:ty)*
             $(,)?
-        ) -> $retty:ty
+        ) $(-> $retty:ty)?
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
             $is_deref_return,
             map_owned,
             fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> $retty
+                $self
+                , $owner : $owner_ty
+                $(, $pname : $pty)*
+                $(, #[opt] $opt_pname : $opt_pty)*
+            ) -> godot_wrap_method_return_type!($($retty)?)
         )
     };
     // owned
@@ -178,115 +189,23 @@ macro_rules! godot_wrap_method {
         $type_name:ty,
         $is_deref_return:ident,
         fn $method_name:ident(
-            $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
+            $self:ident
+            , $owner:ident : $owner_ty:ty
+            $(, $pname:ident : $pty:ty)*
+            $(, #[opt] $opt_pname:ident : $opt_pty:ty)*
             $(,)?
-        ) -> $retty:ty
+        ) $(-> $retty:ty)?
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
             $is_deref_return,
             map_owned,
             fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> $retty
-        )
-    };
-    // mutable without return type
-    (
-        $type_name:ty,
-        $is_deref_return:ident,
-        fn $method_name:ident(
-            &mut $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
-            $(,)?
-        )
-    ) => {
-        $crate::godot_wrap_method!(
-            $type_name,
-            $is_deref_return,
-            fn $method_name(
-                &mut $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> ()
-        )
-    };
-    // immutable without return type
-    (
-        $type_name:ty,
-        $is_deref_return:ident,
-        fn $method_name:ident(
-            & $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
-            $(,)?
-        )
-    ) => {
-        $crate::godot_wrap_method!(
-            $type_name,
-            $is_deref_return,
-            fn $method_name(
-                & $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> ()
-        )
-    };
-    // owned without return type
-    (
-        $type_name:ty,
-        $is_deref_return:ident,
-        fn $method_name:ident(
-            mut $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
-            $(,)?
-        )
-    ) => {
-        $crate::godot_wrap_method!(
-            $type_name,
-            $is_deref_return,
-            fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> ()
-        )
-    };
-    // owned without return type
-    (
-        $type_name:ty,
-        $is_deref_return:ident,
-        fn $method_name:ident(
-            $self:ident,
-            $owner:ident : $owner_ty:ty
-            $(,$pname:ident : $pty:ty)*
-            $(,#[opt] $opt_pname:ident : $opt_pty:ty)*
-            $(,)?
-        )
-    ) => {
-        $crate::godot_wrap_method!(
-            $type_name,
-            $is_deref_return,
-            fn $method_name(
-                $self,
-                $owner: $owner_ty
-                $(,$pname : $pty)*
-                $(,#[opt] $opt_pname : $opt_pty)*
-            ) -> ()
+                $self
+                , $owner : $owner_ty
+                $(, $pname : $pty)*
+                $(, #[opt] $opt_pname : $opt_pty)*
+            ) -> godot_wrap_method_return_type!($($retty)?)
         )
     };
 }

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -37,7 +37,8 @@ macro_rules! deprecated_reference_return {
 
 #[doc(hidden)]
 #[macro_export]
-#[deprecated = "#[export] is deprecated and will be removed in the next major version. Use #[godot] instead."]
+#[deprecated = "\n#[export] is deprecated and will be removed in godot-rust 0.11. Use #[godot] instead.\n\
+  For more information, see https://godot-rust.github.io/docs/gdnative/derive/derive.NativeClass.html."]
 macro_rules! deprecated_export_syntax {
     () => {};
 }

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -13,9 +13,21 @@ macro_rules! godot_wrap_method_parameter_count {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! godot_wrap_method_if_deref {
+    (true, $ret:expr) => {
+        std::ops::Deref::deref(&$ret)
+    };
+    (false, $ret:expr) => {
+        $ret
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,
+        $is_deref_return:ident,
         $map_method:ident,
         fn $method_name:ident(
             $self:ident,
@@ -56,7 +68,9 @@ macro_rules! godot_wrap_method_inner {
                                     $($pname,)*
                                     $($opt_pname,)*
                                 );
-                                gdnative::core_types::OwnedToVariant::owned_to_variant(ret)
+                                gdnative::core_types::OwnedToVariant::owned_to_variant(
+                                    $crate::godot_wrap_method_if_deref!($is_deref_return, ret)
+                                )
                             }
                         })
                         .unwrap_or_else(|err| {
@@ -83,6 +97,7 @@ macro_rules! godot_wrap_method {
     // mutable
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             &mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -93,6 +108,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_mut,
             fn $method_name(
                 $self,
@@ -105,6 +121,7 @@ macro_rules! godot_wrap_method {
     // immutable
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             & $self:ident,
             $owner:ident : $owner_ty:ty
@@ -115,6 +132,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map,
             fn $method_name(
                 $self,
@@ -127,6 +145,7 @@ macro_rules! godot_wrap_method {
     // owned
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -137,6 +156,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_owned,
             fn $method_name(
                 $self,
@@ -149,6 +169,7 @@ macro_rules! godot_wrap_method {
     // owned
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             $self:ident,
             $owner:ident : $owner_ty:ty
@@ -159,6 +180,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method_inner!(
             $type_name,
+            $is_deref_return,
             map_owned,
             fn $method_name(
                 $self,
@@ -171,6 +193,7 @@ macro_rules! godot_wrap_method {
     // mutable without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             &mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -181,6 +204,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 &mut $self,
                 $owner: $owner_ty
@@ -192,6 +216,7 @@ macro_rules! godot_wrap_method {
     // immutable without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             & $self:ident,
             $owner:ident : $owner_ty:ty
@@ -202,6 +227,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 & $self,
                 $owner: $owner_ty
@@ -213,6 +239,7 @@ macro_rules! godot_wrap_method {
     // owned without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             mut $self:ident,
             $owner:ident : $owner_ty:ty
@@ -223,6 +250,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 $self,
                 $owner: $owner_ty
@@ -234,6 +262,7 @@ macro_rules! godot_wrap_method {
     // owned without return type
     (
         $type_name:ty,
+        $is_deref_return:ident,
         fn $method_name:ident(
             $self:ident,
             $owner:ident : $owner_ty:ty
@@ -244,6 +273,7 @@ macro_rules! godot_wrap_method {
     ) => {
         $crate::godot_wrap_method!(
             $type_name,
+            $is_deref_return,
             fn $method_name(
                 $self,
                 $owner: $owner_ty

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -37,6 +37,13 @@ macro_rules! deprecated_reference_return {
 
 #[doc(hidden)]
 #[macro_export]
+#[deprecated = "#[export] is deprecated and will be removed in the next major version. Use #[godot] instead."]
+macro_rules! deprecated_export_syntax {
+    () => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! godot_wrap_method_void {
     ($ident:ident, $void:tt) => {
         $ident

--- a/gdnative-core/src/export/mod.rs
+++ b/gdnative-core/src/export/mod.rs
@@ -26,9 +26,9 @@ pub(crate) mod type_tag;
 
 pub mod user_data;
 
-#[allow(deprecated)]
-pub use crate::deprecated_reference_return;
 pub use crate::godot_wrap_method;
+#[allow(deprecated)]
+pub use crate::{deprecated_export_syntax, deprecated_reference_return};
 pub use class::*;
 pub use class_builder::*;
 pub use method::*;

--- a/gdnative-core/src/export/mod.rs
+++ b/gdnative-core/src/export/mod.rs
@@ -26,6 +26,8 @@ pub(crate) mod type_tag;
 
 pub mod user_data;
 
+#[allow(deprecated)]
+pub use crate::deprecated_reference_return;
 pub use crate::godot_wrap_method;
 pub use class::*;
 pub use class_builder::*;

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -50,7 +50,7 @@ mod variant;
 /// impl gdnative::export::NativeClassMethods for Foo {
 ///     fn register(builder: &ClassBuilder<Self>) {
 ///         use gdnative::export::*;
-///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, false, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
+///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, false, fn foo(&self, #[base] _owner: &Reference, bar: i64) -> i64))
 ///             .with_rpc_mode(RpcMode::Disabled)
 ///             .done_stateless();
 ///     }

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -50,7 +50,7 @@ mod variant;
 /// impl gdnative::export::NativeClassMethods for Foo {
 ///     fn register(builder: &ClassBuilder<Self>) {
 ///         use gdnative::export::*;
-///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
+///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, false, fn foo(&self, _owner: &Reference, bar: i64) -> i64))
 ///             .with_rpc_mode(RpcMode::Disabled)
 ///             .done_stateless();
 ///     }

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -232,7 +232,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                         let (is_export, is_old_syntax) = if let Some("export") = last_seg.as_deref()
                         {
                             (true, true)
-                        } else if let Some("method") = last_seg.as_deref() {
+                        } else if let Some("godot") = last_seg.as_deref() {
                             (true, false)
                         } else {
                             (false, false)
@@ -304,7 +304,10 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                             } else {
                                                 errors.push(syn::Error::new(
                                                     nested_meta.span(),
-                                                    format!("unexpected value for `rpc`: {}", value),
+                                                    format!(
+                                                        "unexpected value for `rpc`: {}",
+                                                        value
+                                                    ),
                                                 ));
                                             }
                                         }

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -141,8 +141,14 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
                 }
             });
 
+            let warn_deprecated_export = if export_args.is_old_syntax {
+                Some(quote_spanned!(ret_span=> ::gdnative::export::deprecated_export_syntax!();))
+            } else {
+                None
+            };
+
             // See gdnative-core::export::deprecated_reference_return!()
-            let deprecated = if let syn::ReturnType::Type(_, ty) = &sig.output {
+            let warn_deprecated_ref_return  = if let syn::ReturnType::Type(_, ty) = &sig.output {
                 if !is_deref_return && matches!(**ty, syn::Type::Reference(_)) {
                     quote_spanned!(ret_span=> ::gdnative::export::deprecated_reference_return!();)
                 } else {
@@ -164,7 +170,8 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
                         .with_rpc_mode(#rpc)
                         .done_stateless();
 
-                    #deprecated
+                    #warn_deprecated_export
+                    #warn_deprecated_ref_return
                 }
             )
         })

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -229,14 +229,14 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                             .last()
                             .map(|i| i.ident.to_string());
 
-                        let (is_export, is_old_syntax) = if let Some("export") = last_seg.as_deref()
-                        {
-                            (true, true)
-                        } else if let Some("godot") = last_seg.as_deref() {
-                            (true, false)
-                        } else {
-                            (false, false)
-                        };
+                        let (is_export, is_old_syntax, macro_name) =
+                            if let Some("export") = last_seg.as_deref() {
+                                (true, true, "export")
+                            } else if let Some("godot") = last_seg.as_deref() {
+                                (true, false, "godot")
+                            } else {
+                                (false, false, "unknown")
+                            };
 
                         if is_export {
                             use syn::{punctuated::Punctuated, Lit, Meta, NestedMeta};
@@ -363,7 +363,8 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                     }
                                 } else {
                                     let msg = format!(
-                                        "unknown option for #[export]: `{}`",
+                                        "unknown option for #[{}]: `{}`",
+                                        macro_name,
                                         path.to_token_stream()
                                     );
                                     errors.push(syn::Error::new(nested_meta.span(), msg));

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -98,7 +98,7 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
             if arg_count == 0 {
                 return syn::Error::new(
                     sig_span,
-                    "exported methods must take self parameter",
+                    "#[godot] exported methods must take self parameter",
                 )
                 .to_compile_error();
             }
@@ -106,7 +106,7 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
             if export_args.is_old_syntax && !exist_base_arg {
                 return syn::Error::new(
                     sig_span,
-                    "exported methods must take second parameter",
+                    "deprecated #[export] methods must take second parameter (base/owner)",
                 )
                 .to_compile_error();
             }
@@ -289,7 +289,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                         None => {
                                             errors.push(syn::Error::new(
                                                 nested_meta.span(),
-                                                "name parameter requires string value",
+                                                "`rpc` parameter requires string value",
                                             ));
                                         }
                                         Some(Lit::Str(str)) => {
@@ -298,20 +298,20 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                                 if export_args.rpc_mode.replace(mode).is_some() {
                                                     errors.push(syn::Error::new(
                                                         nested_meta.span(),
-                                                        "rpc mode was set more than once",
+                                                        "`rpc` mode was set more than once",
                                                     ));
                                                 }
                                             } else {
                                                 errors.push(syn::Error::new(
                                                     nested_meta.span(),
-                                                    format!("unexpected value for rpc: {}", value),
+                                                    format!("unexpected value for `rpc`: {}", value),
                                                 ));
                                             }
                                         }
                                         _ => {
                                             errors.push(syn::Error::new(
                                                 nested_meta.span(),
-                                                "unexpected type for rpc value, expected string",
+                                                "unexpected type for `rpc` value, expected string",
                                             ));
                                         }
                                     }
@@ -321,7 +321,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                         None => {
                                             errors.push(syn::Error::new(
                                                 nested_meta.span(),
-                                                "name parameter requires string value",
+                                                "`name` parameter requires string value",
                                             ));
                                         }
                                         Some(Lit::Str(str)) => {
@@ -332,14 +332,14 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                             {
                                                 errors.push(syn::Error::new(
                                                     nested_meta.span(),
-                                                    "name was set more than once",
+                                                    "`name` was set more than once",
                                                 ));
                                             }
                                         }
                                         _ => {
                                             errors.push(syn::Error::new(
                                                 nested_meta.span(),
-                                                "unexpected type for name value, expected string",
+                                                "unexpected type for `name` value, expected string",
                                             ));
                                         }
                                     }
@@ -348,19 +348,19 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                                     if lit.is_some() {
                                         errors.push(syn::Error::new(
                                             nested_meta.span(),
-                                            "value for deref_return parameter is not valid",
+                                            "`deref_return` does not take any values",
                                         ));
                                     } else if export_args.is_deref_return {
                                         errors.push(syn::Error::new(
                                             nested_meta.span(),
-                                            "deref_return was apply more than once",
+                                            "`deref_return` was set more than once",
                                         ));
                                     } else {
                                         export_args.is_deref_return = true;
                                     }
                                 } else {
                                     let msg = format!(
-                                        "unknown option for export: `{}`",
+                                        "unknown option for #[export]: `{}`",
                                         path.to_token_stream()
                                     );
                                     errors.push(syn::Error::new(nested_meta.span(), msg));
@@ -407,7 +407,7 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                             if n < 2 {
                                 errors.push(syn::Error::new(
                                     arg.span(),
-                                    "self or owner cannot be optional",
+                                    "self or base cannot be optional",
                                 ));
                             } else {
                                 *optional_args.get_or_insert(0) += 1;

--- a/gdnative/tests/ui/derive_pass.rs
+++ b/gdnative/tests/ui/derive_pass.rs
@@ -10,8 +10,8 @@ impl Foo {
         Foo {}
     }
 
-    #[export]
-    fn bar(&self, __owner: &Node) {}
+    #[godot]
+    fn bar(&self) {}
 }
 
 fn main() {}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::blacklisted_name)]
+#![allow(deprecated)]
 
 use gdnative::prelude::*;
 


### PR DESCRIPTION
Resolve #850

### Feature
Allows onwer argument to be omitted.
```rust
#[method]
fn foo(&self, a: i32, b: i32) -> i32 {
    a + b
}
```

By adding the #[base] attribute to the argument, it is defined as the owner argument. Only the second argument can be the owner argument. Also, there is no way to define the owner argument without #[base].
```rust
#[method]
fn foo(&self, #[base] base: TRef<&Node>, value: i32) {
    base.do_something(value);
}
```

All optional parameters that can be used with the #[export] attribute can also be used with #[method].

### Compatibility
The old syntax #[export] attribute will continue to be supported. (It does _not_ support omission of the owner argument.)
```rust
#[export]
fn foo(&self, base: TRef<&Node>, value: i32) {
    base.do_something(value);
}
```

The `godot_wrap_method!` macro is not compatible because its definition has changed. (Can be fixed for compatibility if needed)

Written tests. (https://github.com/B-head/godot-rust/pull/1)