### PR TITLE
Add missing tests to #[methods] macro

### DIFF
--- a/gdnative/tests/ui/derive_fail_methods.stderr
+++ b/gdnative/tests/ui/derive_fail_methods.stderr
@@ -2,4 +2,4 @@ error: cannot find attribute `export` in this scope
   --> $DIR/derive_fail_methods.rs:12:7
    |
 12 |     #[export]
-   |       ^^^^^^
+   |       ^^^^^^ help: a built-in attribute with a similar name exists: `expect`

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -1,4 +1,5 @@
-use std::cell::Cell;
+use std::cell::{self, Cell, RefCell};
+use std::rc::Rc;
 
 use gdnative::export::Property;
 use gdnative::prelude::*;
@@ -8,7 +9,14 @@ pub(crate) fn run_tests() -> bool {
 
     status &= test_derive_to_variant();
     status &= test_derive_owned_to_variant();
+    status &= test_derive_nativeclass();
     status &= test_derive_nativeclass_without_constructor();
+    status &= test_derive_nativeclass_without_inherit();
+    status &= test_derive_nativeclass_godot_attr_without_base();
+    status &= test_derive_nativeclass_godot_attr_with_base();
+    status &= test_derive_nativeclass_godot_attr_deref_return();
+    status &= test_derive_nativeclass_godot_attr_rename_method();
+    status &= test_derive_nativeclass_godot_attr_to_use_all_macro_parameters();
     status &= test_derive_nativeclass_with_property_get_set();
     status &= test_derive_nativeclass_property_with_only_getter();
 
@@ -16,7 +24,14 @@ pub(crate) fn run_tests() -> bool {
 }
 
 pub(crate) fn register(handle: InitHandle) {
+    handle.add_class::<MinimalDerive>();
     handle.add_class::<EmplacementOnly>();
+    handle.add_class::<WithoutInherit>();
+    handle.add_class::<GodotAttrWithoutBase>();
+    handle.add_class::<GodotAttrWithBase>();
+    handle.add_class::<GodotAttrDerefReturn>();
+    handle.add_class::<GodotAttrRenameMethod>();
+    handle.add_class::<GodotAttrToUseAllMacroParameters>();
     handle.add_class::<CustomGetSet>();
     handle.add_class::<MyVec>();
 }
@@ -180,6 +195,39 @@ fn test_derive_owned_to_variant() -> bool {
 
 #[derive(NativeClass)]
 #[inherit(Reference)]
+struct MinimalDerive(i64);
+
+#[methods]
+impl MinimalDerive {
+    fn new(_owner: &Reference) -> Self {
+        Self(54)
+    }
+
+    #[export]
+    fn answer(&self, _owner: &Reference) -> i64 {
+        self.0
+    }
+}
+
+fn test_derive_nativeclass() -> bool {
+    println!(" -- test_derive_nativeclass");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<MinimalDerive, _>::new();
+        let base: Ref<Reference, Unique> = thing.into_base();
+        assert_eq!(unsafe { base.call("answer", &[]).to::<i64>() }, Some(54));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
 #[no_constructor]
 struct EmplacementOnly(i64);
 
@@ -210,6 +258,213 @@ fn test_derive_nativeclass_without_constructor() -> bool {
 
     if !ok {
         godot_error!("   !! Test test_derive_nativeclass_without_constructor failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+struct WithoutInherit(i64);
+
+#[methods]
+impl WithoutInherit {
+    fn new(_owner: &Reference) -> Self {
+        Self(54)
+    }
+
+    #[export]
+    fn answer(&self, _owner: &Reference) -> i64 {
+        self.0
+    }
+}
+
+fn test_derive_nativeclass_without_inherit() -> bool {
+    println!(" -- test_derive_nativeclass_without_inherit");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<WithoutInherit, _>::new();
+        let base = thing.into_base();
+        assert_eq!(unsafe { base.call("answer", &[]).to::<i64>() }, Some(54));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass_without_inherit failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct GodotAttrWithoutBase(i64);
+
+#[methods]
+impl GodotAttrWithoutBase {
+    fn new(_owner: &Reference) -> Self {
+        Self(54)
+    }
+
+    #[godot]
+    fn answer(&self) -> i64 {
+        self.0
+    }
+}
+
+fn test_derive_nativeclass_godot_attr_without_base() -> bool {
+    println!(" -- test_derive_nativeclass_godot_attr_without_base");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<GodotAttrWithoutBase, _>::new();
+        let base = thing.into_base();
+        assert_eq!(unsafe { base.call("answer", &[]).to::<i64>() }, Some(54));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass_godot_attr_without_base failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct GodotAttrWithBase(i64);
+
+#[methods]
+impl GodotAttrWithBase {
+    fn new(_owner: &Reference) -> Self {
+        Self(54)
+    }
+
+    #[godot]
+    fn answer(&self, #[base] _base: &Reference) -> i64 {
+        self.0
+    }
+}
+
+fn test_derive_nativeclass_godot_attr_with_base() -> bool {
+    println!(" -- test_derive_nativeclass_godot_attr_with_base");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<GodotAttrWithBase, _>::new();
+        let base = thing.into_base();
+        assert_eq!(unsafe { base.call("answer", &[]).to::<i64>() }, Some(54));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass_godot_attr_with_base failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct GodotAttrDerefReturn(Rc<RefCell<Vec<i64>>>);
+
+#[methods]
+impl GodotAttrDerefReturn {
+    fn new(_owner: &Reference) -> Self {
+        let vec = Vec::from([12, 34]);
+        let rc_ref = Rc::new(RefCell::new(vec));
+        Self(rc_ref)
+    }
+
+    #[godot(deref_return)]
+    fn answer(&self) -> cell::Ref<Vec<i64>> {
+        self.0.borrow()
+    }
+}
+
+fn test_derive_nativeclass_godot_attr_deref_return() -> bool {
+    println!(" -- test_derive_nativeclass_godot_attr_deref_return");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<GodotAttrDerefReturn, _>::new();
+        let base = thing.into_base();
+
+        let res = unsafe { base.call("answer", &[]).to::<Vec<i64>>() };
+        assert_eq!(res, Some([12, 34].into()));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass_godot_attr_deref_return failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct GodotAttrRenameMethod(i64);
+
+#[methods]
+impl GodotAttrRenameMethod {
+    fn new(_owner: &Reference) -> Self {
+        Self(54)
+    }
+
+    #[godot(name = "ask")]
+    fn answer(&self) -> i64 {
+        self.0
+    }
+}
+
+fn test_derive_nativeclass_godot_attr_rename_method() -> bool {
+    println!(" -- test_derive_nativeclass_godot_attr_rename_method");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<GodotAttrRenameMethod, _>::new();
+        let base = thing.into_base();
+        assert_eq!(unsafe { base.call("ask", &[]).to::<i64>() }, Some(54));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_derive_nativeclass_godot_attr_rename_method failed");
+    }
+
+    ok
+}
+
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct GodotAttrToUseAllMacroParameters(Rc<RefCell<Vec<i64>>>);
+
+#[methods]
+impl GodotAttrToUseAllMacroParameters {
+    fn new(_owner: &Reference) -> Self {
+        let vec = Vec::from([12, 34]);
+        let rc_ref = Rc::new(RefCell::new(vec));
+        Self(rc_ref)
+    }
+
+    #[godot(rpc = "disabled", name = "ask", deref_return)]
+    fn answer(&self, #[base] _base: &Reference) -> cell::Ref<Vec<i64>> {
+        self.0.borrow()
+    }
+}
+
+fn test_derive_nativeclass_godot_attr_to_use_all_macro_parameters() -> bool {
+    println!(" -- test_derive_nativeclass_godot_attr_to_use_all_macro_parameters");
+
+    let ok = std::panic::catch_unwind(|| {
+        let thing = Instance::<GodotAttrToUseAllMacroParameters, _>::new();
+        let base = thing.into_base();
+
+        let res = unsafe { base.call("ask", &[]).to::<Vec<i64>>() };
+        assert_eq!(res, Some([12, 34].into()));
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!(
+            "   !! Test test_derive_nativeclass_godot_attr_to_use_all_macro_parameters failed"
+        );
     }
 
     ok


### PR DESCRIPTION
Added tests for the following features.
- Minimal derive
- Omitted inherit
- Omitted base prameter
- Method attribute
- Deref return
- Rename method

I could not add a test for Rpc mode. We need a way to add a node to the scene tree during a test.