### PR TITLE
`Ord` implementation now covered by macro

### DIFF
--- a/gdnative-core/src/core_types/rid.rs
+++ b/gdnative-core/src/core_types/rid.rs
@@ -91,6 +91,6 @@ impl_basic_traits_as_sys! {
     for Rid as godot_rid {
         Default => godot_rid_new;
         Eq => godot_rid_operator_equal;
-        PartialOrd => godot_rid_operator_less;
+        Ord => godot_rid_operator_less;
     }
 }

--- a/gdnative-core/src/core_types/rid.rs
+++ b/gdnative-core/src/core_types/rid.rs
@@ -1,6 +1,5 @@
 use crate::private::get_api;
 use crate::sys;
-use std::cmp::Ordering;
 use std::mem::transmute;
 
 // Note: for safety design, consult:
@@ -90,20 +89,8 @@ impl Rid {
 
 impl_basic_traits_as_sys! {
     for Rid as godot_rid {
-        Eq => godot_rid_operator_equal;
         Default => godot_rid_new;
-    }
-}
-
-impl PartialOrd for Rid {
-    #[inline]
-    fn partial_cmp(&self, other: &Rid) -> Option<Ordering> {
-        if PartialEq::eq(self, other) {
-            Some(Ordering::Equal)
-        } else if unsafe { (get_api().godot_rid_operator_less)(self.sys(), other.sys()) } {
-            Some(Ordering::Less)
-        } else {
-            Some(Ordering::Greater)
-        }
+        Eq => godot_rid_operator_equal;
+        PartialOrd => godot_rid_operator_less;
     }
 }

--- a/gdnative-core/src/core_types/string.rs
+++ b/gdnative-core/src/core_types/string.rs
@@ -592,7 +592,7 @@ impl_basic_traits_as_sys! {
     for StringName as godot_string_name {
         Drop => godot_string_name_destroy;
         Eq => godot_string_name_operator_equal;
-        PartialOrd => godot_string_name_operator_less;
+        Ord => godot_string_name_operator_less;
     }
 }
 

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -603,7 +603,7 @@ impl_basic_traits_as_sys!(
         Drop => godot_variant_destroy;
         Clone => godot_variant_new_copy;
         PartialEq => godot_variant_operator_equal;
-        PartialOrd => godot_variant_operator_less;
+        Ord => godot_variant_operator_less;
     }
 );
 

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -603,6 +603,7 @@ impl_basic_traits_as_sys!(
         Drop => godot_variant_destroy;
         Clone => godot_variant_new_copy;
         PartialEq => godot_variant_operator_equal;
+        PartialOrd => godot_variant_operator_less;
     }
 );
 

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -174,30 +174,25 @@ macro_rules! impl_basic_trait_as_sys {
     };
 
     (
-        PartialOrd for $Type:ty as $GdType:ident : $gd_method:ident
-    ) => {
-        impl PartialOrd for $Type {
-             #[inline]
-             fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                if self == other {
-                    Some(std::cmp::Ordering::Equal)
-                } else if unsafe { (get_api().$gd_method)(&self.0, &other.0) } {
-                    Some(std::cmp::Ordering::Less)
-                } else {
-                    Some(std::cmp::Ordering::Greater)
-                }
-            }
-        }
-    };
-
-    (
         Ord for $Type:ty as $GdType:ident : $gd_method:ident
     ) => {
-        impl_basic_trait_as_sys!(PartialOrd for $Type as $GdType : $gd_method);
+        impl PartialOrd for $Type {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
         impl Ord for $Type {
-             #[inline]
-             fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                self.partial_cmp(other).unwrap()
+            #[inline]
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                let op_less = get_api().$gd_method;
+                if unsafe { op_less(&self.0, &other.0) } {
+                    std::cmp::Ordering::Less
+                } else if unsafe { op_less(&other.0, &self.0) } {
+                    std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Equal
+                }
             }
         }
     };


### PR DESCRIPTION
Unifies `impl Ord` for various types.

Also upgrades from `PartialOrd` to `Ord`, since Godot defines total order on these types.