### PR TITLE
added load function to globalscope

### DIFF
--- a/gdnative/src/gdscript.rs
+++ b/gdnative/src/gdscript.rs
@@ -1,0 +1,31 @@
+use gdnative_bindings::{Resource, ResourceLoader};
+use gdnative_core::{
+    core_types::NodePath,
+    object::{memory::RefCounted, GodotObject, Ref, SubClass},
+};
+
+/// Loads a resource from the filesystem located at `path`. The resource is loaded on the method call (unless it's referenced already elsewhere, e.g. in another script or in the scene), which might cause slight delay, especially when loading scenes.
+/// # Note:
+/// Resource paths can be obtained by right-clicking on a resource in the FileSystem dock and choosing "Copy Path" or by dragging the file from the FileSystem dock into the script.
+///
+/// Load a scene called main located in the root of the project directory and cache it in a variable. var main = load("res://main.tscn")  main will contain a PackedScene resource.
+/// # Important:
+/// The path must be absolute, a local path will just return null.
+/// This method is a simplified version of `ResourceLoader.load()`, which can be used for more advanced scenarios.
+/// # Examples:
+/// ```no_run
+/// use gdnative::globalscope::load;
+/// use gdnative::prelude::PackedScene;
+///
+/// let scene = load::<PackedScene>("res://path").unwrap();
+/// ```
+#[inline]
+pub fn load<T>(path: impl Into<NodePath>) -> Option<Ref<T>>
+where
+    T: SubClass<Resource> + GodotObject<Memory = RefCounted>,
+{
+    ResourceLoader::godot_singleton()
+        .load(path.into(), "", false)
+        .unwrap()
+        .cast::<T>()
+}

--- a/gdnative/src/gdscript.rs
+++ b/gdnative/src/gdscript.rs
@@ -20,12 +20,12 @@ use gdnative_core::{
 /// let scene = load::<PackedScene>("res://path").unwrap();
 /// ```
 #[inline]
-pub fn load<T>(path: impl Into<NodePath>) -> Option<Ref<T>>
+pub fn load<T>(path: &str) -> Option<Ref<T>>
 where
     T: SubClass<Resource> + GodotObject<Memory = RefCounted>,
 {
     ResourceLoader::godot_singleton()
-        .load(path.into(), "", false)
+        .load(path, "", false)
         .unwrap()
         .cast::<T>()
 }

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -81,7 +81,14 @@
 // Items, which are #[doc(hidden)] in their original crate and re-exported with a wildcard, lose
 // their hidden status. Re-exporting them manually and hiding the wildcard solves this.
 #[doc(inline)]
-pub use gdnative_core::{core_types, export, globalscope, init, log, object, profiler};
+pub use gdnative_core::{core_types, export, init, log, object, profiler};
+
+mod gdscript; // new methods from `@GDscript`, so far only `load`
+pub mod globalscope {
+    pub use crate::gdscript::*;
+    #[doc(inline)]
+    pub use gdnative_core::globalscope::*;
+}
 
 // Implementation details (e.g. used by macros).
 // However, do not re-export macros (on crate level), thus no wildcard


### PR DESCRIPTION
 added a `globalscope::load()` since it's such a common operation -- without all the default args;
 **so instead of :**
 ```rust
let scene = ResourceLoader::godot_singleton()
                .load("res://scenes/Enemy/Enemy.tscn", "", false)
                .unwrap();
let packed_scene = scene.cast::<PackedScene>().unwrap();
```
**you can just:**
 ```rust
let scene = load::<PackedScene>("res://path").unwrap();

```