### PR TITLE
use ManuallyDrop in ptrcalls to prevent drop reordering

### DIFF
--- a/bindings-generator/src/methods.rs
+++ b/bindings-generator/src/methods.rs
@@ -468,8 +468,12 @@ mod ptrcall {
                 .map(|(name, ty)| generate_argument_pre(ty, name));
             let return_pre = generate_return_pre(&sig.return_type);
 
+            let arg_forgets = arguments.clone().map(|(name, _)| {
+                quote! { let #name = ::std::mem::ManuallyDrop::new(#name); }
+            });
+
             let arg_drops = arguments.clone().map(|(name, _)| {
-                quote! { drop(#name); }
+                quote! { ::std::mem::ManuallyDrop::into_inner(#name); }
             });
 
             quote! {
@@ -478,6 +482,8 @@ mod ptrcall {
                 let mut argument_buffer : [*const libc::c_void; #arg_count] = [
                     #(#args),*
                 ];
+
+                #(#arg_forgets)*
 
                 #return_pre
 


### PR DESCRIPTION
On rustc 1.65.0-nightly (29e4a9ee0 2022-08-10), drops of args in some ptrcalls are seemingly being reordered to before the FFI call. Using `ManuallyDrop` prevents this.

This could potentially be related to #894, but I'm not confident enough to say it will definitely fix it yet.