### PR TITLE
Add cargo-machete and remove unnecessary dependencies 🔪 

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -35,6 +35,7 @@ env:
   GDRUST_FEATURES: "gdnative/async,gdnative/serde,gdnative_bindings_generator/debug"
   CARGO_DENY_VERSION: "0.11.4"
   CARGO_DINGHY_VERSION: "0.4.71"
+  CARGO_MACHETE_VERSION: "0.3"
 
 on:
   push:
@@ -80,11 +81,13 @@ jobs:
       - name: "Check clippy"
         run: cargo clippy --workspace --features ${GDRUST_FEATURES} -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented
 
-  cargo-deny:
+  cargo-deny-machete:
     runs-on: ubuntu-latest
     needs: rustfmt
     steps:
       - uses: actions/checkout@v2
+
+      # Deny
       # Note: manually downloading is ~30s faster than https://github.com/EmbarkStudios/cargo-deny-action
       - name: "Install cargo-deny"
         run: |
@@ -92,8 +95,18 @@ jobs:
           tar -zxvf cargo-deny.tar.gz
           mkdir -p $HOME/.cargo/bin
           mv cargo-deny-$CARGO_DENY_VERSION-x86_64-unknown-linux-musl/cargo-deny $HOME/.cargo/bin
-      - name: "Check cargo-deny"
+      - name: "Deny non-conforming dependencies"
         run: cargo deny check --config tools/deny.toml
+
+      # Machete
+      - name: "Install cargo-machete"
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-machete
+          version: ${{ env.CARGO_MACHETE_VERSION }}
+      - name: "Use machete to cut down dependencies"
+        run: cargo machete
+
 
   test:
     name: test-${{ matrix.os.name }}${{ matrix.rust.postfix }}
@@ -285,7 +298,7 @@ jobs:
     needs:
       #- rustfmt
       - clippy
-      - cargo-deny
+      - cargo-deny-machete
       - test
       - integration-test-godot
       - build-release

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -33,8 +33,8 @@ env:
   # Local variables
   # Note: using variables is limited at the moment, see https://github.com/actions/runner/issues/480
   GDRUST_FEATURES: "gdnative/async,gdnative/serde,gdnative_bindings_generator/debug"
-  CARGO_DENY_VERSION: "0.11.0"
-  CARGO_DINGHY_VERSION: "0.4.68"
+  CARGO_DENY_VERSION: "0.11.4"
+  CARGO_DINGHY_VERSION: "0.4.71"
 
 on:
   push:

--- a/bindings-generator/Cargo.toml
+++ b/bindings-generator/Cargo.toml
@@ -17,7 +17,6 @@ custom-godot = ["which"]
 
 [dependencies]
 heck = "0.4"
-memchr = "2"
 miniserde = "0.1.16"
 proc-macro2 = "1"
 quote = "1"

--- a/gdnative-async/Cargo.toml
+++ b/gdnative-async/Cargo.toml
@@ -19,7 +19,6 @@ gdnative-core = { path = "../gdnative-core", version = "=0.10.0" }
 gdnative-bindings = { path = "../gdnative-bindings", version = "=0.10.0" }
 atomic-waker = "1"
 crossbeam-channel = "0.5"
-crossbeam-utils = "0.8"
 futures-task = "0.3"
 once_cell = "1"
 parking_lot = "0.12"

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -17,9 +17,7 @@ one-class-one-file = []
 custom-godot = ["gdnative_bindings_generator/custom-godot"]
 
 [dependencies]
-gdnative-sys = { path = "../gdnative-sys", version = "=0.10.0" }
 gdnative-core = { path = "../gdnative-core", version = "=0.10.0" }
-bitflags = "1"
 libc = "0.2"
 
 [build-dependencies]

--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -21,3 +21,7 @@ proc-macro2 = "1"
 quote = "1"
 miniserde = "0.1.16"
 semver = "1"
+
+# False positives found by cargo-machete
+[package.metadata.cargo-machete]
+ignored = ["libc"]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -17,7 +17,6 @@ custom-godot = ["gdnative/custom-godot"]
 
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd-test", "serde", "async"] }
-gdnative-derive = { path = "../gdnative-derive" }
 approx = "0.5"
 ron = "0.7"
 serde = "1"
@@ -26,4 +25,3 @@ bincode = "1"
 serde_yaml = "0.8.23"
 rmp-serde = "1"
 futures = "0.3"
-once_cell = "1"


### PR DESCRIPTION
[**cargo-machete**](https://github.com/bnjbvr/cargo-machete) is a tool designed to detect unnecessary dependencies in Rust crates. Having a similar goal as cargo-udep, it chooses some different trade-offs, which are explained in the [blog post](https://blog.benj.me/2022/04/27/cargo-machete/).

In godot-rust, machete detected _**6 cases**_  of unnecessary dependencies (of which 2 are between internal crates). I automated checks via CI action, which runs in less than a second -- most time is spent on `cargo install`, which is cached when possible. I needed to highlight one false positive (`libc`), which is fortunately a well-supported feature of machete. With the amount of proc-macros and code generation we deal with, I was surprised it wasn't more.

This addition should help us detect dependencies which are no longer needed, and slightly reduce initial compile time. It won't have a big effect on incremental compilation. We may need to monitor in the coming weeks if the removed dependencies cause issues in one way or another -- that would however also highlight a lack of coverage in our CI pipeline.

bors try