### PR TITLE
Doc CI on unchanged code + minimal dependency tweak

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ env:
 
 
 # In the very unlikely cases where two PRs are merged, and the first 'doc' job is still running when the 2nd 'full-ci' starts,
-# make sure the first one is awaited. Even though docs are eventually overwritten, this ensures continuitiy in the doc repo history.
+# make sure the first one is awaited. Even though docs are eventually overwritten, this ensures continuity in the doc repo history.
 concurrency:
   group: 'sync-doc'
   cancel-in-progress: false
@@ -58,6 +58,7 @@ jobs:
       # For email address, see https://github.community/t/github-actions-bot-email-address/17204
       # As search-index.js changes every time, even if source hasn't changed, this will not need 'git commit --allow-empty'
       - name: "Prepare upload"
+        id: prepareUpload
         run: |
           mkdir ~/.ssh
           echo '${{ secrets.DOC_DEPLOY_SSH_KEY }}' > ~/.ssh/id_rsa
@@ -72,23 +73,30 @@ jobs:
           mv ${GITHUB_WORKSPACE}/target/doc/* .
           mv ${GITHUB_WORKSPACE}/.github/workflows/doc/* .
 
-          GDRUST_VERSION=$(grep -Po '^version = "\K[^"]*' ${GITHUB_WORKSPACE}/gdnative/Cargo.toml)
-          GDRUST_SHORT_SHA=$(git rev-parse --short "${GITHUB_SHA}")
+          libVersion=$(grep -Po '^version = "\K[^"]*' ${GITHUB_WORKSPACE}/gdnative/Cargo.toml)
+          shortSha=$(git rev-parse --short "${GITHUB_SHA}")
 
-          find gdnative -name .html -o -type f -print0 | xargs -0 sed -i 's/'"${GDRUST_VERSION}"'/master/g'
+          find gdnative -name .html -o -type f -print0 | xargs -0 sed -i 's/'"$libVersion"'/master/g'
 
-          git add --all
-          git commit -m "Sync doc from ${GDRUST_SHORT_SHA}
-
-          Revision in godot-rust: ${GITHUB_SHA}"
+          if git diff --exit-code 
+          then
+            echo "$shortSha introduces no doc changes; skip commit and push."
+          else
+            git add --all
+            git commit -m "Sync doc from $shortSha
+  
+            Revision in godot-rust: ${GITHUB_SHA}"
+          
+            echo ::set-output name=docsChanged::true
+          fi
 
       - name: "Upload"
         working-directory: doc
         run: git push origin ${GDRUST_DOC_BRANCH}
+        if: ${{ steps.prepareUpload.outputs.docsChanged == 'true' }}
 
       - name: "Cleanup"
         run: shred -u ~/.ssh/id_rsa
-
 
 
 # Possible alternative: dispatching a remote workflow

--- a/bindings-generator/Cargo.toml
+++ b/bindings-generator/Cargo.toml
@@ -18,7 +18,7 @@ custom-godot = ["which"]
 [dependencies]
 heck = "0.4"
 memchr = "2"
-miniserde = "0.1.10"
+miniserde = "0.1.16"
 proc-macro2 = "1"
 quote = "1"
 regex = { version = "1.5.5", default-features = false, features = ["std"] } # for security: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html

--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -19,5 +19,5 @@ libc = "0.2"
 bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
 proc-macro2 = "1"
 quote = "1"
-miniserde = "0.1.10"
+miniserde = "0.1.16"
 semver = "1"


### PR DESCRIPTION
**Doc CI**

Many times, the `doc` CI job failed, since there was no actual diff in generated documentation. This caused `git commit` to return an error status, failing the entire job. This PR addresses this.


**Minimal dependency versions**

Apparently, `miniserde` versions 0.1.10..=0.1.15 work for rustc 1.59.0, but not for older rustc versions.
Our CI only checks the stable channel with `cargo +nightly update -Z minimal-versions`, so this was not caught.

For the moment, no new CI job is added (to keep minimal dependencies and minimal rustc as orthogonal as possible).
Changing the "minimal dependencies" job to also use MSRV would be an option, but that would make it less easy to see whether a job fails due to rustc or dependency versions.


bors r+