### PR TITLE
Add TryFrom to convert from Varargs to tuples

### DIFF
--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -249,26 +249,16 @@ impl Method<VarargsGets> for CalcMethod {
     }
 }
 
-fn test_varargs_gets() -> bool {
-    println!(" -- test_varargs_gets");
+crate::godot_itest! { test_varargs_gets {
+    let thing = Instance::<VarargsGets, _>::new();
+    let base = thing.base();
 
-    let ok = std::panic::catch_unwind(|| {
-        let thing = Instance::<VarargsGets, _>::new();
-        let base = thing.base();
+    let args = [3_i64.to_variant(), 4_i64.to_variant(), 5_i64.to_variant()];
+    assert_eq!(unsafe { base.call("calc", &args).to() }, Some(7));
 
-        let args = [3_i64.to_variant(), 4_i64.to_variant(), 5_i64.to_variant()];
-        assert_eq!(unsafe { base.call("calc", &args).to() }, Some(7));
-
-        let args = [3_i64.to_variant(), 4_i64.to_variant()];
-        assert_eq!(unsafe { base.call("calc", &args).to() }, Some(1));
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_varargs_gets failed");
-    }
-    ok
-}
+    let args = [3_i64.to_variant(), 4_i64.to_variant()];
+    assert_eq!(unsafe { base.call("calc", &args).to() }, Some(1));
+}}
 
 #[derive(NativeClass)]
 #[inherit(Reference)]
@@ -301,20 +291,10 @@ impl Method<VarargsToTuple> for CalcMethod2 {
     }
 }
 
-fn test_varargs_to_tuple() -> bool {
-    println!(" -- test_varargs_to_tuple");
+crate::godot_itest! { test_varargs_to_tuple {
+    let thing = Instance::<VarargsToTuple, _>::new();
+    let base = thing.base();
 
-    let ok = std::panic::catch_unwind(|| {
-        let thing = Instance::<VarargsToTuple, _>::new();
-        let base = thing.base();
-
-        let args = [3_i64.to_variant(), 4_i64.to_variant(), 5_i64.to_variant()];
-        assert_eq!(unsafe { base.call("calc", &args).to() }, Some(7));
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_varargs_to_tuple failed");
-    }
-    ok
-}
+    let args = [3_i64.to_variant(), 4_i64.to_variant(), 5_i64.to_variant()];
+    assert_eq!(unsafe { base.call("calc", &args).to() }, Some(7));
+}}


### PR DESCRIPTION
This PR is stacked on `varargs_gets` branch. See #892 for details on some of the commits included in this PR.

## Feature
Dirty syntax to convert to tuples. This makes manual binding easier to write than ever before.

Implement via `varargs_into_tuple!()` macro. Can be converted to tuples up to 12 in length. This is the same length supported by standard library.
```rust
fn call(&self, _this: TInstance<'_, Foo>, args: Varargs<'_>) -> Variant {

    // Convert from Varargs to tuples.
    let (a, b, c): (i64, i64, i64) = args.try_into().unwrap();

    let ret = (a * b - c);
    ret.to_variant()
}
```

## Compatibility
Since this PR only adds an API, there are no compatibility issues.