### PR TITLE
Generate accessor methods for indexed properties

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -9,6 +9,7 @@ mod test_async;
 mod test_constructor;
 mod test_derive;
 mod test_free_ub;
+mod test_indexed_props;
 mod test_map_owned;
 mod test_register;
 mod test_return_leak;
@@ -76,6 +77,7 @@ pub extern "C" fn run_tests(
     status &= test_constructor::run_tests();
     status &= test_derive::run_tests();
     status &= test_free_ub::run_tests();
+    status &= test_indexed_props::run_tests();
     status &= test_map_owned::run_tests();
     status &= test_register::run_tests();
     status &= test_return_leak::run_tests();
@@ -238,6 +240,7 @@ fn init(handle: InitHandle) {
     test_constructor::register(handle);
     test_derive::register(handle);
     test_free_ub::register(handle);
+    test_indexed_props::register(handle);
     test_map_owned::register(handle);
     test_register::register(handle);
     test_return_leak::register(handle);

--- a/test/src/test_indexed_props.rs
+++ b/test/src/test_indexed_props.rs
@@ -1,0 +1,32 @@
+use gdnative::core_types::Margin;
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    let mut status = true;
+
+    status &= test_indexed_props();
+
+    status
+}
+
+pub(crate) fn register(_handle: InitHandle) {}
+
+crate::godot_itest! { test_indexed_props {
+    let control = Control::new();
+
+    assert_eq!(0, control.margin_top());
+    assert_eq!(0, control.margin_left());
+
+    control.set_margin_top(42);
+
+    assert_eq!(42, control.margin_top());
+    assert_eq!(42, control.margin(Margin::Top.into()) as i64);
+    assert_eq!(0, control.margin_left());
+    assert_eq!(0, control.margin(Margin::Left.into()) as i64);
+
+    control.set_margin(Margin::Left.into(), 24.0);
+
+    assert_eq!(24, control.margin_left());
+
+    control.free();
+}}


### PR DESCRIPTION
Getters and setters are now generated for indexed properties that are naturally accessible in GDScript (i.e. do not have '/' in the name), like `SpatialMaterial::albedo_texture`. Doc generation for the underlying accessors has also been improved.

Close #689