### PR TITLE
Remove deprecated symbols; rename `NativeClass` derived methods

### DIFF
--- a/gdnative-async/src/rt/bridge.rs
+++ b/gdnative-async/src/rt/bridge.rs
@@ -52,7 +52,7 @@ impl NativeClass for SignalBridge {
     type Base = Reference;
     type UserData = ArcData<SignalBridge>;
 
-    fn register_properties(_builder: &ClassBuilder<Self>) {}
+    fn nativeclass_register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 impl SignalBridge {
@@ -128,7 +128,7 @@ impl Method<SignalBridge> for OnSignalFn {
 }
 
 impl NativeClassMethods for SignalBridge {
-    fn register(builder: &ClassBuilder<Self>) {
+    fn nativeclass_register(builder: &ClassBuilder<Self>) {
         builder.method("_on_signal", OnSignalFn).done_stateless();
     }
 }

--- a/gdnative-async/src/rt/func_state.rs
+++ b/gdnative-async/src/rt/func_state.rs
@@ -25,7 +25,7 @@ impl NativeClass for FuncState {
     type Base = Reference;
     type UserData = LocalCellData<FuncState>;
 
-    fn register_properties(builder: &ClassBuilder<Self>) {
+    fn nativeclass_register_properties(builder: &ClassBuilder<Self>) {
         builder
             .signal("completed")
             .with_param_untyped("value")
@@ -153,7 +153,7 @@ impl StaticArgsMethod<FuncState> for ResumeFn {
 }
 
 impl NativeClassMethods for FuncState {
-    fn register(builder: &ClassBuilder<Self>) {
+    fn nativeclass_register(builder: &ClassBuilder<Self>) {
         builder
             .method("is_valid", StaticArgs::new(IsValidFn))
             .done_stateless();

--- a/gdnative-core/src/export/class.rs
+++ b/gdnative-core/src/export/class.rs
@@ -43,11 +43,6 @@ pub trait NativeClass: Sized + 'static {
     /// See module-level documentation on `user_data` for more info.
     type UserData: UserData<Target = Self>;
 
-    // TODO(0.11) bugfix for https://github.com/godot-rust/godot-rust/issues/885
-    // * Rename init, register_properties, register by prefixing them with "nativeclass_"
-    // * Mark them as #[doc(hidden)]
-    // * Discourage manual NativeClass and NativeClassMethod impls
-
     /// Function that creates a value of `Self`, used for the script-instance. The default
     /// implementation simply panics.
     ///
@@ -58,8 +53,7 @@ pub trait NativeClass: Sized + 'static {
     /// of such scripts can only be created from Rust using `Instance::emplace`. See
     /// documentation on `Instance::emplace` for an example.
     #[inline]
-    #[deprecated = "This method will be removed from the public API."]
-    fn init(_owner: TRef<'_, Self::Base, Shared>) -> Self {
+    fn nativeclass_init(_owner: TRef<'_, Self::Base, Shared>) -> Self {
         panic!(
             "{} does not have a zero-argument constructor",
             class_registry::class_name_or_default::<Self>()
@@ -68,8 +62,7 @@ pub trait NativeClass: Sized + 'static {
 
     /// Register any exported properties to Godot.
     #[inline]
-    #[deprecated = "This method will be removed from the public API."]
-    fn register_properties(_builder: &ClassBuilder<Self>) {}
+    fn nativeclass_register_properties(_builder: &ClassBuilder<Self>) {}
 
     /// Convenience method to create an `Instance<Self, Unique>`. This is a new `Self::Base`
     /// with the script attached.
@@ -119,9 +112,7 @@ pub trait StaticallyNamed: NativeClass {
 pub trait NativeClassMethods: NativeClass {
     /// Function that registers all exposed methods to Godot.
     ///
-    // TODO see comment in NativeClass
-    #[deprecated = "This method will be removed from the public API."]
-    fn register(builder: &ClassBuilder<Self>);
+    fn nativeclass_register(builder: &ClassBuilder<Self>);
 }
 
 /// Trait for types that can be used as the `owner` arguments of exported methods. This trait

--- a/gdnative-core/src/init/init_handle.rs
+++ b/gdnative-core/src/init/init_handle.rs
@@ -118,8 +118,9 @@ impl InitHandle {
                     };
 
                     let val = match panic::catch_unwind(AssertUnwindSafe(|| {
-                        emplace::take()
-                            .unwrap_or_else(|| C::init(TRef::new(C::Base::cast_ref(owner))))
+                        emplace::take().unwrap_or_else(|| {
+                            C::nativeclass_init(TRef::new(C::Base::cast_ref(owner)))
+                        })
                     })) {
                         Ok(val) => val,
                         Err(_) => {
@@ -193,10 +194,10 @@ impl InitHandle {
 
             let builder = ClassBuilder::new(self.handle, c_class_name);
 
-            C::register_properties(&builder);
+            C::nativeclass_register_properties(&builder);
 
             // register methods
-            C::register(&builder);
+            C::nativeclass_register(&builder);
         }
     }
 }

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -48,7 +48,7 @@ mod variant;
 ///     const CLASS_NAME: &'static str = "Foo";
 /// }
 /// impl gdnative::export::NativeClassMethods for Foo {
-///     fn register(builder: &ClassBuilder<Self>) {
+///     fn nativeclass_register(builder: &ClassBuilder<Self>) {
 ///         use gdnative::export::*;
 ///         builder.method("foo", gdnative::export::godot_wrap_method!(Foo, false, fn foo(&self, #[base] _base: &Reference, bar: i64) -> i64))
 ///             .with_rpc_mode(RpcMode::Disabled)

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -182,7 +182,7 @@ pub(crate) fn derive_methods(item_impl: ItemImpl) -> TokenStream2 {
 
         #derived
         impl gdnative::export::NativeClassMethods for #class_name {
-            fn register(#builder: &::gdnative::export::ClassBuilder<Self>) {
+            fn nativeclass_register(#builder: &::gdnative::export::ClassBuilder<Self>) {
                 use gdnative::export::*;
 
                 #(#methods)*

--- a/gdnative-derive/src/native_script/mod.rs
+++ b/gdnative-derive/src/native_script/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn impl_empty_nativeclass(derive_input: &DeriveInput) -> TokenStream2
             type Base = ::gdnative::api::Object;
             type UserData = ::gdnative::export::user_data::LocalCellData<Self>;
 
-            fn init(owner: ::gdnative::object::TRef<'_, Self::Base, Shared>) -> Self {
+            fn nativeclass_init(owner: ::gdnative::object::TRef<'_, Self::Base, Shared>) -> Self {
                 unimplemented!()
             }
         }
@@ -165,7 +165,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
             None
         } else {
             Some(quote! {
-                fn init(owner: ::gdnative::object::TRef<Self::Base>) -> Self {
+                fn nativeclass_init(owner: ::gdnative::object::TRef<Self::Base>) -> Self {
                     Self::new(::gdnative::export::OwnerArg::from_safe_ref(owner))
                 }
             })
@@ -179,7 +179,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
 
                 #init
 
-                fn register_properties(builder: &::gdnative::export::ClassBuilder<Self>) {
+                fn nativeclass_register_properties(builder: &::gdnative::export::ClassBuilder<Self>) {
                     #(#properties)*;
                     #register_callback
                 }

--- a/gdnative/src/prelude.rs
+++ b/gdnative/src/prelude.rs
@@ -36,16 +36,3 @@ pub mod user_data {
 }
 #[doc(inline)]
 pub use crate::globalscope::load;
-
-// Deprecated symbols. Keep them only in prelude, as all the other paths have changed anyway.
-// This way, old symbol names are still discoverable and users who used prelude won't have (as many) breaking changes.
-// Important: the referred-to type (right-hand-side) should point into the full path, not the prelude re-export.
-
-#[deprecated(since = "0.10.0", note = "Confusing name; use TInstance instead.")]
-pub type RefInstance<'a, T, Own> = crate::object::TInstance<'a, T, Own>;
-
-#[deprecated(
-    since = "0.10.0",
-    note = "Renamed for GDScript consistency; use PoolArray instead."
-)]
-pub type TypedArray<T> = crate::core_types::PoolArray<T>;

--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -29,10 +29,10 @@ struct RegisterSignal;
 impl NativeClass for RegisterSignal {
     type Base = Reference;
     type UserData = user_data::Aether<RegisterSignal>;
-    fn init(_owner: TRef<Reference>) -> RegisterSignal {
+    fn nativeclass_init(_owner: TRef<Reference>) -> RegisterSignal {
         RegisterSignal
     }
-    fn register_properties(builder: &ClassBuilder<Self>) {
+    fn nativeclass_register_properties(builder: &ClassBuilder<Self>) {
         builder
             .signal("progress")
             .with_param("amount", VariantType::I64)
@@ -54,10 +54,10 @@ struct RegisterProperty {
 impl NativeClass for RegisterProperty {
     type Base = Reference;
     type UserData = user_data::MutexData<RegisterProperty>;
-    fn init(_owner: TRef<Reference>) -> RegisterProperty {
+    fn nativeclass_init(_owner: TRef<Reference>) -> RegisterProperty {
         RegisterProperty { value: 42 }
     }
-    fn register_properties(builder: &ClassBuilder<Self>) {
+    fn nativeclass_register_properties(builder: &ClassBuilder<Self>) {
         builder
             .property("value")
             .with_default(42)

--- a/test/src/test_return_leak.rs
+++ b/test/src/test_return_leak.rs
@@ -28,7 +28,7 @@ impl NativeClass for Probe {
     type Base = api::AnimationNodeAdd2;
     type UserData = user_data::RwLockData<Probe>;
 
-    fn register_properties(_builder: &ClassBuilder<Self>) {}
+    fn nativeclass_register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 impl StaticallyNamed for Probe {

--- a/test/src/test_variant_call_args.rs
+++ b/test/src/test_variant_call_args.rs
@@ -18,10 +18,10 @@ struct VariantCallArgs;
 impl NativeClass for VariantCallArgs {
     type Base = Reference;
     type UserData = user_data::MutexData<VariantCallArgs>;
-    fn init(_owner: TRef<Reference>) -> VariantCallArgs {
+    fn nativeclass_init(_owner: TRef<Reference>) -> VariantCallArgs {
         VariantCallArgs
     }
-    fn register_properties(_builder: &ClassBuilder<Self>) {}
+    fn nativeclass_register_properties(_builder: &ClassBuilder<Self>) {}
 }
 
 impl StaticallyNamed for VariantCallArgs {


### PR DESCRIPTION
Follows through with the changes planned in https://github.com/godot-rust/godot-rust/issues/885.

Despite already deprecated, this PR does _not_ remove the `#[export]` syntax and attempts to return from exported methods by reference, but will keep issuing a warning. This should give users more time to migrate, as those changes were only added to gdnative v0.10.1.

The `NativeClass` methods also remain public contrary to initial plans. If users for some reason must implement `NativeClass` manually, then they can -- documentation is already provided.