### PR TITLE
fix leaks in as_arg tests

### DIFF
--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -614,8 +614,8 @@ godot_test!(
     test_array_debug {
         use std::panic::catch_unwind;
 
-        println!("  -- expected 4 'Index 3 out of bounds (len 3)' error messages for edge cases");
-        println!("  -- the test is successful when and only when these errors are shown");
+        println!("  -- expecting four 'Index 3 out of bounds (len 3)' panic messages for edge cases");
+        println!("  -- the test is successful when and only when these four errors are shown");
 
         let arr = VariantArray::new(); // []
         arr.push(&Variant::new("hello world"));


### PR DESCRIPTION
Multiple objects were being leaked by the `test_as_arg` tests. Dropping the parent in the `add_[node/instance]_with` methods solved most of them, and replacing the dummy node with a `MaybeUninit` for the shared ref tests fixed the rest.

(I also edited the message in `test_array_debug` to make it clearer to me what's supposed to happen.