### PR TITLE
fix(check.sh): make it more portable

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Small utility to run tests locally
 # Similar to minimal-ci
 
@@ -77,7 +79,7 @@ for arg in "${args[@]}"; do
     itest)
         findGodot
         cmds+=("cargo build --manifest-path test/Cargo.toml --features $features")
-        cmds+=("cp target/debug/gdnative_test* test/project/lib/")
+        cmds+=("cp target/debug/*gdnative_test* test/project/lib/")
         cmds+=("$godotBin --path test/project")
         ;;
     doc)


### PR DESCRIPTION
adjust the pattern to match output lib path, and add shebang to ensure which shell to use.

Fixes #965 