### PR TITLE
Add helpers for raw method creation

### DIFF
--- a/gdnative-core/src/export/class_builder.rs
+++ b/gdnative-core/src/export/class_builder.rs
@@ -76,6 +76,13 @@ impl<C: NativeClass> ClassBuilder<C> {
         MethodBuilder::new(self, name, method)
     }
 
+    /// Returns a `RawMethodBuilder` which can be used to add a raw method to the class being registered.
+    /// TODO: Write example.
+    #[inline]
+    pub fn raw_method<'a>(&'a self, name: &'a str) -> RawMethodBuilder<'a, C> {
+        RawMethodBuilder::new(self, name)
+    }
+
     /// Returns a `PropertyBuilder` which can be used to add a property to the class being
     /// registered.
     ///

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -96,6 +96,8 @@ type ScriptMethodFn = unsafe extern "C" fn(
     *mut *mut sys::godot_variant,
 ) -> sys::godot_variant;
 
+type ScriptFreeFn = unsafe extern "C" fn(*mut libc::c_void) -> ();
+
 pub enum RpcMode {
     Disabled,
     Remote,
@@ -123,7 +125,7 @@ pub(crate) struct ScriptMethod<'l> {
     pub attributes: ScriptMethodAttributes,
 
     pub method_data: *mut libc::c_void,
-    pub free_func: Option<unsafe extern "C" fn(*mut libc::c_void) -> ()>,
+    pub free_func: Option<ScriptFreeFn>,
 }
 
 /// Safe low-level trait for stateful, variadic methods that can be called on a native script type.

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -277,7 +277,6 @@ impl<'a> Varargs<'a> {
     /// # Safety
     ///
     /// `args` must point to an array of valid `godot_variant` pointers of at least `num_args` long.
-    #[doc(hidden)]
     #[inline]
     pub unsafe fn from_sys(num_args: libc::c_int, args: *mut *mut sys::godot_variant) -> Self {
         let args = std::slice::from_raw_parts(args, num_args as usize);


### PR DESCRIPTION
## Feature
Easily write code for manual bindings. The error propagation operator can now be used for error handling.
Let's compare this with the [original code](https://github.com/godot-rust/godot-rust/blob/c69c5a0241a2206ec45e2a8028922ca10648bcfa/gdnative-core/src/export/method.rs#L538-L591).
```rust
unsafe extern "C" fn raw_calc(
    this: *mut sys::godot_object,
    _method_data: *mut libc::c_void,
    user_data: *mut libc::c_void,
    num_args: libc::c_int,
    args: *mut *mut sys::godot_variant,
) -> sys::godot_variant {
    (|| {
        let _this = unsafe { Ref::<Reference>::try_from_sys(this)?.assume_safe_unchecked() };
        let user_data = unsafe { cast_sys_user_data::<RawMethod>(user_data)? };
        let mut args = unsafe { Varargs::from_sys(num_args, args) };

        let a = args.next().and_then(|v| v.to::<i64>()).unwrap_or(3);
        let b = args.next().and_then(|v| v.to::<i64>()).unwrap_or(4);

        let result =
            user_data.map(|ud| gdnative::export::catch_unwind(move || a * b + ud.inner));

        Ok::<_, Box<dyn Error>>(result??.to_variant())
    })()
    .unwrap_or_else(|err| {
        log::error(godot_site!(raw_calc), err);
        Variant::nil()
    })
    .leak()
}
```

## List of APIs to add
Most APIs are added to simplify error handling.

### `Ref::try_from_sys()`
Convert from a raw pointer, incrementing the reference counter if reference-counted.
If `obj` is null, an error is returned.

### `cast_sys_user_data()`
The user_data wrapper can be obtained directly.

Takes an opaque pointer produced by `into_user_data` and "clones" it to produce the
original instance, increasing the reference count.
If `user_data` is null, an error is returned.

### `catch_unwind()`
Wrapper function for `std:panic:catch_unwind()` that returns `PanickedError` when panicked.
`PanickedError` displays the contents if the payload passed during panic has type `&str` or `String`.

### `RawMethodBuilder`
Builder type used to register a raw method on a `NativeClass`.

## Compatibility
Since this PR only adds an API, there are no compatibility issues.