### PR TITLE
Give `get_api` panic message

### DIFF
--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -245,7 +245,12 @@ macro_rules! godot_test_impl {
                 ).is_ok();
 
                 if !ok {
-                    $crate::godot_error!("   !! Test {} failed", str_name);
+                    if ::std::panic::catch_unwind(|| {
+                        $crate::godot_error!("   !! Test {} failed", str_name);
+                    }).is_err() {
+                        eprintln!("   !! Test {} failed", str_name);
+                        eprintln!("   !! And failed to call Godot API to log error message");
+                    }
                 }
 
                 ok


### PR DESCRIPTION
Fix #926 

But about the last sentence in function doc

> This allows it to be used in FFI contexts without a `catch_unwind`

I am not sure whether this changes after `get_api` switched from `abort` to `panic!`.
