### PR TITLE
Rename `#[godot]` to `#[method]`

### DIFF
--- a/examples/dodge-the-creeps/src/hud.rs
+++ b/examples/dodge-the-creeps/src/hud.rs
@@ -16,7 +16,7 @@ impl Hud {
         Hud
     }
 
-    #[godot]
+    #[method]
     pub fn show_message(&self, #[base] owner: &CanvasLayer, text: String) {
         let message_label = unsafe { owner.get_node_as::<Label>("message_label").unwrap() };
         message_label.set_text(text);
@@ -37,20 +37,20 @@ impl Hud {
         button.show();
     }
 
-    #[godot]
+    #[method]
     pub fn update_score(&self, #[base] owner: &CanvasLayer, score: i64) {
         let label = unsafe { owner.get_node_as::<Label>("score_label").unwrap() };
         label.set_text(score.to_string());
     }
 
-    #[godot]
+    #[method]
     fn on_start_button_pressed(&self, #[base] owner: &CanvasLayer) {
         let button = unsafe { owner.get_node_as::<Button>("start_button").unwrap() };
         button.hide();
         owner.emit_signal("start_game", &[]);
     }
 
-    #[godot]
+    #[method]
     fn on_message_timer_timeout(&self, #[base] owner: &CanvasLayer) {
         let message_label = unsafe { owner.get_node_as::<Label>("message_label").unwrap() };
         message_label.hide()

--- a/examples/dodge-the-creeps/src/main_scene.rs
+++ b/examples/dodge-the-creeps/src/main_scene.rs
@@ -24,7 +24,7 @@ impl Main {
         }
     }
 
-    #[godot]
+    #[method]
     fn game_over(&self, #[base] owner: &Node) {
         let score_timer = unsafe { owner.get_node_as::<Timer>("score_timer").unwrap() };
         let mob_timer = unsafe { owner.get_node_as::<Timer>("mob_timer").unwrap() };
@@ -38,7 +38,7 @@ impl Main {
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[godot]
+    #[method]
     fn new_game(&mut self, #[base] owner: &Node) {
         let start_position = unsafe { owner.get_node_as::<Position2D>("start_position").unwrap() };
         let player = unsafe {
@@ -66,7 +66,7 @@ impl Main {
         .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[godot]
+    #[method]
     fn on_start_timer_timeout(&self, #[base] owner: &Node) {
         let mob_timer = unsafe { owner.get_node_as::<Timer>("mob_timer").unwrap() };
         let score_timer = unsafe { owner.get_node_as::<Timer>("score_timer").unwrap() };
@@ -74,7 +74,7 @@ impl Main {
         score_timer.start(0.0);
     }
 
-    #[godot]
+    #[method]
     fn on_score_timer_timeout(&mut self, #[base] owner: &Node) {
         self.score += 1;
 
@@ -84,7 +84,7 @@ impl Main {
             .unwrap_or_else(|| godot_print!("Unable to get hud"));
     }
 
-    #[godot]
+    #[method]
     fn on_mob_timer_timeout(&self, #[base] owner: &Node) {
         let mob_spawn_location = unsafe {
             owner

--- a/examples/dodge-the-creeps/src/mob.rs
+++ b/examples/dodge-the-creeps/src/mob.rs
@@ -40,7 +40,7 @@ impl Mob {
         }
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: &RigidBody2D) {
         let mut rng = rand::thread_rng();
         let animated_sprite = unsafe {
@@ -51,14 +51,14 @@ impl Mob {
         animated_sprite.set_animation(MOB_TYPES.choose(&mut rng).unwrap().to_str())
     }
 
-    #[godot]
+    #[method]
     fn on_visibility_screen_exited(&self, #[base] owner: &RigidBody2D) {
         unsafe {
             owner.assume_unique().queue_free();
         }
     }
 
-    #[godot]
+    #[method]
     fn on_start_game(&self, #[base] owner: &RigidBody2D) {
         unsafe {
             owner.assume_unique().queue_free();

--- a/examples/dodge-the-creeps/src/player.rs
+++ b/examples/dodge-the-creeps/src/player.rs
@@ -26,14 +26,14 @@ impl Player {
         }
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: &Area2D) {
         let viewport = owner.get_viewport_rect();
         self.screen_size = viewport.size;
         owner.hide();
     }
 
-    #[godot]
+    #[method]
     fn _process(&mut self, #[base] owner: &Area2D, delta: f32) {
         let animated_sprite = unsafe {
             owner
@@ -88,7 +88,7 @@ impl Player {
         owner.set_global_position(position);
     }
 
-    #[godot]
+    #[method]
     fn on_player_body_entered(&self, #[base] owner: &Area2D, _body: Ref<PhysicsBody2D>) {
         owner.hide();
         owner.emit_signal("hit", &[]);
@@ -102,7 +102,7 @@ impl Player {
         collision_shape.set_deferred("disabled", true);
     }
 
-    #[godot]
+    #[method]
     pub fn start(&self, #[base] owner: &Area2D, pos: Vector2) {
         owner.set_global_position(pos);
         owner.show();

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -10,7 +10,7 @@ impl HelloWorld {
         HelloWorld
     }
 
-    #[godot]
+    #[method]
     fn _ready(&self) {
         godot_print!("hello, world.")
     }

--- a/examples/native-plugin/src/lib.rs
+++ b/examples/native-plugin/src/lib.rs
@@ -14,7 +14,7 @@ impl CustomNode {
         CustomNode
     }
 
-    #[godot]
+    #[method]
     fn _enter_tree(&self, #[base] owner: TRef<EditorPlugin>) {
         // Initialization of the plugin goes here.
         // Add the new type with a name, a parent type, a script and an icon.
@@ -25,7 +25,7 @@ impl CustomNode {
         owner.add_custom_type("MyButton", "Button", script, texture);
     }
 
-    #[godot]
+    #[method]
     fn _exit_tree(&self, #[base] owner: TRef<EditorPlugin>) {
         // Clean-up of the plugin goes here.
         // Always remember to remove it from the engine when deactivated.
@@ -43,14 +43,14 @@ impl MyButton {
         MyButton
     }
 
-    #[godot]
+    #[method]
     fn _enter_tree(&self, #[base] owner: TRef<Button>) {
         owner
             .connect("pressed", owner, "clicked", VariantArray::new_shared(), 0)
             .unwrap();
     }
 
-    #[godot]
+    #[method]
     fn clicked(&self) {
         godot_print!("You clicked me!");
     }

--- a/examples/resource/src/lib.rs
+++ b/examples/resource/src/lib.rs
@@ -37,7 +37,7 @@ impl Greeter {
         }
     }
 
-    #[godot]
+    #[method]
     fn _ready(&self) {
         if let Some(greeting_resource) = self.greeting_resource.as_ref() {
             let greeting_resource = unsafe { greeting_resource.assume_safe() };

--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -17,7 +17,7 @@ impl ServerPuppet {
         Self
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: TRef<Node>) {
         let peer = NetworkedMultiplayerENet::new();
         peer.create_client(
@@ -44,12 +44,12 @@ impl ServerPuppet {
         .unwrap();
     }
 
-    #[godot]
+    #[method]
     fn on_connected_to_server(&mut self, #[base] owner: TRef<Node>) {
         owner.rpc("greet_server", &[Variant::new("hello")]);
     }
 
-    #[godot(rpc = "puppet")]
+    #[method(rpc = "puppet")]
     fn return_greeting(&mut self, msg: GodotString) {
         godot_print!("Server says: {}", msg);
     }

--- a/examples/rpc/src/server.rs
+++ b/examples/rpc/src/server.rs
@@ -16,7 +16,7 @@ impl Server {
         Self
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: &Node) {
         let peer = NetworkedMultiplayerENet::new();
         peer.create_server(PORT, MAX_CLIENTS, IN_BANDWIDTH, OUT_BANDWIDTH)
@@ -28,7 +28,7 @@ impl Server {
         tree.set_network_peer(peer);
     }
 
-    #[godot(rpc = "master")]
+    #[method(rpc = "master")]
     fn greet_server(&mut self, #[base] owner: &Node, msg: GodotString) {
         godot_print!("Client says: {}", msg);
 

--- a/examples/scene-create/src/lib.rs
+++ b/examples/scene-create/src/lib.rs
@@ -33,7 +33,7 @@ impl SceneCreate {
         }
     }
 
-    #[gdnative::derive::godot]
+    #[gdnative::derive::method]
     fn _ready(&mut self) {
         self.template = load_scene("res://Child_scene.tscn");
         match &self.template {
@@ -42,7 +42,7 @@ impl SceneCreate {
         }
     }
 
-    #[gdnative::derive::godot]
+    #[gdnative::derive::method]
     fn spawn_one(&mut self, #[base] owner: &Spatial, message: GodotString) {
         godot_print!("Called spawn_one({})", message.to_string());
 
@@ -77,7 +77,7 @@ impl SceneCreate {
         update_panel(owner, num_children);
     }
 
-    #[gdnative::derive::godot]
+    #[gdnative::derive::method]
     fn remove_one(&mut self, #[base] owner: &Spatial, str: GodotString) {
         godot_print!("Called remove_one({})", str);
         let num_children = owner.get_child_count();

--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -28,7 +28,7 @@ impl SignalEmitter {
         }
     }
 
-    #[godot]
+    #[method]
     fn _process(&mut self, #[base] owner: &Node, delta: f64) {
         if self.timer < 1.0 {
             self.timer += delta;
@@ -57,7 +57,7 @@ impl SignalSubscriber {
         SignalSubscriber { times_received: 0 }
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: TRef<Label>) {
         let emitter = &mut owner.get_node("../SignalEmitter").unwrap();
         let emitter = unsafe { emitter.assume_safe() };
@@ -76,7 +76,7 @@ impl SignalSubscriber {
             .unwrap();
     }
 
-    #[godot]
+    #[method]
     fn notify(&mut self, #[base] owner: &Label) {
         self.times_received += 1;
         let msg = format!("Received signal \"tick\" {} times", self.times_received);
@@ -84,7 +84,7 @@ impl SignalSubscriber {
         owner.set_text(msg);
     }
 
-    #[godot]
+    #[method]
     fn notify_with_data(&mut self, #[base] owner: &Label, data: Variant) {
         let msg = format!(
             "Received signal \"tick_with_data\" with data {}",

--- a/examples/spinning-cube/src/lib.rs
+++ b/examples/spinning-cube/src/lib.rs
@@ -46,12 +46,12 @@ impl RustTest {
         }
     }
 
-    #[godot]
+    #[method]
     fn _ready(&mut self, #[base] owner: &MeshInstance) {
         owner.set_physics_process(true);
     }
 
-    #[godot]
+    #[method]
     fn _physics_process(&mut self, #[base] owner: &MeshInstance, delta: f64) {
         use gdnative::api::SpatialMaterial;
 

--- a/gdnative-core/src/export/macros.rs
+++ b/gdnative-core/src/export/macros.rs
@@ -26,7 +26,7 @@ macro_rules! deprecated_reference_return {
 
 #[doc(hidden)]
 #[macro_export]
-#[deprecated = "\n#[export] is deprecated and will be removed in godot-rust 0.11. Use #[godot] instead.\n\
+#[deprecated = "\n#[export] is deprecated and will be removed in godot-rust 0.11. Use #[method] instead.\n\
   For more information, see https://godot-rust.github.io/docs/gdnative/derive/derive.NativeClass.html."]
 macro_rules! deprecated_export_syntax {
     () => {};

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -239,7 +239,7 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// For additional details about how `#[methods]` expands, please refer to [gdnative::methods](macro@methods)
 ///
-/// ### `#[godot]`
+/// ### `#[method]`
 /// Registers the attributed function signature to be used by Godot.
 ///
 /// This attribute was formerly called `#[export]`, but is not directly related to the concept of
@@ -258,19 +258,19 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// // No access to base parameter
-/// #[godot]
+/// #[method]
 /// fn foo(&self);
 ///
 /// // Access base parameter as &T
-/// #[godot]
+/// #[method]
 /// fn foo(&self, #[base] base: &Reference);
 ///
 /// // Access base parameter as TRef<T>
-/// #[godot]
+/// #[method]
 /// fn foo(&self, #[base] base: TRef<Reference>);
 /// ```
 ///
-/// **Note**: Marking a function with `#[godot]` does not have any effect unless inside an `impl` block that has the `#[methods]` attribute.
+/// **Note**: Marking a function with `#[method]` does not have any effect unless inside an `impl` block that has the `#[methods]` attribute.
 ///
 /// Possible arguments for this attribute are:
 ///
@@ -300,7 +300,7 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 ///   For example:
 ///   ```ignore
-///   #[godot(deref_return)]
+///   #[method(deref_return)]
 ///   fn get_numbers(&self) -> std::cell::Ref<Vec<i32>> {
 ///      // Assume self.cell is std::cell::RefCell<Vec<i32>>
 ///      self.cell.borrow()
@@ -312,7 +312,7 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// This is a list of common Godot virtual functions that are automatically called via [notifications](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-notification).
 ///
-/// It is assumed that every method is exported via `#[godot]` attribute. The parameter `#[base] base: &Node` can be omitted if you don't need it.
+/// It is assumed that every method is exported via `#[method]` attribute. The parameter `#[base] base: &Node` can be omitted if you don't need it.
 ///
 /// ```ignore
 /// fn _ready(&self, #[base] base: &Node);

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -98,7 +98,7 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
             if arg_count == 0 {
                 return syn::Error::new(
                     sig_span,
-                    "#[godot] exported methods must take self parameter",
+                    "#[method] exported methods must take self parameter",
                 )
                 .to_compile_error();
             }
@@ -232,8 +232,8 @@ fn impl_gdnative_expose(ast: ItemImpl) -> (ItemImpl, ClassMethodExport) {
                         let (is_export, is_old_syntax, macro_name) =
                             if let Some("export") = last_seg.as_deref() {
                                 (true, true, "export")
-                            } else if let Some("godot") = last_seg.as_deref() {
-                                (true, false, "godot")
+                            } else if let Some("method") = last_seg.as_deref() {
+                                (true, false, "method")
                             } else {
                                 (false, false, "unknown")
                             };

--- a/gdnative/tests/ui/derive_pass.rs
+++ b/gdnative/tests/ui/derive_pass.rs
@@ -10,7 +10,7 @@ impl Foo {
         Foo {}
     }
 
-    #[godot]
+    #[method]
     fn bar(&self) {}
 }
 

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -261,7 +261,7 @@ impl GodotAttrWithoutBase {
         Self(54)
     }
 
-    #[godot]
+    #[method]
     fn answer(&self) -> i64 {
         self.0
     }
@@ -285,7 +285,7 @@ impl GodotAttrWithBase {
         Self(54)
     }
 
-    #[godot]
+    #[method]
     fn answer(&self, #[base] _base: &Reference) -> i64 {
         self.0
     }
@@ -311,7 +311,7 @@ impl GodotAttrDerefReturn {
         Self(rc_ref)
     }
 
-    #[godot(deref_return)]
+    #[method(deref_return)]
     fn answer(&self) -> cell::Ref<Vec<i64>> {
         self.0.borrow()
     }
@@ -337,7 +337,7 @@ impl GodotAttrRenameMethod {
         Self(54)
     }
 
-    #[godot(name = "ask")]
+    #[method(name = "ask")]
     fn answer(&self) -> i64 {
         self.0
     }
@@ -363,7 +363,7 @@ impl GodotAttrAllArguments {
         Self(rc_ref)
     }
 
-    #[godot(rpc = "disabled", name = "ask", deref_return)]
+    #[method(rpc = "disabled", name = "ask", deref_return)]
     fn answer(&self, #[base] _base: &Reference) -> cell::Ref<Vec<i64>> {
         self.0.borrow()
     }


### PR DESCRIPTION
Follow-up to #872.

As mentioned there, the syntax was provisional and still subject to change. This PR renames `#[godot]` back to `#[method]`.
Other changes, such as the `#[base]` parameter name, remain unaffected (still a bit conflicted about that too, but that's another story...)

Reasoning behind the name `#[godot]` was a potential greater unification of godot-rust attributes, which would allow to use `#[godot]` more widespread as _the_ attribute, e.g.
```rs
#[derive(NativeClass)]
#[godot(inherit=Node, no_constructor)]
struct MyClass {
    #[godot(get)]
    my_property: i32,
}

#[godot_api]
impl MyClass {
    #[godot]
    fn my_method(&self, #[base] base: &Node) {...}
}
```

However, this comes with a bigger change. In order to avoid huge deprecations or breaking changes, I think it makes sense to not include this in the current minor version. It could be discussed for v0.11, or maybe only for GDExtension. Since having `#[godot]` in only one place would be "somewhere in between" the old and new naming, I'd rather find an identifier that fits the existing `#[property]` and `#[methods]` naming scheme -- and `#[method]` as suggested by the original author would fit relatively nicely. 

Overall, I still believe "method" is not expressive and there is room for improvement, as well as for other names like "property" or so. But I don't want this to delay the whole 0.10.1 release further; we'd rather think about nicer naming another time, maybe when GDExtension is around.

This PR introduces a breaking change toward `master`, but not toward the last released version `0.10.0`, so it can be included in `0.10.1`.