### PR TITLE
allow deriving of `FromVariant` for uninhabitable enums

### DIFF
--- a/gdnative-derive/src/variant/mod.rs
+++ b/gdnative-derive/src/variant/mod.rs
@@ -107,3 +107,17 @@ pub(crate) fn derive_from_variant(derive_input: DeriveInput) -> Result<TokenStre
     let variant = parse_derive_input(derive_input, &bound, Direction::From);
     from::expand_from_variant(variant?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_from_variant_on_uninhabitable_enums() {
+        let input = parse_quote! {
+            enum Test {}
+        };
+
+        derive_from_variant(input).unwrap();
+    }
+}

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -1,4 +1,5 @@
 use std::cell::{self, Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use gdnative::export::Property;
@@ -143,6 +144,19 @@ crate::godot_itest! { test_derive_to_variant {
     assert_eq!(
         Ok(ToVarTuple::<f64, i128>(1, 0, false)),
         ToVarTuple::from_variant(&variant)
+    );
+
+    // Derive on uninhabitable enum results an error
+    #[derive(Debug, PartialEq, FromVariant)]
+    enum NoVariant {}
+
+    let input = HashMap::from_iter([("foo", "bar")]).to_variant();
+    assert_eq!(
+        NoVariant::from_variant(&input),
+        Err(FromVariantError::UnknownEnumVariant {
+            variant: "foo".into(),
+            expected: &[]
+        })
     );
 }}
 


### PR DESCRIPTION
Fixs #444 
What type of error should be returned might need further discussion.