### PR TITLE
Refactor integration tests by reusing godot_test macro

### DIFF
--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -250,7 +250,6 @@ macro_rules! godot_test {
     }
 }
 
-
 /// Declares a test to be run with the Godot engine (i.e. not a pure Rust unit test).
 ///
 /// Creates a wrapper function that catches panics, prints errors and returns true/false.

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -208,12 +208,15 @@ macro_rules! impl_basic_traits_as_sys {
     )
 }
 
-macro_rules! godot_test {
-    ($($test_name:ident $body:block)*) => {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! godot_test_impl {
+    ( $( $test_name:ident $body:block $($attrs:tt)* )* ) => {
         $(
-            #[cfg(feature = "gd-test")]
+            $($attrs)*
             #[doc(hidden)]
             #[inline]
+            #[must_use]
             pub fn $test_name() -> bool {
                 let str_name = stringify!($test_name);
                 println!("   -- {}", str_name);
@@ -228,6 +231,38 @@ macro_rules! godot_test {
 
                 ok
             }
+        )*
+    }
+}
+
+/// Declares a test to be run with the Godot engine (i.e. not a pure Rust unit test).
+///
+/// Creates a wrapper function that catches panics, prints errors and returns true/false.
+/// To be manually invoked in higher-level test routine.
+///
+/// This macro is designed to be used within the current crate only, hence the #[cfg] attribute.
+#[doc(hidden)]
+macro_rules! godot_test {
+    ($($test_name:ident $body:block)*) => {
+        $(
+            godot_test_impl!($test_name $body #[cfg(feature = "gd-test")]);
+        )*
+    }
+}
+
+
+/// Declares a test to be run with the Godot engine (i.e. not a pure Rust unit test).
+///
+/// Creates a wrapper function that catches panics, prints errors and returns true/false.
+/// To be manually invoked in higher-level test routine.
+///
+/// This macro is designed to be used within the `test` crate, hence the method is always declared (not only in certain features).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! godot_itest {
+    ($($test_name:ident $body:block)*) => {
+        $(
+            $crate::godot_test_impl!($test_name $body);
         )*
     }
 }

--- a/impl/proc-macros/src/lib.rs
+++ b/impl/proc-macros/src/lib.rs
@@ -12,14 +12,14 @@ mod pool_array_element;
 
 #[proc_macro]
 pub fn impl_typed_array_element(input: TokenStream) -> TokenStream {
-    self::pool_array_element::impl_element(input)
+    pool_array_element::impl_element(input)
         .unwrap_or_else(to_compile_errors)
         .into()
 }
 
 #[proc_macro]
 pub fn decl_typed_array_element(input: TokenStream) -> TokenStream {
-    self::pool_array_element::decl_element(input)
+    pool_array_element::decl_element(input)
         .unwrap_or_else(to_compile_errors)
         .into()
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -17,6 +17,7 @@ custom-godot = ["gdnative/custom-godot"]
 
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd-test", "serde", "async"] }
+gdnative-core = { path = "../gdnative-core" }
 approx = "0.5"
 ron = "0.7"
 serde = "1"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -79,7 +79,7 @@ pub extern "C" fn run_tests(
     status &= test_variant_call_args::run_tests();
     status &= test_variant_ops::run_tests();
 
-    gdnative::core_types::Variant::new(status).leak()
+    Variant::new(status).leak()
 }
 
 fn test_underscore_method_binding() -> bool {

--- a/test/src/test_as_arg.rs
+++ b/test/src/test_as_arg.rs
@@ -8,20 +8,10 @@ pub(crate) fn register(handle: InitHandle) {
 }
 
 pub(crate) fn run_tests() -> bool {
-    println!(" -- test_as_arg");
+    let mut ok = true;
 
-    let ok = std::panic::catch_unwind(|| {
-        println!("   -- test_ref_as_arg");
-        test_ref_as_arg();
-
-        println!("   -- test_instance_as_arg");
-        test_instance_as_arg();
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_as_arg failed");
-    }
+    ok &= test_as_arg_ref();
+    ok &= test_as_arg_instance();
 
     ok
 }
@@ -40,7 +30,7 @@ impl MyNode {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-fn test_ref_as_arg() {
+crate::godot_itest! { test_as_arg_ref {
     // Ref<T, Unique>
     add_node_with(|n: Ref<Node2D, Unique>| n);
 
@@ -56,9 +46,9 @@ fn test_ref_as_arg() {
 
     // TRef<T, Shared>
     add_node_with(|n: Ref<Node2D, Unique>| unsafe { n.into_shared().assume_safe() });
-}
+}}
 
-fn test_instance_as_arg() {
+crate::godot_itest! { test_as_arg_instance {
     // Instance<T, Unique>
     add_instance_with(|n: Instance<MyNode, Unique>| n);
 
@@ -74,7 +64,7 @@ fn test_instance_as_arg() {
 
     // TInstance<T, Shared>
     add_instance_with(|n: Instance<MyNode, Unique>| unsafe { n.into_shared().assume_safe() });
-}
+}}
 
 fn add_node_with<F, T>(to_arg: F)
 where

--- a/test/src/test_constructor.rs
+++ b/test/src/test_constructor.rs
@@ -27,43 +27,32 @@ fn test_constructor() -> bool {
     true
 }
 
-fn test_from_class_name() -> bool {
-    println!(" -- test_from_class_name");
+crate::godot_itest! { test_from_class_name {
+    // Since this method is restricted to Godot types, there is no way we can detect
+    // here whether any invalid objects are leaked. Instead, the CI script is modified
+    // to look at stdout for any reported leaks.
 
-    let ok = std::panic::catch_unwind(|| {
-        // Since this method is restricted to Godot types, there is no way we can detect
-        // here whether any invalid objects are leaked. Instead, the CI script is modified
-        // to look at stdout for any reported leaks.
+    let node = Ref::<Node, _>::by_class_name("Node2D").unwrap();
+    assert_eq!("Node2D", node.get_class().to_string());
+    let node = node.cast::<Node2D>().unwrap();
+    assert_eq!("Node2D", node.get_class().to_string());
+    let _ = node.position();
+    node.free();
 
-        let node = Ref::<Node, _>::by_class_name("Node2D").unwrap();
-        assert_eq!("Node2D", node.get_class().to_string());
-        let node = node.cast::<Node2D>().unwrap();
-        assert_eq!("Node2D", node.get_class().to_string());
-        let _ = node.position();
-        node.free();
+    let shader = Ref::<Reference, _>::by_class_name("Shader").unwrap();
+    assert_eq!("Shader", &shader.get_class().to_string());
+    let shader = shader.cast::<Shader>().unwrap();
+    assert_eq!("Shader", &shader.get_class().to_string());
 
-        let shader = Ref::<Reference, _>::by_class_name("Shader").unwrap();
-        assert_eq!("Shader", &shader.get_class().to_string());
-        let shader = shader.cast::<Shader>().unwrap();
-        assert_eq!("Shader", &shader.get_class().to_string());
+    let none = Ref::<Object, _>::by_class_name("Shader");
+    assert!(none.is_none());
 
-        let none = Ref::<Object, _>::by_class_name("Shader");
-        assert!(none.is_none());
+    let none = Ref::<Node2D, _>::by_class_name("Spatial");
+    assert!(none.is_none());
 
-        let none = Ref::<Node2D, _>::by_class_name("Spatial");
-        assert!(none.is_none());
+    let none = Ref::<Shader, _>::by_class_name("AudioEffectReverb");
+    assert!(none.is_none());
 
-        let none = Ref::<Shader, _>::by_class_name("AudioEffectReverb");
-        assert!(none.is_none());
-
-        let none = Ref::<Object, _>::by_class_name("ClassThatDoesNotExistProbably");
-        assert!(none.is_none());
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_from_class_name failed");
-    }
-
-    ok
-}
+    let none = Ref::<Object, _>::by_class_name("ClassThatDoesNotExistProbably");
+    assert!(none.is_none());
+}}

--- a/test/src/test_map_owned.rs
+++ b/test/src/test_map_owned.rs
@@ -30,40 +30,29 @@ impl VecBuilder {
     }
 }
 
-fn test_map_owned() -> bool {
-    println!(" -- test_map_owned");
+crate::godot_itest! { test_map_owned {
+    let v1 = Instance::emplace(VecBuilder { v: Vec::new() }).into_shared();
+    let v1 = unsafe { v1.assume_safe() };
 
-    let ok = std::panic::catch_unwind(|| {
-        let v1 = Instance::emplace(VecBuilder { v: Vec::new() }).into_shared();
-        let v1 = unsafe { v1.assume_safe() };
+    let v2 = v1
+        .map_owned(|s, owner| s.append(owner, vec![1, 2, 3]))
+        .unwrap();
+    let v2 = unsafe { v2.assume_safe() };
+    assert!(v1
+        .map_owned(|_, _| panic!("should never be called"))
+        .is_err());
 
-        let v2 = v1
-            .map_owned(|s, owner| s.append(owner, vec![1, 2, 3]))
-            .unwrap();
-        let v2 = unsafe { v2.assume_safe() };
-        assert!(v1
-            .map_owned(|_, _| panic!("should never be called"))
-            .is_err());
+    let v3 = v2
+        .map_owned(|s, owner| s.append(owner, vec![4, 5, 6]))
+        .unwrap();
+    let v3 = unsafe { v3.assume_safe() };
+    assert!(v2
+        .map_owned(|_, _| panic!("should never be called"))
+        .is_err());
 
-        let v3 = v2
-            .map_owned(|s, owner| s.append(owner, vec![4, 5, 6]))
-            .unwrap();
-        let v3 = unsafe { v3.assume_safe() };
-        assert!(v2
-            .map_owned(|_, _| panic!("should never be called"))
-            .is_err());
-
-        let v = v3.map_owned(|s, _| s.v).unwrap();
-        assert_eq!(&v, &[1, 2, 3, 4, 5, 6]);
-        assert!(v3
-            .map_owned(|_, _| panic!("should never be called"))
-            .is_err());
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_map_owned failed");
-    }
-
-    ok
-}
+    let v = v3.map_owned(|s, _| s.v).unwrap();
+    assert_eq!(&v, &[1, 2, 3, 4, 5, 6]);
+    assert!(v3
+        .map_owned(|_, _| panic!("should never be called"))
+        .is_err());
+}}

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -79,32 +79,17 @@ impl RegisterProperty {
     }
 }
 
-fn test_register_property() -> bool {
-    println!(" -- test_register_property");
+crate::godot_itest! { test_register_property {
+    let obj = RegisterProperty::new_instance();
+    let base = obj.into_base();
+    assert_eq!(Some(42), unsafe { base.call("get_value", &[]).to() });
 
-    let ok = std::panic::catch_unwind(|| {
-        let obj = RegisterProperty::new_instance();
+    base.set("value", 54.to_variant());
+    assert_eq!(Some(54), unsafe { base.call("get_value", &[]).to() });
 
-        let base = obj.into_base();
-
-        assert_eq!(Some(42), unsafe { base.call("get_value", &[]).to() });
-
-        base.set("value", 54.to_variant());
-
-        assert_eq!(Some(54), unsafe { base.call("get_value", &[]).to() });
-
-        unsafe { base.call("set_value", &[4242.to_variant()]) };
-
-        assert_eq!(Some(4242), unsafe { base.call("get_value", &[]).to() });
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_register_property failed");
-    }
-
-    ok
-}
+    unsafe { base.call("set_value", &[4242.to_variant()]) };
+    assert_eq!(Some(4242), unsafe { base.call("get_value", &[]).to() });
+}}
 
 #[derive(NativeClass)]
 #[inherit(Reference)]
@@ -169,66 +154,55 @@ fn register_methods(builder: &ClassBuilder<AdvancedMethods>) {
         .done();
 }
 
-fn test_advanced_methods() -> bool {
-    println!(" -- test_advanced_methods");
+crate::godot_itest! { test_advanced_methods {
+    let thing = Instance::<AdvancedMethods, _>::new();
+    let thing = thing.base();
 
-    let ok = std::panic::catch_unwind(|| {
-        let thing = Instance::<AdvancedMethods, _>::new();
-        let thing = thing.base();
-
-        assert_eq!(
-            45,
-            i32::from_variant(unsafe {
-                &thing.call(
-                    "add_ints",
-                    &[1.to_variant(), 2.to_variant(), Variant::nil()],
-                )
-            })
-            .unwrap()
-        );
-
-        assert_eq!(
-            48,
-            i32::from_variant(unsafe {
-                &thing.call(
-                    "add_ints",
-                    &[1.to_variant(), 2.to_variant(), 3.to_variant()],
-                )
-            })
-            .unwrap()
-        );
-
-        approx::assert_relative_eq!(
-            6.5,
-            f32::from_variant(unsafe {
-                &thing.call(
-                    "add_floats",
-                    &[(5.0).to_variant(), (-2.5).to_variant(), Variant::nil()],
-                )
-            })
-            .unwrap()
-        );
-
-        let v = Vector2::from_variant(unsafe {
+    assert_eq!(
+        45,
+        i32::from_variant(unsafe {
             &thing.call(
-                "add_vectors",
-                &[
-                    Vector2::new(5.0, -5.0).to_variant(),
-                    Vector2::new(-2.5, 2.5).to_variant(),
-                    Variant::nil(),
-                ],
+                "add_ints",
+                &[1.to_variant(), 2.to_variant(), Variant::nil()],
             )
         })
-        .unwrap();
+        .unwrap()
+    );
 
-        approx::assert_relative_eq!(3.5, v.x);
-        approx::assert_relative_eq!(-0.5, v.y);
+    assert_eq!(
+        48,
+        i32::from_variant(unsafe {
+            &thing.call(
+                "add_ints",
+                &[1.to_variant(), 2.to_variant(), 3.to_variant()],
+            )
+        })
+        .unwrap()
+    );
+
+    approx::assert_relative_eq!(
+        6.5,
+        f32::from_variant(unsafe {
+            &thing.call(
+                "add_floats",
+                &[(5.0).to_variant(), (-2.5).to_variant(), Variant::nil()],
+            )
+        })
+        .unwrap()
+    );
+
+    let v = Vector2::from_variant(unsafe {
+        &thing.call(
+            "add_vectors",
+            &[
+                Vector2::new(5.0, -5.0).to_variant(),
+                Vector2::new(-2.5, 2.5).to_variant(),
+                Variant::nil(),
+            ],
+        )
     })
-    .is_ok();
+    .unwrap();
 
-    if !ok {
-        godot_error!("   !! Test test_advanced_methods failed");
-    }
-
-    ok
-}
+    approx::assert_relative_eq!(3.5, v.x);
+    approx::assert_relative_eq!(-0.5, v.y);
+}}

--- a/test/src/test_serde.rs
+++ b/test/src/test_serde.rs
@@ -112,176 +112,100 @@ impl Foo {
     }
 }
 
-/// Sanity check that a round trip through Variant preserves equality for Foo.
-fn test_variant_eq() -> bool {
-    println!("   -- test_variant_eq");
+// Sanity check that a round trip through Variant preserves equality for Foo.
+crate::godot_itest! { test_variant_eq {
+    let foo = Foo::new();
+    let variant = foo.to_variant();
+    let result = Foo::from_variant(&variant).expect("Foo::from_variant");
+    assert_eq!(foo, result);
+}}
 
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
-        let variant = foo.to_variant();
-        let result = Foo::from_variant(&variant).expect("Foo::from_variant");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
+// Sanity check that a round trip through VariantDispatch preserves equality for Foo.
+crate::godot_itest! { test_dispatch_eq {
+    let foo = Foo::new();
+    let dispatch = foo.to_variant().dispatch();
+    let result = Foo::from_variant(&Variant::from(&dispatch)).expect("Foo from Dispatch");
+    assert_eq!(foo, result);
+}}
 
-    if !ok {
-        godot_error!("     !! Test test_variant_eq failed");
-    }
+crate::godot_itest! { test_ron {
+    let foo = Foo::new();
 
-    ok
-}
+    let ron_str = ron::to_string(&foo).expect("Foo to RON str");
+    let mut de = ron::Deserializer::from_str(ron_str.as_ref());
+    let result = Foo::deserialize(de.as_mut().expect("deserialize Foo from RON")).unwrap();
+    assert_eq!(foo, result);
 
-/// Sanity check that a round trip through VariantDispatch preserves equality for Foo.
-fn test_dispatch_eq() -> bool {
-    println!("   -- test_dispatch_eq");
+    let ron_disp_str = ron::to_string(&foo.to_variant().dispatch()).expect("Dispatch to RON");
+    let mut de = ron::Deserializer::from_str(ron_disp_str.as_ref());
+    let de = de
+        .as_mut()
+        .expect("disp_round_trip ron::Deserializer::from_str");
+    let disp = VariantDispatch::deserialize(de).expect("Dispatch from RON");
+    let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from RON");
+    assert_eq!(foo, result);
+}}
 
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
-        let dispatch = foo.to_variant().dispatch();
-        let result = Foo::from_variant(&Variant::from(&dispatch)).expect("Foo from Dispatch");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
+crate::godot_itest! { test_json {
+    let foo = Foo::new();
 
-    if !ok {
-        godot_error!("     !! Test test_dispatch_eq failed");
-    }
+    let json_str = serde_json::to_string(&foo).expect("Foo to JSON");
+    let result = serde_json::from_str::<Foo>(json_str.as_ref()).expect("Foo from JSON");
+    assert_eq!(foo, result);
 
-    ok
-}
+    let foo = Foo::new();
+    let json_disp_str =
+        serde_json::to_string(&foo.to_variant().dispatch()).expect("Foo Dispatch to JSON");
+    let disp = serde_json::from_str::<VariantDispatch>(json_disp_str.as_ref())
+        .expect("Dispatch from JSON");
 
-fn test_ron() -> bool {
-    println!("   -- test_ron");
+    let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from JSON");
+    assert_eq!(foo, result);
+}}
 
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
+crate::godot_itest! { test_yaml {
+    let foo = Foo::new();
 
-        let ron_str = ron::to_string(&foo).expect("Foo to RON str");
-        let mut de = ron::Deserializer::from_str(ron_str.as_ref());
-        let result = Foo::deserialize(de.as_mut().expect("deserialize Foo from RON")).unwrap();
-        assert_eq!(foo, result);
+    let yaml_str = serde_yaml::to_string(&foo).expect("Foo to YAML");
+    let result = serde_yaml::from_str::<Foo>(&yaml_str).expect("Foo from YAML");
+    assert_eq!(foo, result);
 
-        let ron_disp_str = ron::to_string(&foo.to_variant().dispatch()).expect("Dispatch to RON");
-        let mut de = ron::Deserializer::from_str(ron_disp_str.as_ref());
-        let de = de
-            .as_mut()
-            .expect("disp_round_trip ron::Deserializer::from_str");
-        let disp = VariantDispatch::deserialize(de).expect("Dispatch from RON");
-        let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from RON");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
+    let yaml_str =
+        serde_yaml::to_string(&foo.to_variant().dispatch()).expect("Dispatch to YAML");
+    let disp = serde_yaml::from_str::<VariantDispatch>(&yaml_str).expect("Dispatch from YAML");
+    let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from YAML");
+    assert_eq!(foo, result);
+}}
 
-    if !ok {
-        godot_error!("     !! Test test_ron failed");
-    }
+crate::godot_itest! { test_msgpack {
+    let foo = Foo::new();
 
-    ok
-}
+    let msgpack_bytes = rmp_serde::to_vec_named(&foo).expect("Foo to MessagePack");
+    let result =
+        rmp_serde::from_read_ref::<_, Foo>(&msgpack_bytes).expect("Foo from MessagePack");
+    assert_eq!(foo, result);
 
-fn test_json() -> bool {
-    println!("   -- test_json");
+    let msgpack_disp_bytes =
+        rmp_serde::to_vec_named(&foo.to_variant().dispatch()).expect("Dispatch to MessagePack");
+    let disp = rmp_serde::from_read_ref::<_, VariantDispatch>(&msgpack_disp_bytes)
+        .expect("Dispatch from MessagePack");
+    let result =
+        Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from MessagePack");
+    assert_eq!(foo, result);
+}}
 
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
+crate::godot_itest! { test_bincode {
+    let foo = Foo::new();
 
-        let json_str = serde_json::to_string(&foo).expect("Foo to JSON");
-        let result = serde_json::from_str::<Foo>(json_str.as_ref()).expect("Foo from JSON");
-        assert_eq!(foo, result);
+    let bincode_bytes = bincode::serialize(&foo).expect("Foo to bincode");
+    let result = bincode::deserialize::<Foo>(bincode_bytes.as_ref()).expect("Foo from bincode");
+    assert_eq!(foo, result);
 
-        let foo = Foo::new();
-        let json_disp_str =
-            serde_json::to_string(&foo.to_variant().dispatch()).expect("Foo Dispatch to JSON");
-        let disp = serde_json::from_str::<VariantDispatch>(json_disp_str.as_ref())
-            .expect("Dispatch from JSON");
-        let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from JSON");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("     !! Test test_json failed");
-    }
-
-    ok
-}
-
-fn test_yaml() -> bool {
-    println!("   -- test_yaml");
-
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
-
-        let yaml_str = serde_yaml::to_string(&foo).expect("Foo to YAML");
-        let result = serde_yaml::from_str::<Foo>(&yaml_str).expect("Foo from YAML");
-        assert_eq!(foo, result);
-
-        let yaml_str =
-            serde_yaml::to_string(&foo.to_variant().dispatch()).expect("Dispatch to YAML");
-        let disp = serde_yaml::from_str::<VariantDispatch>(&yaml_str).expect("Dispatch from YAML");
-        let result = Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from YAML");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("     !! Test test_yaml failed");
-    }
-
-    ok
-}
-
-fn test_msgpack() -> bool {
-    println!("   -- test_msgpack");
-
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
-
-        let msgpack_bytes = rmp_serde::to_vec_named(&foo).expect("Foo to MessagePack");
-        let result =
-            rmp_serde::from_read_ref::<_, Foo>(&msgpack_bytes).expect("Foo from MessagePack");
-        assert_eq!(foo, result);
-
-        let msgpack_disp_bytes =
-            rmp_serde::to_vec_named(&foo.to_variant().dispatch()).expect("Dispatch to MessagePack");
-        let disp = rmp_serde::from_read_ref::<_, VariantDispatch>(&msgpack_disp_bytes)
-            .expect("Dispatch from MessagePack");
-        let result =
-            Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from MessagePack");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("     !! Test test_msgpack failed");
-    }
-
-    ok
-}
-
-fn test_bincode() -> bool {
-    println!("   -- test_bincode");
-
-    let ok = std::panic::catch_unwind(|| {
-        let foo = Foo::new();
-
-        let bincode_bytes = bincode::serialize(&foo).expect("Foo to bincode");
-        let result = bincode::deserialize::<Foo>(bincode_bytes.as_ref()).expect("Foo from bincode");
-        assert_eq!(foo, result);
-
-        let bincode_bytes =
-            bincode::serialize(&foo.to_variant().dispatch()).expect("Dispatch to bincode");
-        let disp = bincode::deserialize::<VariantDispatch>(bincode_bytes.as_ref())
-            .expect("Dispatch from bincode");
-        let result =
-            Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from bincode");
-        assert_eq!(foo, result);
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("     !! Test test_bincode failed");
-    }
-
-    ok
-}
+    let bincode_bytes =
+        bincode::serialize(&foo.to_variant().dispatch()).expect("Dispatch to bincode");
+    let disp = bincode::deserialize::<VariantDispatch>(bincode_bytes.as_ref())
+        .expect("Dispatch from bincode");
+    let result =
+        Foo::from_variant(&Variant::from(&disp)).expect("Foo from Dispatch from bincode");
+    assert_eq!(foo, result);
+}}

--- a/test/src/test_vararray_return.rs
+++ b/test/src/test_vararray_return.rs
@@ -1,8 +1,6 @@
 use gdnative::api::Camera;
 use gdnative::prelude::*;
 
-use gdnative_core::godot_itest;
-
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
 
@@ -13,7 +11,7 @@ pub(crate) fn run_tests() -> bool {
 
 pub(crate) fn register(_handle: InitHandle) {}
 
-godot_itest! { test_vararray_return_crash {
+crate::godot_itest! { test_vararray_return_crash {
     // See https://github.com/godot-rust/godot-rust/issues/422
     let camera = Camera::new();
 

--- a/test/src/test_vararray_return.rs
+++ b/test/src/test_vararray_return.rs
@@ -1,6 +1,8 @@
 use gdnative::api::Camera;
 use gdnative::prelude::*;
 
+use gdnative_core::godot_itest;
+
 pub(crate) fn run_tests() -> bool {
     let mut status = true;
 
@@ -11,24 +13,11 @@ pub(crate) fn run_tests() -> bool {
 
 pub(crate) fn register(_handle: InitHandle) {}
 
-fn test_vararray_return_crash() -> bool {
-    println!(" -- test_vararray_return_crash");
+godot_itest! { test_vararray_return_crash {
+    // See https://github.com/godot-rust/godot-rust/issues/422
+    let camera = Camera::new();
 
-    let ok = std::panic::catch_unwind(|| {
-        // See https://github.com/godot-rust/godot-rust/issues/422
-        let camera = Camera::new();
-
-        camera.set_frustum(5.0, Vector2::new(1.0, 2.0), 0.0, 1.0);
-
-        camera.get_frustum(); // this should not crash!
-
-        camera.free();
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_vararray_return_crash failed");
-    }
-
-    ok
-}
+    camera.set_frustum(5.0, Vector2::new(1.0, 2.0), 0.0, 1.0);
+    camera.get_frustum(); // this should not crash!
+    camera.free();
+}}

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -51,40 +51,29 @@ impl VariantCallArgs {
     }
 }
 
-fn test_variant_call_args() -> bool {
-    println!(" -- test_variant_call_args");
+crate::godot_itest! { test_variant_call_args {
+    let obj = Instance::<VariantCallArgs, _>::new();
 
-    let ok = std::panic::catch_unwind(|| {
-        let obj = Instance::<VariantCallArgs, _>::new();
+    let mut base = obj.into_base().into_shared().to_variant();
 
-        let mut base = obj.into_base().into_shared().to_variant();
+    assert_eq!(Some(42), call_i64(&mut base, "zero", &[]));
 
-        assert_eq!(Some(42), call_i64(&mut base, "zero", &[]));
+    assert_eq!(Some(126), call_i64(&mut base, "one", &[Variant::new(3)]));
 
-        assert_eq!(Some(126), call_i64(&mut base, "one", &[Variant::new(3)]));
+    assert_eq!(
+        Some(-10),
+        call_i64(&mut base, "two", &[Variant::new(-1), Variant::new(32)])
+    );
 
-        assert_eq!(
-            Some(-10),
-            call_i64(&mut base, "two", &[Variant::new(-1), Variant::new(32)])
-        );
-
-        assert_eq!(
-            Some(-52),
-            call_i64(
-                &mut base,
-                "three",
-                &[Variant::new(-2), Variant::new(4), Variant::new(8),]
-            )
-        );
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_variant_call_args failed");
-    }
-
-    ok
-}
+    assert_eq!(
+        Some(-52),
+        call_i64(
+            &mut base,
+            "three",
+            &[Variant::new(-2), Variant::new(4), Variant::new(8),]
+        )
+    );
+}}
 
 fn call_i64(variant: &mut Variant, method: &str, args: &[Variant]) -> Option<i64> {
     let result = unsafe { variant.call(method, args) };

--- a/test/src/test_variant_ops.rs
+++ b/test/src/test_variant_ops.rs
@@ -11,38 +11,27 @@ pub(crate) fn run_tests() -> bool {
 
 pub(crate) fn register(_handle: InitHandle) {}
 
-fn test_variant_ops() -> bool {
-    println!(" -- test_variant_ops");
+crate::godot_itest! { test_variant_ops {
+    let arr = VariantArray::new();
+    arr.push(&"bar".to_variant());
+    arr.push(&"baz".to_variant());
+    let arr = arr.into_shared().to_variant();
 
-    let ok = std::panic::catch_unwind(|| {
-        let arr = VariantArray::new();
-        arr.push(&"bar".to_variant());
-        arr.push(&"baz".to_variant());
-        let arr = arr.into_shared().to_variant();
+    assert_eq!(
+        Ok(42.to_variant()),
+        6.to_variant()
+            .evaluate(VariantOperator::Multiply, &7.to_variant()),
+    );
 
-        assert_eq!(
-            Ok(42.to_variant()),
-            6.to_variant()
-                .evaluate(VariantOperator::Multiply, &7.to_variant()),
-        );
+    assert_eq!(
+        Ok(false.to_variant()),
+        "foo".to_variant().evaluate(VariantOperator::In, &arr),
+    );
 
-        assert_eq!(
-            Ok(false.to_variant()),
-            "foo".to_variant().evaluate(VariantOperator::In, &arr),
-        );
-
-        assert_eq!(
-            Err(InvalidOp),
-            "foo"
-                .to_variant()
-                .evaluate(VariantOperator::Multiply, &"bar".to_variant()),
-        );
-    })
-    .is_ok();
-
-    if !ok {
-        godot_error!("   !! Test test_variant_ops failed");
-    }
-
-    ok
-}
+    assert_eq!(
+        Err(InvalidOp),
+        "foo"
+            .to_variant()
+            .evaluate(VariantOperator::Multiply, &"bar".to_variant()),
+    );
+}}


### PR DESCRIPTION
Reduces boilerplate of the form
```rs
fn test_with_certain_name() -> bool {
    println!(" -- test_with_certain_name");

    let ok = std::panic::catch_unwind(|| {
        // actual test code here
    })
    .is_ok();

    if !ok {
        godot_error!("   !! Test test_with_certain_name failed");
    }

    ok
}
```
to
```rs
godot_itest! { test_with_certain_name {
    // actual test code here
}}
```
which reduces repetition and focuses on important things. This is done by slightly adjusting the existing `godot_test` macro to `godot_itest`, which is needed so it can also be used in the `tests` crate.

This change leads to a net removal of 300 lines of code.

---

I was also considering a proc-macro attribute
```rs
#[godot_test]
fn test_with_certain_name() {
    // actual test code here
}
```
which might be a tiny bit nicer syntax-wise, and even started implementing it. But I think the declarative macro does the job, is simpler and likely faster to compile (as we don't need `syn` to tokenize the entire code).

---

Tests of this form now all have the `#[must_use]` attribute, yielding a warning if a boolean test result is ignored.