### PR TITLE
Fixed ToVariant/FromVariant derive for generic types with bounds

### DIFF
--- a/gdnative-derive/src/variant/bounds.rs
+++ b/gdnative-derive/src/variant/bounds.rs
@@ -1,5 +1,6 @@
+use syn::punctuated::Punctuated;
 use syn::visit::Visit;
-use syn::Generics;
+use syn::{GenericParam, Generics};
 
 use crate::extend_bounds::{with_visitor, BoundsVisitor};
 
@@ -49,4 +50,21 @@ pub(crate) fn extend_bounds(
             }
         }
     })
+}
+
+pub(crate) fn remove_bounds(mut generics: Generics) -> Generics {
+    for param in generics.params.iter_mut() {
+        match param {
+            GenericParam::Type(ty) => {
+                ty.colon_token = None;
+                ty.bounds = Punctuated::new();
+            }
+            GenericParam::Lifetime(lt) => {
+                lt.colon_token = None;
+                lt.bounds = Punctuated::new();
+            }
+            GenericParam::Const(_) => {}
+        }
+    }
+    generics
 }

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Literal, Span, TokenStream as TokenStream2};
 
+use crate::variant::bounds;
 use syn::Ident;
 
 use super::repr::Repr;
@@ -106,11 +107,12 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> Result<TokenStream
         }
     };
 
+    let generics_no_bounds = bounds::remove_bounds(generics.clone());
     let where_clause = &generics.where_clause;
 
     let result = quote! {
         #derived
-        impl #generics ::gdnative::core_types::FromVariant for #ident #generics #where_clause {
+        impl #generics ::gdnative::core_types::FromVariant for #ident #generics_no_bounds #where_clause {
             fn from_variant(
                 #input_ident: &::gdnative::core_types::Variant
             ) -> ::std::result::Result<Self, ::gdnative::core_types::FromVariantError> {

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -1,3 +1,4 @@
+use crate::variant::bounds;
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 
 use super::repr::Repr;
@@ -69,11 +70,12 @@ pub(crate) fn expand_to_variant(
         }
     };
 
+    let generics_no_bounds = bounds::remove_bounds(generics.clone());
     let where_clause = &generics.where_clause;
 
     let result = quote! {
         #derived
-        impl #generics #trait_path for #ident #generics #where_clause {
+        impl #generics #trait_path for #ident #generics_no_bounds #where_clause {
             fn #to_variant_fn(#to_variant_receiver) -> ::gdnative::core_types::Variant {
                 use #trait_path;
                 use ::gdnative::core_types::FromVariant;

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -40,9 +40,8 @@ pub(crate) fn register(handle: InitHandle) {
 
 crate::godot_itest! { test_derive_to_variant {
     #[derive(Clone, Eq, PartialEq, Debug, ToVariant, FromVariant)]
-    struct ToVar<T, R>
+    struct ToVar<T: Associated, R>
     where
-        T: Associated,
         R: Default,
     {
         foo: T::A,
@@ -55,7 +54,7 @@ crate::godot_itest! { test_derive_to_variant {
     }
 
     #[derive(Clone, Eq, PartialEq, Debug, ToVariant, FromVariant)]
-    enum ToVarEnum<T> {
+    enum ToVarEnum<T: Bound> {
         Foo(T),
         Bar,
         Baz { baz: u8 },
@@ -67,9 +66,12 @@ crate::godot_itest! { test_derive_to_variant {
         T: Associated,
         R: Default;
 
+    trait Bound {}
+    impl Bound for bool {}
+
     trait Associated {
         type A;
-        type B;
+        type B : Bound;
     }
 
     impl Associated for f64 {


### PR DESCRIPTION
Fixes part of #957; but there's a separate problem with `where` clauses (see description).