### PR TITLE
`godot_init` may not find some symbols

### DIFF
--- a/gdnative-core/src/init/macros.rs
+++ b/gdnative-core/src/init/macros.rs
@@ -38,6 +38,8 @@ macro_rules! godot_nativescript_init {
             // Compatibility warning if using in-house Godot version (not applicable for custom ones)
             #[cfg(not(feature = "custom-godot"))]
             {
+                use $crate::core_types::Variant;
+
                 let engine = gdnative::api::Engine::godot_singleton();
                 let info = engine.get_version_info();
 
@@ -45,7 +47,7 @@ macro_rules! godot_nativescript_init {
                 || info.get("minor").expect("minor version") != Variant::new(5)
                 || info.get("patch").expect("patch version") < Variant::new(1) {
                     let string = info.get("string").expect("version str").to::<String>().expect("version str type");
-                    gdnative::log::godot_warn!(
+                    $crate::log::godot_warn!(
                         "This godot-rust version is only compatible with Godot >= 3.5.1 and < 3.6; detected version {}.\n\
                         GDNative mismatches may lead to subtle bugs, undefined behavior or crashes at runtime.\n\
                 	    Apply the 'custom-godot' feature if you want to use current godot-rust with another Godot engine version.",


### PR DESCRIPTION
This fixes an issue for users without `use gdnative::prelude::*`, which could run into an error regarding symbols not found (e.g. Variant).

bors try