### PR TITLE
Implemented From/To Variant for HashMap

### DIFF
--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -1,7 +1,9 @@
 use crate::*;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::default::Default;
 use std::fmt;
+use std::hash::Hash;
 use std::mem::{forget, transmute};
 use std::ptr;
 
@@ -1602,6 +1604,37 @@ impl<T: FromVariant> FromVariant for Vec<T> {
     }
 }
 
+impl<K: ToVariant + Hash + ToVariantEq, V: ToVariant> ToVariant for HashMap<K, V> {
+    #[inline]
+    fn to_variant(&self) -> Variant {
+        let dict = Dictionary::new();
+        for (key, value) in self {
+            dict.insert(key, value);
+        }
+        dict.owned_to_variant()
+    }
+}
+
+impl<K: FromVariant + Hash + Eq, V: FromVariant> FromVariant for HashMap<K, V> {
+    #[inline]
+    fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
+        let dictionary = Dictionary::from_variant(variant)?;
+        let len: usize = dictionary
+            .len()
+            .try_into()
+            .expect("Dictionary length should fit in usize");
+        let mut hash_map = HashMap::with_capacity(len);
+        for (key, value) in dictionary.iter() {
+            hash_map.insert(
+                K::from_variant(&key)?,
+                // Maybe add a custom FromVariantError variant if this fails
+                V::from_variant(&value)?,
+            );
+        }
+        Ok(hash_map)
+    }
+}
+
 macro_rules! tuple_length {
     () => { 0usize };
     ($_x:ident, $($xs:ident,)*) => {
@@ -1772,6 +1805,16 @@ godot_test!(
         assert_eq!(Some(&42), vec_maybe[0].as_ref().ok());
         assert_eq!(Some(&Variant::nil()), vec_maybe[1].as_ref().err());
         assert_eq!(Some(&f64::to_variant(&54.0)), vec_maybe[2].as_ref().err());
+    }
+
+    test_variant_hash_map {
+        let original_hash_map = HashMap::from([
+            ("Foo".to_string(), 4u32),
+            ("Bar".to_string(), 2u32)
+        ]);
+        let variant = original_hash_map.to_variant();
+        let check_hash_map = variant.try_to::<HashMap<String, u32>>().expect("should be hash map");
+        assert_eq!(original_hash_map, check_hash_map);
     }
 
     test_variant_tuple {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -40,6 +40,7 @@ pub extern "C" fn run_tests(
 
     status &= gdnative::core_types::test_variant_option();
     status &= gdnative::core_types::test_variant_result();
+    status &= gdnative::core_types::test_variant_hash_map();
     status &= gdnative::core_types::test_to_variant_iter();
     status &= gdnative::core_types::test_variant_tuple();
     status &= gdnative::core_types::test_variant_dispatch();


### PR DESCRIPTION
Since the `FromVariant` and `ToVariant` traits are already implemented for `Vec<T>` it only makes sense to also implement it for the common `HashMap<K,V>`. \
This addition is useful, because it allows easier use of Dictionaries from Godot in rust.