### PR TITLE
Compatibility warning between godot-rust and Godot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.10.2] - unreleased
+
+Last maintenance release for Godot 3.4.
+
+# Added
+
+- `globalscope::load` method ([#940](https://github.com/godot-rust/godot-rust/pull/940), [#941](https://github.com/godot-rust/godot-rust/pull/941))
+- `Color` constructors from HTML string and integers ([#939](https://github.com/godot-rust/godot-rust/pull/939))
+- Version check to warn if Godot is not 3.4 ([#942](https://github.com/godot-rust/godot-rust/pull/942))
+
 ## [0.10.1] - 2022-09-03
 
 This is a backwards-compatible release; thus no removals or breaking changes.

--- a/gdnative-core/src/init/macros.rs
+++ b/gdnative-core/src/init/macros.rs
@@ -35,6 +35,24 @@ macro_rules! godot_nativescript_init {
                 return;
             }
 
+            // Compatibility warning if using in-house Godot version (not applicable for custom ones)
+            #[cfg(not(feature = "custom-godot"))]
+            {
+                let engine = gdnative::api::Engine::godot_singleton();
+                let info = engine.get_version_info();
+
+                if info.get("major").expect("major version") != Variant::new(3)
+                || info.get("minor").expect("minor version") != Variant::new(4) {
+                    let string = info.get("string").expect("version str").to::<String>().expect("version str type");
+                    gdnative::log::godot_warn!(
+                        "This godot-rust version is only compatible with Godot 3.4.x; detected version {}.\n\
+                        GDNative mismatches may lead to subtle bugs, undefined behavior or crashes at runtime.\n\
+                	    Apply the 'custom-godot' feature if you want to use current godot-rust with another Godot engine version.",
+                        string
+                    );
+                }
+            }
+
             let __result = ::std::panic::catch_unwind(|| {
                 $callback($crate::init::InitHandle::new(handle));
             });


### PR DESCRIPTION
Adds a warning on startup, if godot-rust is used with a Godot engine version that ships a partially incompatible GDNative API version.

Currently only a warning and not a hard error; we need to see how it goes.